### PR TITLE
fix: resolve TypeScript errors in RelationshipCard.test.ts (closes #106)

### DIFF
--- a/src/lib/components/entity/RelationshipCard.test.ts
+++ b/src/lib/components/entity/RelationshipCard.test.ts
@@ -19,7 +19,7 @@ import type { BaseEntity, EntityLink } from '$lib/types';
 describe('RelationshipCard Component - Basic Rendering (Issue #72)', () => {
 	let linkedEntity: BaseEntity;
 	let link: EntityLink;
-	let onRemove: ReturnType<typeof vi.fn>;
+	let onRemove: (linkId: string) => void;
 
 	beforeEach(() => {
 		linkedEntity = createMockEntity({
@@ -106,7 +106,7 @@ describe('RelationshipCard Component - Basic Rendering (Issue #72)', () => {
 
 describe('RelationshipCard Component - Strength Badge', () => {
 	let linkedEntity: BaseEntity;
-	let onRemove: ReturnType<typeof vi.fn>;
+	let onRemove: (linkId: string) => void;
 
 	beforeEach(() => {
 		linkedEntity = createMockEntity({
@@ -214,7 +214,7 @@ describe('RelationshipCard Component - Strength Badge', () => {
 
 describe('RelationshipCard Component - Notes Section', () => {
 	let linkedEntity: BaseEntity;
-	let onRemove: ReturnType<typeof vi.fn>;
+	let onRemove: (linkId: string) => void;
 
 	beforeEach(() => {
 		linkedEntity = createMockEntity({
@@ -322,7 +322,7 @@ describe('RelationshipCard Component - Notes Section', () => {
 
 describe('RelationshipCard Component - Timestamps', () => {
 	let linkedEntity: BaseEntity;
-	let onRemove: ReturnType<typeof vi.fn>;
+	let onRemove: (linkId: string) => void;
 
 	beforeEach(() => {
 		linkedEntity = createMockEntity({
@@ -415,7 +415,7 @@ describe('RelationshipCard Component - Timestamps', () => {
 
 describe('RelationshipCard Component - Tags', () => {
 	let linkedEntity: BaseEntity;
-	let onRemove: ReturnType<typeof vi.fn>;
+	let onRemove: (linkId: string) => void;
 
 	beforeEach(() => {
 		linkedEntity = createMockEntity({
@@ -550,7 +550,7 @@ describe('RelationshipCard Component - Tags', () => {
 
 describe('RelationshipCard Component - Tension Indicator', () => {
 	let linkedEntity: BaseEntity;
-	let onRemove: ReturnType<typeof vi.fn>;
+	let onRemove: (linkId: string) => void;
 
 	beforeEach(() => {
 		linkedEntity = createMockEntity({
@@ -683,7 +683,7 @@ describe('RelationshipCard Component - Tension Indicator', () => {
 
 describe('RelationshipCard Component - Asymmetric Relationships', () => {
 	let linkedEntity: BaseEntity;
-	let onRemove: ReturnType<typeof vi.fn>;
+	let onRemove: (linkId: string) => void;
 
 	beforeEach(() => {
 		linkedEntity = createMockEntity({
@@ -753,7 +753,7 @@ describe('RelationshipCard Component - Asymmetric Relationships', () => {
 
 describe('RelationshipCard Component - Reverse Links', () => {
 	let linkedEntity: BaseEntity;
-	let onRemove: ReturnType<typeof vi.fn>;
+	let onRemove: (linkId: string) => void;
 
 	beforeEach(() => {
 		linkedEntity = createMockEntity({
@@ -825,7 +825,7 @@ describe('RelationshipCard Component - Reverse Links', () => {
 describe('RelationshipCard Component - Delete Functionality', () => {
 	let linkedEntity: BaseEntity;
 	let link: EntityLink;
-	let onRemove: ReturnType<typeof vi.fn>;
+	let onRemove: (linkId: string) => void;
 
 	beforeEach(() => {
 		linkedEntity = createMockEntity({
@@ -890,7 +890,7 @@ describe('RelationshipCard Component - Delete Functionality', () => {
 
 describe('RelationshipCard Component - Combined Metadata', () => {
 	let linkedEntity: BaseEntity;
-	let onRemove: ReturnType<typeof vi.fn>;
+	let onRemove: (linkId: string) => void;
 
 	beforeEach(() => {
 		linkedEntity = createMockEntity({
@@ -963,7 +963,7 @@ describe('RelationshipCard Component - Combined Metadata', () => {
 describe('RelationshipCard Component - Accessibility', () => {
 	let linkedEntity: BaseEntity;
 	let link: EntityLink;
-	let onRemove: ReturnType<typeof vi.fn>;
+	let onRemove: (linkId: string) => void;
 
 	beforeEach(() => {
 		linkedEntity = createMockEntity({


### PR DESCRIPTION
## Summary
- Fixed all 45 TypeScript errors occurring during `npm run check`
- Replaced `ReturnType<typeof vi.fn>` with explicit function type `(linkId: string) => void` in 11 describe blocks in `RelationshipCard.test.ts`

## Verification
- ✅ `npm run check` now passes with 0 errors (17 unrelated a11y warnings remain)
- ✅ `npm run build` completes successfully

## Test plan
- [x] Run `npm run check` - should report 0 errors
- [x] Run `npm run build` - should complete successfully

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)