### PR TITLE
feat: implement in-place relationship editing (closes #75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Accurate link count calculation for each entity node
   - Exports interfaces: RelationshipMapNode, RelationshipMapEdge, RelationshipMap, RelationshipMapOptions
   - Comprehensive JSDoc documentation with usage examples
+- In-place relationship editing (Issue #75)
+  - New EditRelationshipModal component for editing relationships without delete/recreate
+  - Edit button added to relationship cards (forward links only)
+  - Modify relationship type, strength, notes, tags, and tension
+  - Toggle bidirectional status on existing relationships
+  - Creating reverse link when toggling bidirectional ON
+  - Removing reverse link when toggling bidirectional OFF
+  - Preserves timestamps and metadata during edits
+  - Success notification after saving changes
 
 ### Fixed
 - Resolved Svelte 5 state_unsafe_mutation error in entity pages (Issue #98)

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -284,13 +284,30 @@ On any entity's detail page, the Relationships section shows:
 
 ### Editing Relationships
 
-To modify a relationship:
+You can modify existing relationships without having to delete and recreate them.
+
+**To edit a relationship:**
 
 1. View the entity's detail page
 2. Find the relationship in the Relationships section
-3. Click the edit icon
-4. Update the fields
-5. Click "Save Changes"
+3. Click the edit icon (pencil button) on the relationship card
+4. The edit modal opens with current values
+5. Update any fields you want to change:
+   - Relationship type
+   - Strength (strong, moderate, weak)
+   - Notes
+   - Tags
+   - Tension level (0-100)
+   - Bidirectional toggle
+6. Click "Save Changes"
+
+**Important Notes:**
+
+- Only forward links show the edit button. Reverse links (incoming relationships from bidirectional connections) must be edited from the other entity.
+- When you toggle bidirectional ON, a reverse link is automatically created on the target entity.
+- When you toggle bidirectional OFF, the reverse link is removed from the target entity.
+- Timestamps are updated to reflect when the relationship was last modified.
+- All changes are saved immediately after you click "Save Changes".
 
 ### Deleting Relationships
 

--- a/src/lib/components/entity/EditRelationshipModal.svelte
+++ b/src/lib/components/entity/EditRelationshipModal.svelte
@@ -1,0 +1,337 @@
+<script lang="ts">
+	import { X } from 'lucide-svelte';
+	import type { BaseEntity, EntityLink } from '$lib/types';
+
+	interface Props {
+		sourceEntity: BaseEntity;
+		targetEntity: BaseEntity;
+		link: EntityLink;
+		open?: boolean;
+		onClose: () => void;
+		onSave: (changes: {
+			relationship: string;
+			notes?: string;
+			strength?: 'strong' | 'moderate' | 'weak';
+			metadata?: { tags?: string[]; tension?: number };
+			bidirectional?: boolean;
+		}) => Promise<void>;
+	}
+
+	let { sourceEntity, targetEntity, link, open = $bindable(false), onClose, onSave }: Props = $props();
+
+	// Form state
+	let relationship = $state(link.relationship);
+	let strength = $state<'' | 'strong' | 'moderate' | 'weak'>(link.strength ?? '');
+	let notes = $state(link.notes ?? '');
+	let tension = $state(link.metadata?.tension ?? 0);
+	let tags = $state<string[]>(link.metadata?.tags ?? []);
+	let tagInput = $state('');
+	let bidirectional = $state(link.bidirectional);
+	let isSubmitting = $state(false);
+	let errorMessage = $state('');
+	let validationError = $state('');
+
+	// Reset form when link changes
+	$effect(() => {
+		relationship = link.relationship;
+		strength = link.strength ?? '';
+		notes = link.notes ?? '';
+		tension = link.metadata?.tension ?? 0;
+		tags = link.metadata?.tags ?? [];
+		tagInput = '';
+		bidirectional = link.bidirectional;
+		errorMessage = '';
+		validationError = '';
+	});
+
+	function handleClose() {
+		// Reset form to original values
+		relationship = link.relationship;
+		strength = link.strength ?? '';
+		notes = link.notes ?? '';
+		tension = link.metadata?.tension ?? 0;
+		tags = link.metadata?.tags ?? [];
+		tagInput = '';
+		bidirectional = link.bidirectional;
+		errorMessage = '';
+		validationError = '';
+		open = false;
+		onClose();
+	}
+
+	function handleBackdropClick(e: MouseEvent) {
+		if (e.target === e.currentTarget) {
+			handleClose();
+		}
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			handleClose();
+		}
+	}
+
+	function handleAddTag(e: KeyboardEvent) {
+		if (e.key === 'Enter' && tagInput.trim()) {
+			e.preventDefault();
+			if (!tags.includes(tagInput.trim())) {
+				tags = [...tags, tagInput.trim()];
+			}
+			tagInput = '';
+		}
+	}
+
+	function handleRemoveTag(tagToRemove: string) {
+		tags = tags.filter(t => t !== tagToRemove);
+	}
+
+	async function handleSubmit() {
+		// Validation
+		if (!relationship.trim()) {
+			validationError = 'Relationship type is required';
+			return;
+		}
+
+		// Clamp tension value
+		const clampedTension = Math.max(0, Math.min(100, tension));
+
+		isSubmitting = true;
+		errorMessage = '';
+		validationError = '';
+
+		try {
+			const changes: {
+				relationship: string;
+				notes?: string;
+				strength?: 'strong' | 'moderate' | 'weak';
+				metadata?: { tags?: string[]; tension?: number };
+				bidirectional?: boolean;
+			} = {
+				relationship: relationship.trim(),
+			};
+
+			// Add notes (can be empty string)
+			changes.notes = notes.trim();
+
+			// Add strength if not empty
+			if (strength && strength !== '') {
+				changes.strength = strength as 'strong' | 'moderate' | 'weak';
+			}
+
+			// Build metadata
+			const metadata: { tags?: string[]; tension?: number } = {};
+			if (tags.length > 0) {
+				metadata.tags = tags;
+			}
+			if (clampedTension !== 0) {
+				metadata.tension = clampedTension;
+			}
+
+			if (Object.keys(metadata).length > 0) {
+				changes.metadata = metadata;
+			}
+
+			// Add bidirectional status
+			changes.bidirectional = bidirectional;
+
+			await onSave(changes);
+			handleClose();
+		} catch (error) {
+			errorMessage = error instanceof Error ? error.message : 'Failed to update relationship';
+		} finally {
+			isSubmitting = false;
+		}
+	}
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+{#if open}
+	<div
+		class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+		onclick={handleBackdropClick}
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby="edit-relationship-title"
+		tabindex="-1"
+	>
+		<div
+			class="bg-white dark:bg-slate-800 rounded-lg shadow-xl max-w-2xl w-full max-h-[80vh] overflow-y-auto"
+			onclick={(e) => e.stopPropagation()}
+		>
+			<!-- Header -->
+			<div class="flex items-center justify-between p-4 border-b border-slate-200 dark:border-slate-700">
+				<h2 id="edit-relationship-title" class="text-lg font-semibold text-slate-900 dark:text-white">
+					Edit Relationship
+				</h2>
+				<button
+					onclick={handleClose}
+					class="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200"
+					aria-label="Close"
+					type="button"
+				>
+					<X class="w-5 h-5" />
+				</button>
+			</div>
+
+			<!-- Content -->
+			<div class="p-4 space-y-4">
+				<!-- Entity names -->
+				<div class="p-3 bg-slate-50 dark:bg-slate-700 rounded-lg border border-slate-200 dark:border-slate-600">
+					<div class="text-sm text-slate-600 dark:text-slate-400">
+						<span class="font-medium text-slate-900 dark:text-white">{sourceEntity.name}</span>
+						<span class="mx-2">→</span>
+						<span class="font-medium text-slate-900 dark:text-white">{targetEntity.name}</span>
+					</div>
+				</div>
+
+				<!-- Relationship type -->
+				<div>
+					<label for="relationship-type" class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+						Relationship Type
+					</label>
+					<input
+						id="relationship-type"
+						type="text"
+						bind:value={relationship}
+						placeholder="e.g., friend_of, knows, member_of"
+						class="w-full px-4 py-2 border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-700 text-slate-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+					/>
+				</div>
+
+				<!-- Strength -->
+				<div>
+					<label for="strength" class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+						Strength
+					</label>
+					<select
+						id="strength"
+						bind:value={strength}
+						onchange={(e) => { strength = (e.currentTarget as HTMLSelectElement).value as '' | 'strong' | 'moderate' | 'weak'; }}
+						class="w-full px-4 py-2 border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-700 text-slate-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+					>
+						<option value="">None</option>
+						<option value="strong">strong</option>
+						<option value="moderate">moderate</option>
+						<option value="weak">weak</option>
+					</select>
+				</div>
+
+				<!-- Notes -->
+				<div>
+					<label for="notes" class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+						Notes
+					</label>
+					<textarea
+						id="notes"
+						bind:value={notes}
+						placeholder="Optional notes about this relationship..."
+						rows="3"
+						class="w-full px-4 py-2 border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-700 text-slate-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-y"
+					></textarea>
+				</div>
+
+				<!-- Tags -->
+				<div>
+					<label for="tag-input" class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+						Tags
+					</label>
+					<input
+						id="tag-input"
+						type="text"
+						bind:value={tagInput}
+						onkeydown={handleAddTag}
+						placeholder="Add a tag (press Enter)"
+						class="w-full px-4 py-2 border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-700 text-slate-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+					/>
+					{#if tags.length > 0}
+						<div class="flex flex-wrap gap-2 mt-2">
+							{#each tags as tag}
+								<span class="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
+									{tag}
+									<button
+										onclick={() => handleRemoveTag(tag)}
+										class="hover:text-blue-900 dark:hover:text-blue-100"
+										aria-label="Remove tag {tag}"
+										type="button"
+									>
+										<X class="w-3 h-3" />
+									</button>
+								</span>
+							{/each}
+						</div>
+					{/if}
+				</div>
+
+				<!-- Tension -->
+				<div>
+					<label for="tension" class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+						Tension
+					</label>
+					<input
+						id="tension"
+						type="number"
+						min="0"
+						max="100"
+						bind:value={tension}
+						class="w-full px-4 py-2 border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-700 text-slate-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+					/>
+				</div>
+
+				<!-- Bidirectional -->
+				<div>
+					<label class="flex items-center gap-2 text-sm font-medium text-slate-700 dark:text-slate-300 cursor-pointer">
+						<input
+							id="bidirectional"
+							type="checkbox"
+							bind:checked={bidirectional}
+							class="w-4 h-4 border border-slate-300 dark:border-slate-600 rounded bg-white dark:bg-slate-700 text-blue-600 focus:ring-2 focus:ring-blue-500 focus:ring-offset-0"
+						/>
+						<span>Bidirectional</span>
+					</label>
+					<p class="text-xs text-slate-500 dark:text-slate-400 mt-1 ml-6">
+						Creates a reverse relationship on the target entity
+					</p>
+				</div>
+
+				<!-- Validation Error -->
+				{#if validationError}
+					<div class="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-red-700 dark:text-red-300 text-sm">
+						{validationError}
+					</div>
+				{/if}
+
+				<!-- Error Message -->
+				{#if errorMessage}
+					<div class="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-red-700 dark:text-red-300 text-sm">
+						{errorMessage}
+					</div>
+				{/if}
+
+				<!-- Buttons -->
+				<div class="flex gap-2 justify-end pt-2">
+					<button
+						onclick={handleClose}
+						class="btn btn-ghost"
+						disabled={isSubmitting}
+						type="button"
+					>
+						Cancel
+					</button>
+					<button
+						onclick={handleSubmit}
+						class="btn btn-primary"
+						disabled={isSubmitting}
+						type="button"
+					>
+						{#if isSubmitting}
+							Saving...
+						{:else}
+							Save
+						{/if}
+					</button>
+				</div>
+			</div>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/entity/EditRelationshipModal.test.ts
+++ b/src/lib/components/entity/EditRelationshipModal.test.ts
@@ -1,0 +1,1189 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import EditRelationshipModal from './EditRelationshipModal.svelte';
+import { createMockEntity } from '../../../tests/utils/testUtils';
+import type { BaseEntity, EntityLink } from '$lib/types';
+
+/**
+ * Tests for EditRelationshipModal Component
+ *
+ * Issue #75: In-place relationship editing
+ *
+ * This modal allows editing relationship metadata without navigating to a different page.
+ * Users can modify relationship type, strength, notes, and tags directly from the entity detail view.
+ *
+ * These tests are written in the RED phase of TDD - they will FAIL until the
+ * component is implemented by senior-web-architect.
+ */
+
+describe('EditRelationshipModal - Basic Rendering', () => {
+	let sourceEntity: BaseEntity;
+	let targetEntity: BaseEntity;
+	let link: EntityLink;
+	let onClose: ReturnType<typeof vi.fn>;
+	let onSave: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		sourceEntity = createMockEntity({
+			id: 'source-1',
+			name: 'Aragorn',
+			type: 'character'
+		});
+
+		targetEntity = createMockEntity({
+			id: 'target-1',
+			name: 'Gandalf',
+			type: 'npc'
+		});
+
+		link = {
+			id: 'link-1',
+			sourceId: 'source-1',
+			targetId: 'target-1',
+			targetType: 'npc',
+			relationship: 'friend_of',
+			bidirectional: true,
+			notes: 'Met at Bree',
+			strength: 'strong',
+			metadata: {
+				tags: ['fellowship'],
+				tension: 10
+			}
+		};
+
+		onClose = vi.fn();
+		onSave = vi.fn();
+	});
+
+	it('should not be visible when open prop is false', () => {
+		render(EditRelationshipModal, {
+			props: { open: false, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const dialog = screen.queryByRole('dialog');
+		expect(dialog).not.toBeInTheDocument();
+	});
+
+	it('should be visible when open prop is true', () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const dialog = screen.getByRole('dialog');
+		expect(dialog).toBeInTheDocument();
+	});
+
+	it('should have appropriate modal title', () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const heading = screen.getByRole('heading', { name: /edit.*relationship/i });
+		expect(heading).toBeInTheDocument();
+	});
+
+	it('should have dialog role for accessibility', () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const dialog = screen.getByRole('dialog');
+		expect(dialog).toHaveAttribute('aria-modal', 'true');
+	});
+
+	it('should display source and target entity names', () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		expect(screen.getByText(/Aragorn/)).toBeInTheDocument();
+		expect(screen.getByText(/Gandalf/)).toBeInTheDocument();
+	});
+});
+
+describe('EditRelationshipModal - Form Fields Pre-population', () => {
+	let sourceEntity: BaseEntity;
+	let targetEntity: BaseEntity;
+	let link: EntityLink;
+	let onClose: ReturnType<typeof vi.fn>;
+	let onSave: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		sourceEntity = createMockEntity({
+			id: 'source-1',
+			name: 'Frodo',
+			type: 'character'
+		});
+
+		targetEntity = createMockEntity({
+			id: 'target-1',
+			name: 'Sam',
+			type: 'npc'
+		});
+
+		link = {
+			id: 'link-1',
+			sourceId: 'source-1',
+			targetId: 'target-1',
+			targetType: 'npc',
+			relationship: 'friend_of',
+			bidirectional: true,
+			notes: 'Loyal companion throughout the journey',
+			strength: 'strong',
+			metadata: {
+				tags: ['fellowship', 'ringbearer'],
+				tension: 5
+			}
+		};
+
+		onClose = vi.fn();
+		onSave = vi.fn();
+	});
+
+	it('should pre-populate relationship type field with current value', () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const relationshipInput = screen.getByLabelText(/relationship.*type/i) as HTMLInputElement;
+		expect(relationshipInput.value).toBe('friend_of');
+	});
+
+	it('should pre-populate strength field with current value', () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const strengthSelect = screen.getByLabelText(/strength/i) as HTMLSelectElement;
+		expect(strengthSelect.value).toBe('strong');
+	});
+
+	it('should pre-populate notes field with current value', () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const notesTextarea = screen.getByLabelText(/notes/i) as HTMLTextAreaElement;
+		expect(notesTextarea.value).toBe('Loyal companion throughout the journey');
+	});
+
+	it('should pre-populate tags field with current values', () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		// Tags should be displayed (exact implementation may vary)
+		expect(screen.getByText('fellowship')).toBeInTheDocument();
+		expect(screen.getByText('ringbearer')).toBeInTheDocument();
+	});
+
+	it('should pre-populate tension field with current value', () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const tensionInput = screen.getByLabelText(/tension/i) as HTMLInputElement;
+		expect(tensionInput.value).toBe('5');
+	});
+
+	it('should handle link with no optional fields', () => {
+		const minimalLink: EntityLink = {
+			id: 'link-2',
+			sourceId: 'source-1',
+			targetId: 'target-1',
+			targetType: 'npc',
+			relationship: 'knows',
+			bidirectional: false
+		};
+
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link: minimalLink, onClose, onSave }
+		});
+
+		const relationshipInput = screen.getByLabelText(/relationship.*type/i) as HTMLInputElement;
+		expect(relationshipInput.value).toBe('knows');
+
+		const notesTextarea = screen.getByLabelText(/notes/i) as HTMLTextAreaElement;
+		expect(notesTextarea.value).toBe('');
+	});
+});
+
+describe('EditRelationshipModal - Form Editing', () => {
+	let sourceEntity: BaseEntity;
+	let targetEntity: BaseEntity;
+	let link: EntityLink;
+	let onClose: ReturnType<typeof vi.fn>;
+	let onSave: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		sourceEntity = createMockEntity({
+			id: 'source-1',
+			name: 'Legolas',
+			type: 'character'
+		});
+
+		targetEntity = createMockEntity({
+			id: 'target-1',
+			name: 'Gimli',
+			type: 'npc'
+		});
+
+		link = {
+			id: 'link-1',
+			sourceId: 'source-1',
+			targetId: 'target-1',
+			targetType: 'npc',
+			relationship: 'rival_of',
+			bidirectional: true,
+			notes: 'Initial rivalry',
+			strength: 'moderate',
+			metadata: {
+				tags: ['contest'],
+				tension: 60
+			}
+		};
+
+		onClose = vi.fn();
+		onSave = vi.fn();
+	});
+
+	it('should allow editing relationship type', async () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const relationshipInput = screen.getByLabelText(/relationship.*type/i) as HTMLInputElement;
+		await fireEvent.input(relationshipInput, { target: { value: 'friend_of' } });
+
+		expect(relationshipInput.value).toBe('friend_of');
+	});
+
+	it('should allow editing strength', async () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const strengthSelect = screen.getByLabelText(/strength/i) as HTMLSelectElement;
+		await fireEvent.change(strengthSelect, { target: { value: 'strong' } });
+
+		expect(strengthSelect.value).toBe('strong');
+	});
+
+	it('should allow editing notes', async () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const notesTextarea = screen.getByLabelText(/notes/i) as HTMLTextAreaElement;
+		await fireEvent.input(notesTextarea, {
+			target: { value: 'Became best friends after the journey' }
+		});
+
+		expect(notesTextarea.value).toBe('Became best friends after the journey');
+	});
+
+	it('should allow adding tags', async () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		// Find the tag input field
+		const tagInput = screen.getByPlaceholderText(/add.*tag/i) as HTMLInputElement;
+		await fireEvent.input(tagInput, { target: { value: 'friendship' } });
+		await fireEvent.keyDown(tagInput, { key: 'Enter' });
+
+		// New tag should appear
+		expect(screen.getByText('friendship')).toBeInTheDocument();
+	});
+
+	it('should allow removing tags', async () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		// Find and click remove button for 'contest' tag
+		const contestTag = screen.getByText('contest');
+		const removeButton = contestTag.parentElement?.querySelector('button');
+		expect(removeButton).toBeDefined();
+
+		await fireEvent.click(removeButton!);
+
+		// Tag should be removed
+		expect(screen.queryByText('contest')).not.toBeInTheDocument();
+	});
+
+	it('should allow editing tension value', async () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const tensionInput = screen.getByLabelText(/tension/i) as HTMLInputElement;
+		await fireEvent.input(tensionInput, { target: { value: '15' } });
+
+		expect(tensionInput.value).toBe('15');
+	});
+
+	it('should validate tension is between 0 and 100', async () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const tensionInput = screen.getByLabelText(/tension/i) as HTMLInputElement;
+
+		// Try invalid value
+		await fireEvent.input(tensionInput, { target: { value: '150' } });
+
+		// Should show validation error or clamp value
+		const saveButton = screen.getByRole('button', { name: /save/i });
+		await fireEvent.click(saveButton);
+
+		// onSave should either not be called or should clamp the value
+		if (onSave.mock.calls.length > 0) {
+			const savedData = onSave.mock.calls[0][0];
+			expect(savedData.metadata.tension).toBeLessThanOrEqual(100);
+		}
+	});
+});
+
+describe('EditRelationshipModal - Save Functionality', () => {
+	let sourceEntity: BaseEntity;
+	let targetEntity: BaseEntity;
+	let link: EntityLink;
+	let onClose: ReturnType<typeof vi.fn>;
+	let onSave: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		sourceEntity = createMockEntity({
+			id: 'source-1',
+			name: 'Boromir',
+			type: 'character'
+		});
+
+		targetEntity = createMockEntity({
+			id: 'target-1',
+			name: 'Ring of Power',
+			type: 'item'
+		});
+
+		link = {
+			id: 'link-1',
+			sourceId: 'source-1',
+			targetId: 'target-1',
+			targetType: 'item',
+			relationship: 'tempted_by',
+			bidirectional: false,
+			notes: 'Growing obsession',
+			strength: 'strong',
+			metadata: {
+				tags: ['corruption'],
+				tension: 85
+			}
+		};
+
+		onClose = vi.fn();
+		onSave = vi.fn().mockResolvedValue(undefined);
+	});
+
+	it('should have a Save button', () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const saveButton = screen.getByRole('button', { name: /save/i });
+		expect(saveButton).toBeInTheDocument();
+	});
+
+	it('should call onSave with updated data when Save is clicked', async () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		// Edit the relationship
+		const relationshipInput = screen.getByLabelText(/relationship.*type/i) as HTMLInputElement;
+		await fireEvent.input(relationshipInput, { target: { value: 'corrupted_by' } });
+
+		// Click Save
+		const saveButton = screen.getByRole('button', { name: /save/i });
+		await fireEvent.click(saveButton);
+
+		expect(onSave).toHaveBeenCalledTimes(1);
+		expect(onSave).toHaveBeenCalledWith(
+			expect.objectContaining({
+				relationship: 'corrupted_by'
+			})
+		);
+	});
+
+	it('should include all modified fields in save data', async () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		// Edit multiple fields
+		const relationshipInput = screen.getByLabelText(/relationship.*type/i) as HTMLInputElement;
+		await fireEvent.input(relationshipInput, { target: { value: 'obsessed_with' } });
+
+		const strengthSelect = screen.getByLabelText(/strength/i) as HTMLSelectElement;
+		await fireEvent.change(strengthSelect, { target: { value: 'strong' } });
+
+		const notesTextarea = screen.getByLabelText(/notes/i) as HTMLTextAreaElement;
+		await fireEvent.input(notesTextarea, { target: { value: 'Fatal temptation' } });
+
+		// Click Save
+		const saveButton = screen.getByRole('button', { name: /save/i });
+		await fireEvent.click(saveButton);
+
+		expect(onSave).toHaveBeenCalledWith(
+			expect.objectContaining({
+				relationship: 'obsessed_with',
+				strength: 'strong',
+				notes: 'Fatal temptation'
+			})
+		);
+	});
+
+	it('should include metadata in save data', async () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const tensionInput = screen.getByLabelText(/tension/i) as HTMLInputElement;
+		await fireEvent.input(tensionInput, { target: { value: '95' } });
+
+		const saveButton = screen.getByRole('button', { name: /save/i });
+		await fireEvent.click(saveButton);
+
+		expect(onSave).toHaveBeenCalledWith(
+			expect.objectContaining({
+				metadata: expect.objectContaining({
+					tension: 95
+				})
+			})
+		);
+	});
+
+	it('should close modal after successful save', async () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const saveButton = screen.getByRole('button', { name: /save/i });
+		await fireEvent.click(saveButton);
+
+		await waitFor(() => {
+			expect(onClose).toHaveBeenCalled();
+		});
+	});
+
+	it('should show loading state while saving', async () => {
+		// Mock slow save operation
+		const slowSave = vi.fn(
+			() =>
+				new Promise((resolve) => {
+					setTimeout(resolve, 100);
+				})
+		);
+
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave: slowSave }
+		});
+
+		const saveButton = screen.getByRole('button', { name: /save/i });
+		await fireEvent.click(saveButton);
+
+		// Button should show loading state
+		expect(saveButton).toHaveTextContent(/saving/i);
+		expect(saveButton).toBeDisabled();
+	});
+
+	it('should handle save errors gracefully', async () => {
+		const errorSave = vi.fn().mockRejectedValue(new Error('Database error'));
+
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave: errorSave }
+		});
+
+		const saveButton = screen.getByRole('button', { name: /save/i });
+		await fireEvent.click(saveButton);
+
+		await waitFor(() => {
+			// Should show error message
+			expect(screen.getByText(/error/i)).toBeInTheDocument();
+		});
+
+		// Should not close modal on error
+		expect(onClose).not.toHaveBeenCalled();
+	});
+});
+
+describe('EditRelationshipModal - Cancel Functionality', () => {
+	let sourceEntity: BaseEntity;
+	let targetEntity: BaseEntity;
+	let link: EntityLink;
+	let onClose: ReturnType<typeof vi.fn>;
+	let onSave: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		sourceEntity = createMockEntity({
+			id: 'source-1',
+			name: 'Entity A',
+			type: 'character'
+		});
+
+		targetEntity = createMockEntity({
+			id: 'target-1',
+			name: 'Entity B',
+			type: 'npc'
+		});
+
+		link = {
+			id: 'link-1',
+			sourceId: 'source-1',
+			targetId: 'target-1',
+			targetType: 'npc',
+			relationship: 'knows',
+			bidirectional: true
+		};
+
+		onClose = vi.fn();
+		onSave = vi.fn();
+	});
+
+	it('should have a Cancel button', () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const cancelButton = screen.getByRole('button', { name: /cancel/i });
+		expect(cancelButton).toBeInTheDocument();
+	});
+
+	it('should call onClose when Cancel is clicked', async () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const cancelButton = screen.getByRole('button', { name: /cancel/i });
+		await fireEvent.click(cancelButton);
+
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('should not call onSave when Cancel is clicked', async () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		// Edit a field
+		const notesTextarea = screen.getByLabelText(/notes/i) as HTMLTextAreaElement;
+		await fireEvent.input(notesTextarea, { target: { value: 'This should not be saved' } });
+
+		// Click Cancel
+		const cancelButton = screen.getByRole('button', { name: /cancel/i });
+		await fireEvent.click(cancelButton);
+
+		expect(onSave).not.toHaveBeenCalled();
+	});
+
+	it('should discard changes when Cancel is clicked', async () => {
+		const { rerender } = render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		// Edit a field
+		const notesTextarea = screen.getByLabelText(/notes/i) as HTMLTextAreaElement;
+		await fireEvent.input(notesTextarea, { target: { value: 'Modified notes' } });
+
+		// Click Cancel
+		const cancelButton = screen.getByRole('button', { name: /cancel/i });
+		await fireEvent.click(cancelButton);
+
+		// Reopen modal
+		rerender({ open: false, sourceEntity, targetEntity, link, onClose, onSave });
+		rerender({ open: true, sourceEntity, targetEntity, link, onClose, onSave });
+
+		// Notes should be back to original value
+		const newNotesTextarea = screen.getByLabelText(/notes/i) as HTMLTextAreaElement;
+		expect(newNotesTextarea.value).toBe('');
+	});
+
+	it('should close on Escape key press', async () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		await fireEvent.keyDown(document, { key: 'Escape' });
+
+		expect(onClose).toHaveBeenCalled();
+	});
+
+	it('should close on backdrop click', async () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const dialog = screen.getByRole('dialog');
+		await fireEvent.click(dialog);
+
+		expect(onClose).toHaveBeenCalled();
+	});
+
+	it('should NOT close when clicking inside modal content', async () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const heading = screen.getByRole('heading', { name: /edit.*relationship/i });
+		await fireEvent.click(heading);
+
+		expect(onClose).not.toHaveBeenCalled();
+	});
+});
+
+describe('EditRelationshipModal - Strength Field Options', () => {
+	let sourceEntity: BaseEntity;
+	let targetEntity: BaseEntity;
+	let link: EntityLink;
+	let onClose: ReturnType<typeof vi.fn>;
+	let onSave: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		sourceEntity = createMockEntity({
+			id: 'source-1',
+			name: 'Test Source',
+			type: 'character'
+		});
+
+		targetEntity = createMockEntity({
+			id: 'target-1',
+			name: 'Test Target',
+			type: 'npc'
+		});
+
+		link = {
+			id: 'link-1',
+			sourceId: 'source-1',
+			targetId: 'target-1',
+			targetType: 'npc',
+			relationship: 'knows',
+			bidirectional: true
+		};
+
+		onClose = vi.fn();
+		onSave = vi.fn();
+	});
+
+	it('should have strength options: strong, moderate, weak', () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const strengthSelect = screen.getByLabelText(/strength/i);
+
+		expect(strengthSelect).toContainHTML('strong');
+		expect(strengthSelect).toContainHTML('moderate');
+		expect(strengthSelect).toContainHTML('weak');
+	});
+
+	it('should allow selecting "strong" strength', async () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const strengthSelect = screen.getByLabelText(/strength/i) as HTMLSelectElement;
+		await fireEvent.change(strengthSelect, { target: { value: 'strong' } });
+
+		expect(strengthSelect.value).toBe('strong');
+	});
+
+	it('should allow selecting "moderate" strength', async () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const strengthSelect = screen.getByLabelText(/strength/i) as HTMLSelectElement;
+		await fireEvent.change(strengthSelect, { target: { value: 'moderate' } });
+
+		expect(strengthSelect.value).toBe('moderate');
+	});
+
+	it('should allow selecting "weak" strength', async () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const strengthSelect = screen.getByLabelText(/strength/i) as HTMLSelectElement;
+		await fireEvent.change(strengthSelect, { target: { value: 'weak' } });
+
+		expect(strengthSelect.value).toBe('weak');
+	});
+
+	it('should allow clearing strength (no strength)', async () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const strengthSelect = screen.getByLabelText(/strength/i) as HTMLSelectElement;
+		await fireEvent.change(strengthSelect, { target: { value: '' } });
+
+		expect(strengthSelect.value).toBe('');
+	});
+});
+
+describe('EditRelationshipModal - Accessibility', () => {
+	let sourceEntity: BaseEntity;
+	let targetEntity: BaseEntity;
+	let link: EntityLink;
+	let onClose: ReturnType<typeof vi.fn>;
+	let onSave: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		sourceEntity = createMockEntity({
+			id: 'source-1',
+			name: 'Test Source',
+			type: 'character'
+		});
+
+		targetEntity = createMockEntity({
+			id: 'target-1',
+			name: 'Test Target',
+			type: 'npc'
+		});
+
+		link = {
+			id: 'link-1',
+			sourceId: 'source-1',
+			targetId: 'target-1',
+			targetType: 'npc',
+			relationship: 'knows',
+			bidirectional: true
+		};
+
+		onClose = vi.fn();
+		onSave = vi.fn();
+	});
+
+	it('should have proper ARIA attributes on dialog', () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const dialog = screen.getByRole('dialog');
+		expect(dialog).toHaveAttribute('aria-modal', 'true');
+	});
+
+	it('should have aria-labelledby connecting title to dialog', () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const dialog = screen.getByRole('dialog');
+		const heading = screen.getByRole('heading', { name: /edit.*relationship/i });
+
+		const headingId = heading.getAttribute('id');
+		expect(headingId).toBeTruthy();
+		expect(dialog).toHaveAttribute('aria-labelledby', headingId);
+	});
+
+	it('should have proper labels on all form fields', () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		expect(screen.getByLabelText(/relationship.*type/i)).toBeInTheDocument();
+		expect(screen.getByLabelText(/strength/i)).toBeInTheDocument();
+		expect(screen.getByLabelText(/notes/i)).toBeInTheDocument();
+		expect(screen.getByLabelText(/tension/i)).toBeInTheDocument();
+	});
+
+	it('should have accessible button labels', () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const saveButton = screen.getByRole('button', { name: /save/i });
+		expect(saveButton).toHaveAccessibleName();
+
+		const cancelButton = screen.getByRole('button', { name: /cancel/i });
+		expect(cancelButton).toHaveAccessibleName();
+	});
+
+	it('should support keyboard navigation', () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const buttons = screen.getAllByRole('button');
+		buttons.forEach((button) => {
+			expect(button).toHaveAttribute('type', 'button');
+		});
+	});
+
+	it('should trap focus within modal when open', () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const dialog = screen.getByRole('dialog');
+		const formElements = screen.getAllByRole('textbox');
+		const buttons = screen.getAllByRole('button');
+
+		// All form elements should be inside dialog
+		formElements.forEach((element) => {
+			expect(dialog).toContainElement(element);
+		});
+
+		buttons.forEach((button) => {
+			expect(dialog).toContainElement(button);
+		});
+	});
+});
+
+describe('EditRelationshipModal - Form Validation', () => {
+	let sourceEntity: BaseEntity;
+	let targetEntity: BaseEntity;
+	let link: EntityLink;
+	let onClose: ReturnType<typeof vi.fn>;
+	let onSave: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		sourceEntity = createMockEntity({
+			id: 'source-1',
+			name: 'Test Source',
+			type: 'character'
+		});
+
+		targetEntity = createMockEntity({
+			id: 'target-1',
+			name: 'Test Target',
+			type: 'npc'
+		});
+
+		link = {
+			id: 'link-1',
+			sourceId: 'source-1',
+			targetId: 'target-1',
+			targetType: 'npc',
+			relationship: 'knows',
+			bidirectional: true
+		};
+
+		onClose = vi.fn();
+		onSave = vi.fn();
+	});
+
+	it('should require relationship type to be non-empty', async () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const relationshipInput = screen.getByLabelText(/relationship.*type/i) as HTMLInputElement;
+		await fireEvent.input(relationshipInput, { target: { value: '' } });
+
+		const saveButton = screen.getByRole('button', { name: /save/i });
+		await fireEvent.click(saveButton);
+
+		// Should show validation error
+		expect(screen.getByText(/relationship.*required/i)).toBeInTheDocument();
+		expect(onSave).not.toHaveBeenCalled();
+	});
+
+	it('should validate tension is a number', async () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const tensionInput = screen.getByLabelText(/tension/i) as HTMLInputElement;
+
+		// HTML input type="number" should prevent non-numeric input
+		expect(tensionInput).toHaveAttribute('type', 'number');
+	});
+
+	it('should validate tension minimum value is 0', async () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const tensionInput = screen.getByLabelText(/tension/i) as HTMLInputElement;
+		expect(tensionInput).toHaveAttribute('min', '0');
+	});
+
+	it('should validate tension maximum value is 100', async () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const tensionInput = screen.getByLabelText(/tension/i) as HTMLInputElement;
+		expect(tensionInput).toHaveAttribute('max', '100');
+	});
+});
+
+describe('EditRelationshipModal - Bidirectional Toggle', () => {
+	let sourceEntity: BaseEntity;
+	let targetEntity: BaseEntity;
+	let link: EntityLink;
+	let onClose: ReturnType<typeof vi.fn>;
+	let onSave: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		sourceEntity = createMockEntity({
+			id: 'source-1',
+			name: 'Alice',
+			type: 'character'
+		});
+
+		targetEntity = createMockEntity({
+			id: 'target-1',
+			name: 'Bob',
+			type: 'npc'
+		});
+
+		link = {
+			id: 'link-1',
+			sourceId: 'source-1',
+			targetId: 'target-1',
+			targetType: 'npc',
+			relationship: 'knows',
+			bidirectional: false
+		};
+
+		onClose = vi.fn();
+		onSave = vi.fn().mockResolvedValue(undefined);
+	});
+
+	it('should have a bidirectional checkbox', () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const bidirectionalCheckbox = screen.getByLabelText(/bidirectional/i) as HTMLInputElement;
+		expect(bidirectionalCheckbox).toBeInTheDocument();
+		expect(bidirectionalCheckbox).toHaveAttribute('type', 'checkbox');
+	});
+
+	it('should pre-populate bidirectional checkbox with current value (false)', () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const bidirectionalCheckbox = screen.getByLabelText(/bidirectional/i) as HTMLInputElement;
+		expect(bidirectionalCheckbox.checked).toBe(false);
+	});
+
+	it('should pre-populate bidirectional checkbox with current value (true)', () => {
+		const bidirectionalLink: EntityLink = {
+			...link,
+			bidirectional: true
+		};
+
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link: bidirectionalLink, onClose, onSave }
+		});
+
+		const bidirectionalCheckbox = screen.getByLabelText(/bidirectional/i) as HTMLInputElement;
+		expect(bidirectionalCheckbox.checked).toBe(true);
+	});
+
+	it('should allow toggling bidirectional ON', async () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const bidirectionalCheckbox = screen.getByLabelText(/bidirectional/i) as HTMLInputElement;
+		expect(bidirectionalCheckbox.checked).toBe(false);
+
+		await fireEvent.click(bidirectionalCheckbox);
+
+		expect(bidirectionalCheckbox.checked).toBe(true);
+	});
+
+	it('should allow toggling bidirectional OFF', async () => {
+		const bidirectionalLink: EntityLink = {
+			...link,
+			bidirectional: true
+		};
+
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link: bidirectionalLink, onClose, onSave }
+		});
+
+		const bidirectionalCheckbox = screen.getByLabelText(/bidirectional/i) as HTMLInputElement;
+		expect(bidirectionalCheckbox.checked).toBe(true);
+
+		await fireEvent.click(bidirectionalCheckbox);
+
+		expect(bidirectionalCheckbox.checked).toBe(false);
+	});
+
+	it('should include bidirectional in save data when toggled ON', async () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const bidirectionalCheckbox = screen.getByLabelText(/bidirectional/i) as HTMLInputElement;
+		await fireEvent.click(bidirectionalCheckbox);
+
+		const saveButton = screen.getByRole('button', { name: /save/i });
+		await fireEvent.click(saveButton);
+
+		expect(onSave).toHaveBeenCalledWith(
+			expect.objectContaining({
+				bidirectional: true
+			})
+		);
+	});
+
+	it('should include bidirectional in save data when toggled OFF', async () => {
+		const bidirectionalLink: EntityLink = {
+			...link,
+			bidirectional: true
+		};
+
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link: bidirectionalLink, onClose, onSave }
+		});
+
+		const bidirectionalCheckbox = screen.getByLabelText(/bidirectional/i) as HTMLInputElement;
+		await fireEvent.click(bidirectionalCheckbox);
+
+		const saveButton = screen.getByRole('button', { name: /save/i });
+		await fireEvent.click(saveButton);
+
+		expect(onSave).toHaveBeenCalledWith(
+			expect.objectContaining({
+				bidirectional: false
+			})
+		);
+	});
+
+	it('should reset bidirectional on cancel', async () => {
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const bidirectionalCheckbox = screen.getByLabelText(/bidirectional/i) as HTMLInputElement;
+		await fireEvent.click(bidirectionalCheckbox);
+		expect(bidirectionalCheckbox.checked).toBe(true);
+
+		const cancelButton = screen.getByRole('button', { name: /cancel/i });
+		await fireEvent.click(cancelButton);
+
+		expect(onSave).not.toHaveBeenCalled();
+	});
+});
+
+describe('EditRelationshipModal - Edge Cases', () => {
+	let sourceEntity: BaseEntity;
+	let targetEntity: BaseEntity;
+	let onClose: ReturnType<typeof vi.fn>;
+	let onSave: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		sourceEntity = createMockEntity({
+			id: 'source-1',
+			name: 'Test Source',
+			type: 'character'
+		});
+
+		targetEntity = createMockEntity({
+			id: 'target-1',
+			name: 'Test Target',
+			type: 'npc'
+		});
+
+		onClose = vi.fn();
+		onSave = vi.fn();
+	});
+
+	it('should handle link with very long notes', () => {
+		const longNotes = 'A'.repeat(5000);
+		const link: EntityLink = {
+			id: 'link-1',
+			sourceId: 'source-1',
+			targetId: 'target-1',
+			targetType: 'npc',
+			relationship: 'knows',
+			bidirectional: true,
+			notes: longNotes
+		};
+
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const notesTextarea = screen.getByLabelText(/notes/i) as HTMLTextAreaElement;
+		expect(notesTextarea.value).toBe(longNotes);
+	});
+
+	it('should handle link with many tags', () => {
+		const manyTags = Array.from({ length: 20 }, (_, i) => `tag${i}`);
+		const link: EntityLink = {
+			id: 'link-1',
+			sourceId: 'source-1',
+			targetId: 'target-1',
+			targetType: 'npc',
+			relationship: 'knows',
+			bidirectional: true,
+			metadata: {
+				tags: manyTags
+			}
+		};
+
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		// Should display all tags
+		manyTags.forEach((tag) => {
+			expect(screen.getByText(tag)).toBeInTheDocument();
+		});
+	});
+
+	it('should handle special characters in relationship type', async () => {
+		const link: EntityLink = {
+			id: 'link-1',
+			sourceId: 'source-1',
+			targetId: 'target-1',
+			targetType: 'npc',
+			relationship: 'knows',
+			bidirectional: true
+		};
+
+		render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		const relationshipInput = screen.getByLabelText(/relationship.*type/i) as HTMLInputElement;
+		await fireEvent.input(relationshipInput, {
+			target: { value: 'parent/child relationship (complex)' }
+		});
+
+		expect(relationshipInput.value).toBe('parent/child relationship (complex)');
+	});
+
+	it('should handle reopening modal with same data', async () => {
+		const link: EntityLink = {
+			id: 'link-1',
+			sourceId: 'source-1',
+			targetId: 'target-1',
+			targetType: 'npc',
+			relationship: 'knows',
+			bidirectional: true,
+			notes: 'Original notes'
+		};
+
+		const { rerender } = render(EditRelationshipModal, {
+			props: { open: true, sourceEntity, targetEntity, link, onClose, onSave }
+		});
+
+		// Close modal
+		rerender({ open: false, sourceEntity, targetEntity, link, onClose, onSave });
+
+		// Reopen modal
+		rerender({ open: true, sourceEntity, targetEntity, link, onClose, onSave });
+
+		// Should still show original data
+		const notesTextarea = screen.getByLabelText(/notes/i) as HTMLTextAreaElement;
+		expect(notesTextarea.value).toBe('Original notes');
+	});
+});

--- a/src/lib/components/entity/index.ts
+++ b/src/lib/components/entity/index.ts
@@ -2,3 +2,4 @@ export { default as EntitySummary } from './EntitySummary.svelte';
 export { default as RelateCommand } from './RelateCommand.svelte';
 export { default as FieldGenerateButton } from './FieldGenerateButton.svelte';
 export { default as RelationshipCard } from './RelationshipCard.svelte';
+export { default as EditRelationshipModal } from './EditRelationshipModal.svelte';


### PR DESCRIPTION
## Summary

- Add EditRelationshipModal component for editing relationships in-place
- Add edit button to relationship cards (forward links only)
- Support editing: relationship type, strength, notes, tags, tension, bidirectional status
- Bidirectional toggle creates/removes reverse links when toggled

## Changes

**New Files:**
- `src/lib/components/entity/EditRelationshipModal.svelte` - Modal component
- `src/lib/components/entity/EditRelationshipModal.test.ts` - 59 tests

**Modified Files:**
- `RelationshipCard.svelte` - Added edit button
- `RelationshipCard.test.ts` - Added 58 edit button tests  
- `entityRepository.ts` - Bidirectional toggle support
- `+page.svelte` - Wire up edit modal
- Documentation (CHANGELOG, USER_GUIDE, ARCHITECTURE)

## Test plan

- [x] Edit button appears on forward relationship cards only
- [x] Modal opens with current relationship data pre-populated
- [x] Can change relationship type, strength, notes, tags, tension
- [x] Can toggle bidirectional status (creates/removes reverse link)
- [x] Cancel discards changes
- [x] Success notification shows after saving
- [x] All 117 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)