### PR TITLE
feat(entities): enhance EntityLink data model with strength, timestamps, and metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "autoprefixer": "^10.4.20",
         "eslint": "^9.17.0",
         "eslint-plugin-svelte": "^2.46.1",
+        "fake-indexeddb": "^6.2.5",
         "happy-dom": "^20.3.1",
         "jsdom": "^27.4.0",
         "postcss": "^8.4.49",
@@ -33,7 +34,7 @@
         "tailwindcss": "^3.4.17",
         "typescript": "^5.7.0",
         "typescript-eslint": "^8.18.0",
-        "vite": "^6.0.0",
+        "vite": "^6.4.1",
         "vitest": "^4.0.17"
       }
     },
@@ -3186,6 +3187,16 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5601,7 +5612,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "autoprefixer": "^10.4.20",
     "eslint": "^9.17.0",
     "eslint-plugin-svelte": "^2.46.1",
+    "fake-indexeddb": "^6.2.5",
     "happy-dom": "^20.3.1",
     "jsdom": "^27.4.0",
     "postcss": "^8.4.49",
@@ -35,7 +36,7 @@
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.18.0",
-    "vite": "^6.0.0",
+    "vite": "^6.4.1",
     "vitest": "^4.0.17"
   },
   "dependencies": {

--- a/src/lib/stores/entities.svelte.ts
+++ b/src/lib/stores/entities.svelte.ts
@@ -172,9 +172,32 @@ function createEntitiesStore() {
 			targetId: string,
 			relationship: string,
 			bidirectional: boolean = false,
-			notes?: string
+			notes?: string,
+			strength?: 'strong' | 'moderate' | 'weak',
+			metadata?: { tags?: string[]; tension?: number; [key: string]: unknown }
 		): Promise<void> {
-			await entityRepository.addLink(sourceId, targetId, relationship, bidirectional, notes);
+			await entityRepository.addLink(
+				sourceId,
+				targetId,
+				relationship,
+				bidirectional,
+				notes,
+				strength,
+				metadata
+			);
+		},
+
+		async updateLink(
+			sourceId: string,
+			linkId: string,
+			changes: {
+				notes?: string;
+				relationship?: string;
+				strength?: 'strong' | 'moderate' | 'weak';
+				metadata?: { tags?: string[]; tension?: number; [key: string]: unknown };
+			}
+		): Promise<void> {
+			await entityRepository.updateLink(sourceId, linkId, changes);
 		},
 
 		async removeLink(sourceId: string, targetId: string): Promise<void> {

--- a/src/lib/types/entities.ts
+++ b/src/lib/types/entities.ts
@@ -28,11 +28,21 @@ export type FieldValue =
 // Entity relationship/link
 export interface EntityLink {
 	id: EntityId;
+	sourceId?: EntityId; // Explicit source reference (optional for backward compat)
 	targetId: EntityId;
 	targetType: EntityType;
 	relationship: string; // "member_of", "located_at", "knows", custom...
 	bidirectional: boolean;
 	notes?: string;
+	strength?: 'strong' | 'moderate' | 'weak'; // Relationship strength
+	createdAt?: Date; // When link was created
+	updatedAt?: Date; // When link was last updated
+	metadata?: {
+		// Extensible metadata for additional link properties
+		tags?: string[];
+		tension?: number;
+		[key: string]: unknown; // Allow additional custom fields
+	};
 }
 
 // Base entity interface - all entities extend this

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom';
+import 'fake-indexeddb/auto';
 import { expect, afterEach, vi } from 'vitest';
 import { cleanup } from '@testing-library/svelte';
 


### PR DESCRIPTION
## Summary
Closes #65

- Add `sourceId`, `strength`, `createdAt`, `updatedAt`, `metadata` fields to EntityLink interface
- Update `addLink()` to populate new fields on link creation
- Add `updateLink()` method for modifying existing links
- Update store wrapper methods
- Add comprehensive test suite (47 tests)
- Add `fake-indexeddb` dev dependency for proper database testing

## Test plan
- [x] All 47 unit tests pass
- [x] Build succeeds
- [x] Existing relationship creation still works (backward compatible)
- [ ] Verify new fields appear in IndexedDB when creating links

🤖 Generated with [Claude Code](https://claude.ai/code)