### PR TITLE
feat: implement relationship navigation breadcrumbs (closes #79)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -53,6 +53,8 @@ src/
 │   │   │   ├── RelationshipsTable.svelte
 │   │   │   ├── RelationshipRow.svelte
 │   │   │   └── BulkActionsBar.svelte
+│   │   ├── navigation/      # Navigation components
+│   │   │   └── RelationshipBreadcrumbs.svelte
 │   │   ├── ui/              # UI components
 │   │   │   ├── LoadingSpinner.svelte
 │   │   │   ├── LoadingSkeleton.svelte
@@ -66,7 +68,8 @@ src/
 │   │   ├── commands.ts      # Command palette definitions
 │   │   └── entityTypes.ts   # Entity type definitions
 │   ├── utils/               # Utility functions
-│   │   └── commandUtils.ts  # Command parsing and filtering
+│   │   ├── commandUtils.ts       # Command parsing and filtering
+│   │   └── breadcrumbUtils.ts    # Breadcrumb path parsing and serialization
 │   ├── db/                  # Database layer
 │   │   ├── index.ts         # Dexie database setup
 │   │   └── repositories/    # Data access layer
@@ -652,6 +655,177 @@ The modal calls the entity repository's `updateLink()` method, which handles:
 - Intuitive bidirectional toggle with automatic reverse link management
 - Immediate validation prevents invalid configurations
 - Success notifications confirm changes were saved
+
+#### Relationship Navigation Breadcrumbs
+
+**Location:** `/src/lib/components/navigation/RelationshipBreadcrumbs.svelte`
+**Utility Functions:** `/src/lib/utils/breadcrumbUtils.ts`
+
+**Purpose:** Track and display the navigation path when users explore entity relationships, allowing them to see where they've been and navigate back through the chain.
+
+**Implementation (Issue #79):**
+
+The breadcrumb system uses URL parameters to persist the navigation trail across page loads and browser history operations.
+
+**URL Format:**
+
+```
+/entities/{type}/{id}?navPath=entityId:relationship:name:type,entityId:relationship:name:type,...
+```
+
+**Example:**
+
+```
+/entities/npc/abc123?navPath=xyz456:patron_of:Lord%20Vance:npc,def789:knows:Elena:npc
+```
+
+This shows the user navigated from Lord Vance → Elena → current entity.
+
+**Breadcrumb Utilities:**
+
+```typescript
+// Parse URL parameter into breadcrumb segments
+parseBreadcrumbPath(pathParam: string | null): BreadcrumbSegment[]
+
+// Serialize segments back to URL parameter
+serializeBreadcrumbPath(segments: BreadcrumbSegment[]): string
+
+// Truncate path to maximum length (keeps most recent)
+truncatePath(segments: BreadcrumbSegment[], maxLength: number): BreadcrumbSegment[]
+
+// Build navigation URL with updated breadcrumb path
+buildNavigationUrl(
+  targetType: string,
+  targetId: string,
+  currentSegments: BreadcrumbSegment[],
+  relationship: string,
+  currentEntity: { id: string; name: string; type: string }
+): string
+```
+
+**BreadcrumbSegment Interface:**
+
+```typescript
+interface BreadcrumbSegment {
+  entityId: string;        // Entity ID for navigation
+  relationship: string;    // Relationship type used to reach this entity
+  entityName: string;      // Display name
+  entityType: string;      // Entity type (for routing)
+}
+```
+
+**Component Features:**
+
+**Visual Display:**
+- Shows clickable entity names in navigation chain
+- Chevron separators (→) between segments
+- Current entity shown in bold (non-clickable)
+- Ellipsis (...) when path exceeds display limit
+- Clear button (X) to reset trail
+
+**Navigation:**
+- Click any breadcrumb segment to jump back to that entity
+- Preserves original navigation path in URL
+- Browser back/forward works with breadcrumb state
+- Clear button removes navPath parameter entirely
+
+**Display Limits:**
+- Component prop `maxVisible` (default: 5) controls displayed segments
+- Storage limit of 6 segments enforced by `buildNavigationUrl()`
+- Older segments auto-truncated when limit exceeded
+- Most recent segments always visible
+
+**Props:**
+
+```typescript
+interface Props {
+  segments: BreadcrumbSegment[];           // Current breadcrumb path
+  currentEntity: {                         // Entity being viewed
+    id: string;
+    name: string;
+    type: string;
+  };
+  maxVisible?: number;                     // Max segments to display (default: 5)
+  onNavigate?: (index: number) => void;    // Callback when clicking segment
+  onClear?: () => void;                    // Callback when clearing trail
+}
+```
+
+**Integration with Entity Detail Pages:**
+
+Entity detail pages (`/src/routes/entities/[type]/[id]/+page.svelte`) integrate breadcrumbs:
+
+1. Read `navPath` query parameter from URL
+2. Parse into `BreadcrumbSegment[]` using `parseBreadcrumbPath()`
+3. Display `RelationshipBreadcrumbs` component at top of page
+4. When user clicks relationship link, call `buildNavigationUrl()` to append current entity
+5. Navigate using SvelteKit's `goto()` with new URL
+
+**State Persistence:**
+
+- Breadcrumb state stored entirely in URL query parameters
+- No client-side storage needed
+- Shareable URLs preserve navigation context
+- Browser history automatically maintains breadcrumb state
+
+**URL Encoding:**
+
+Field values are URL-encoded to handle special characters:
+- Spaces encoded as `%20`
+- Apostrophes, parentheses encoded for safety
+- Colons and commas reserved as delimiters
+- Custom `encodeField()` function for consistent encoding
+
+**Accessibility:**
+
+- `<nav>` element with `aria-label="Breadcrumb navigation"`
+- `<ol>` list with `role="list"`
+- Current entity marked with `aria-current="page"`
+- Clear button has `aria-label="Clear breadcrumb trail"`
+- Keyboard navigable (all buttons focusable)
+
+**Breadcrumb Lifecycle:**
+
+**Created:**
+- User clicks relationship link in Relationships section
+- `buildNavigationUrl()` appends current entity to path
+- Navigation occurs with updated `navPath` parameter
+
+**Persisted:**
+- URL parameter survives page refreshes
+- Browser back/forward maintains breadcrumb state
+- Works across browser sessions (shareable links)
+
+**Cleared:**
+- User clicks X button (removes `navPath` parameter)
+- User navigates via search (new URL without `navPath`)
+- User clicks sidebar entity link (direct navigation)
+- User enters URL directly
+
+**Edge Cases Handled:**
+
+- Empty or malformed `navPath` parameter (returns empty array)
+- URL decoding failures (skips invalid segments)
+- Missing fields in segments (skips incomplete data)
+- Path exceeding storage limit (auto-truncates to 6)
+- Path exceeding display limit (shows ellipsis)
+- Navigation to entity already in path (no cycle detection, path grows)
+
+**Performance Characteristics:**
+
+- O(n) parsing where n = number of segments
+- O(n) serialization where n = number of segments
+- Lightweight URL operations (no database queries)
+- Negligible impact on page load performance
+- URL length limits not a concern (max 6 segments × ~200 chars = ~1200 chars)
+
+**User Benefits:**
+
+- Track complex relationship exploration paths
+- Understand how entities connect indirectly
+- Quick backtracking through relationship network
+- Visual context for current entity's relationship to visited entities
+- Reduced cognitive load when exploring deep networks
 
 ### Loading State Components
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -282,6 +282,47 @@ On any entity's detail page, the Relationships section shows:
 - Relationship strength, tags, and tension if set
 - Quick links to view the connected entities
 
+### Navigating Relationship Chains
+
+When exploring how entities connect, Director Assist shows a breadcrumb trail to help you track your path through the relationship network.
+
+**How It Works:**
+
+When you click on a related entity from the Relationships section, a breadcrumb trail appears at the top of the page showing the chain of entities you've visited.
+
+**Example:**
+```
+Lord Vance → Elena the Bard → Grimwald the Wise (current)
+```
+
+This shows you navigated from Lord Vance to Elena, and then to Grimwald.
+
+**Using Breadcrumbs:**
+
+- **Click any entity** in the trail to jump back to that entity
+- **Click the X button** to clear the trail and view the current entity without navigation context
+- The trail shows up to **6 most recent entities** (older entries are automatically removed)
+- The trail persists when using browser back/forward buttons
+
+**When Breadcrumbs Appear:**
+
+Breadcrumbs appear only when you navigate through relationships by clicking links in the Relationships section.
+
+**When Breadcrumbs Clear:**
+
+The trail automatically clears when you:
+- Use the global search to find an entity
+- Click an entity in the sidebar
+- Navigate directly via URL
+- Click the X button to clear manually
+
+**Why Use Breadcrumbs:**
+
+- Track complex relationship chains ("How did I get here?")
+- Quickly backtrack through your exploration path
+- Understand the context of how entities connect
+- Avoid getting lost in deep relationship networks
+
 ### Managing Relationships (Advanced)
 
 For comprehensive relationship management, use the dedicated relationships page. This page provides powerful tools for viewing, filtering, and managing all relationships for an entity in one place.

--- a/src/lib/components/entity/RelationshipCard.svelte
+++ b/src/lib/components/entity/RelationshipCard.svelte
@@ -11,9 +11,18 @@
 		typeDefinition?: EntityTypeDefinition;
 		onRemove?: (linkId: string) => void;
 		onEdit?: (linkId: string) => void;
+		onNavigate?: (targetEntity: BaseEntity, relationship: string) => void;
 	}
 
-	let { linkedEntity, link, isReverse, typeDefinition, onRemove, onEdit }: Props = $props();
+	let { linkedEntity, link, isReverse, typeDefinition, onRemove, onEdit, onNavigate }: Props = $props();
+
+	function handleNavigate(event: MouseEvent) {
+		if (onNavigate && linkedEntity) {
+			event.preventDefault();
+			const relationship = isReverse && link.reverseRelationship ? link.reverseRelationship : link.relationship;
+			onNavigate(linkedEntity, relationship);
+		}
+	}
 
 	const linkedTypeDefinition = $derived(
 		linkedEntity
@@ -80,6 +89,7 @@
 		<div class="flex-1 min-w-0">
 			<a
 				href="/entities/{linkedEntity.type}/{linkedEntity.id}"
+				onclick={onNavigate ? handleNavigate : undefined}
 				class="text-lg font-semibold text-slate-900 dark:text-white hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
 			>
 				{linkedEntity.name}

--- a/src/lib/components/navigation/RelationshipBreadcrumbs.svelte
+++ b/src/lib/components/navigation/RelationshipBreadcrumbs.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+	import { ChevronRight, X } from 'lucide-svelte';
+	import type { BreadcrumbSegment } from '$lib/utils/breadcrumbUtils';
+
+	interface Props {
+		segments: BreadcrumbSegment[];
+		currentEntity: { id: string; name: string; type: string };
+		maxVisible?: number;
+		onNavigate?: (index: number) => void;
+		onClear?: () => void;
+	}
+
+	let { segments, currentEntity, maxVisible = 5, onNavigate, onClear }: Props = $props();
+
+	// Determine which segments to display based on maxVisible
+	const visibleSegments = $derived(() => {
+		if (segments.length <= maxVisible) {
+			return segments;
+		}
+		// Show most recent segments when truncated
+		return segments.slice(-maxVisible);
+	});
+
+	const showEllipsis = $derived(segments.length > maxVisible);
+
+	function handleSegmentClick(index: number) {
+		if (onNavigate) {
+			// Calculate the actual index in the full segments array
+			const actualIndex = showEllipsis ? segments.length - maxVisible + index : index;
+			onNavigate(actualIndex);
+		}
+	}
+
+	function handleClear() {
+		if (onClear) {
+			onClear();
+		}
+	}
+</script>
+
+<nav aria-label="Breadcrumb navigation" class="flex items-center flex-wrap gap-2 mb-4">
+	<ol class="flex items-center flex-wrap gap-2" role="list" aria-label="Breadcrumb">
+		<!-- Ellipsis for truncated segments -->
+		{#if showEllipsis}
+			<li class="flex items-center gap-2">
+				<span class="text-slate-400 dark:text-slate-500 text-sm">...</span>
+				<ChevronRight class="w-4 h-4 text-slate-400 dark:text-slate-500 separator" />
+			</li>
+		{/if}
+
+		<!-- Breadcrumb segments -->
+		{#each visibleSegments() as segment, index}
+			<li class="flex items-center gap-2">
+				<button
+					type="button"
+					onclick={() => handleSegmentClick(index)}
+					class="text-sm text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:underline transition-colors max-w-[200px] truncate"
+				>
+					{segment.entityName}
+				</button>
+				<ChevronRight class="w-4 h-4 text-slate-400 dark:text-slate-500 separator" />
+			</li>
+		{/each}
+
+		<!-- Current entity (non-clickable) -->
+		<li>
+			<span
+				class="text-sm font-semibold text-slate-900 dark:text-white max-w-[200px] truncate inline-block"
+				aria-current="page"
+			>
+				{currentEntity.name}
+			</span>
+		</li>
+	</ol>
+
+	<!-- Clear button (only shown when segments exist) -->
+	{#if segments.length > 0}
+		<button
+			type="button"
+			onclick={handleClear}
+			class="ml-auto p-1.5 hover:bg-red-50 dark:hover:bg-red-900/20 rounded text-red-600 dark:text-red-400 transition-colors"
+			aria-label="Clear breadcrumb trail"
+		>
+			<X class="w-4 h-4" />
+		</button>
+	{/if}
+</nav>

--- a/src/lib/components/navigation/RelationshipBreadcrumbs.test.ts
+++ b/src/lib/components/navigation/RelationshipBreadcrumbs.test.ts
@@ -1,0 +1,1013 @@
+/**
+ * Tests for RelationshipBreadcrumbs Component
+ *
+ * Issue #79: Relationship Navigation Breadcrumbs
+ *
+ * RED Phase (TDD): These tests define expected behavior before implementation.
+ * Tests should FAIL until RelationshipBreadcrumbs.svelte is properly implemented.
+ *
+ * This component displays a breadcrumb trail showing the navigation path through
+ * relationship chains. It allows users to see where they've been and navigate
+ * back through the hierarchy.
+ *
+ * Covers:
+ * - Rendering breadcrumb segments
+ * - Truncation and ellipsis for long paths
+ * - Navigation click handling
+ * - Clear button functionality
+ * - Current entity display
+ * - Responsive behavior
+ * - Accessibility
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import RelationshipBreadcrumbs from './RelationshipBreadcrumbs.svelte';
+import type { BreadcrumbSegment } from '$lib/utils/breadcrumbUtils';
+
+describe('RelationshipBreadcrumbs Component - Basic Rendering', () => {
+	it('should render single breadcrumb segment', () => {
+		const segments: BreadcrumbSegment[] = [
+			{
+				entityId: 'abc123',
+				relationship: 'allied_with',
+				entityName: 'Gandalf',
+				entityType: 'npc'
+			}
+		];
+
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		expect(screen.getByText('Gandalf')).toBeInTheDocument();
+	});
+
+	it('should render multiple breadcrumb segments', () => {
+		const segments: BreadcrumbSegment[] = [
+			{
+				entityId: 'abc123',
+				relationship: 'allied_with',
+				entityName: 'Gandalf',
+				entityType: 'npc'
+			},
+			{
+				entityId: 'def456',
+				relationship: 'resides_at',
+				entityName: 'Rivendell',
+				entityType: 'location'
+			}
+		];
+
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		expect(screen.getByText('Gandalf')).toBeInTheDocument();
+		expect(screen.getByText('Rivendell')).toBeInTheDocument();
+	});
+
+	it('should display current entity as final breadcrumb', () => {
+		const segments: BreadcrumbSegment[] = [
+			{
+				entityId: 'abc123',
+				relationship: 'knows',
+				entityName: 'Gandalf',
+				entityType: 'npc'
+			}
+		];
+
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		expect(screen.getByText('Frodo')).toBeInTheDocument();
+	});
+
+	it('should show current entity even with no breadcrumb segments', () => {
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments: [],
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		expect(screen.getByText('Frodo')).toBeInTheDocument();
+	});
+
+	it('should display relationship arrows between segments', () => {
+		const segments: BreadcrumbSegment[] = [
+			{
+				entityId: 'abc123',
+				relationship: 'knows',
+				entityName: 'Gandalf',
+				entityType: 'npc'
+			},
+			{
+				entityId: 'def456',
+				relationship: 'lives_at',
+				entityName: 'Rivendell',
+				entityType: 'location'
+			}
+		];
+
+		const { container } = render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		// Should have visual separators (arrows, chevrons, etc.)
+		// Look for ChevronRight icon or similar separator
+		const separators = container.querySelectorAll('[class*="separator"], svg');
+		expect(separators.length).toBeGreaterThan(0);
+	});
+
+	it('should render as a navigation element', () => {
+		const { container } = render(RelationshipBreadcrumbs, {
+			props: {
+				segments: [],
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		const nav = container.querySelector('nav');
+		expect(nav).toBeInTheDocument();
+	});
+
+	it('should have breadcrumb list with proper aria attributes', () => {
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments: [
+					{
+						entityId: 'abc123',
+						relationship: 'knows',
+						entityName: 'Gandalf',
+						entityType: 'npc'
+					}
+				],
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		const list = screen.getByRole('list');
+		expect(list).toBeInTheDocument();
+		expect(list).toHaveAttribute('aria-label', 'Breadcrumb');
+	});
+});
+
+describe('RelationshipBreadcrumbs Component - Truncation and Ellipsis', () => {
+	it('should display all segments when count is under maxVisible', () => {
+		const segments: BreadcrumbSegment[] = [
+			{ entityId: 'id1', relationship: 'rel1', entityName: 'Name1', entityType: 'type1' },
+			{ entityId: 'id2', relationship: 'rel2', entityName: 'Name2', entityType: 'type2' },
+			{ entityId: 'id3', relationship: 'rel3', entityName: 'Name3', entityType: 'type3' }
+		];
+
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Current', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn(),
+				maxVisible: 5
+			}
+		});
+
+		expect(screen.getByText('Name1')).toBeInTheDocument();
+		expect(screen.getByText('Name2')).toBeInTheDocument();
+		expect(screen.getByText('Name3')).toBeInTheDocument();
+	});
+
+	it('should show ellipsis when segments exceed maxVisible', () => {
+		const segments: BreadcrumbSegment[] = [
+			{ entityId: 'id1', relationship: 'rel1', entityName: 'Name1', entityType: 'type1' },
+			{ entityId: 'id2', relationship: 'rel2', entityName: 'Name2', entityType: 'type2' },
+			{ entityId: 'id3', relationship: 'rel3', entityName: 'Name3', entityType: 'type3' },
+			{ entityId: 'id4', relationship: 'rel4', entityName: 'Name4', entityType: 'type4' },
+			{ entityId: 'id5', relationship: 'rel5', entityName: 'Name5', entityType: 'type5' },
+			{ entityId: 'id6', relationship: 'rel6', entityName: 'Name6', entityType: 'type6' }
+		];
+
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Current', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn(),
+				maxVisible: 3
+			}
+		});
+
+		expect(screen.getByText('...')).toBeInTheDocument();
+	});
+
+	it('should show most recent segments when truncated', () => {
+		const segments: BreadcrumbSegment[] = [
+			{ entityId: 'id1', relationship: 'rel1', entityName: 'Name1', entityType: 'type1' },
+			{ entityId: 'id2', relationship: 'rel2', entityName: 'Name2', entityType: 'type2' },
+			{ entityId: 'id3', relationship: 'rel3', entityName: 'Name3', entityType: 'type3' },
+			{ entityId: 'id4', relationship: 'rel4', entityName: 'Name4', entityType: 'type4' },
+			{ entityId: 'id5', relationship: 'rel5', entityName: 'Name5', entityType: 'type5' }
+		];
+
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Current', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn(),
+				maxVisible: 2
+			}
+		});
+
+		// Should show Name4 and Name5 (most recent)
+		expect(screen.queryByText('Name1')).not.toBeInTheDocument();
+		expect(screen.queryByText('Name2')).not.toBeInTheDocument();
+		expect(screen.queryByText('Name3')).not.toBeInTheDocument();
+		expect(screen.getByText('Name4')).toBeInTheDocument();
+		expect(screen.getByText('Name5')).toBeInTheDocument();
+	});
+
+	it('should not show ellipsis when exactly at maxVisible', () => {
+		const segments: BreadcrumbSegment[] = [
+			{ entityId: 'id1', relationship: 'rel1', entityName: 'Name1', entityType: 'type1' },
+			{ entityId: 'id2', relationship: 'rel2', entityName: 'Name2', entityType: 'type2' },
+			{ entityId: 'id3', relationship: 'rel3', entityName: 'Name3', entityType: 'type3' }
+		];
+
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Current', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn(),
+				maxVisible: 3
+			}
+		});
+
+		expect(screen.queryByText('...')).not.toBeInTheDocument();
+	});
+
+	it('should use default maxVisible of 5 when not specified', () => {
+		const segments: BreadcrumbSegment[] = [
+			{ entityId: 'id1', relationship: 'rel1', entityName: 'Name1', entityType: 'type1' },
+			{ entityId: 'id2', relationship: 'rel2', entityName: 'Name2', entityType: 'type2' },
+			{ entityId: 'id3', relationship: 'rel3', entityName: 'Name3', entityType: 'type3' },
+			{ entityId: 'id4', relationship: 'rel4', entityName: 'Name4', entityType: 'type4' }
+		];
+
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Current', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+				// maxVisible not specified, should default to 5
+			}
+		});
+
+		// All 4 should be visible (under default of 5)
+		expect(screen.getByText('Name1')).toBeInTheDocument();
+		expect(screen.getByText('Name4')).toBeInTheDocument();
+		expect(screen.queryByText('...')).not.toBeInTheDocument();
+	});
+});
+
+describe('RelationshipBreadcrumbs Component - Navigation', () => {
+	it('should call onNavigate when breadcrumb segment is clicked', async () => {
+		const onNavigate = vi.fn();
+		const segments: BreadcrumbSegment[] = [
+			{
+				entityId: 'abc123',
+				relationship: 'knows',
+				entityName: 'Gandalf',
+				entityType: 'npc'
+			}
+		];
+
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate,
+				onClear: vi.fn()
+			}
+		});
+
+		const link = screen.getByText('Gandalf');
+		await fireEvent.click(link);
+
+		expect(onNavigate).toHaveBeenCalledTimes(1);
+	});
+
+	it('should pass correct segment index to onNavigate', async () => {
+		const onNavigate = vi.fn();
+		const segments: BreadcrumbSegment[] = [
+			{
+				entityId: 'id1',
+				relationship: 'rel1',
+				entityName: 'Name1',
+				entityType: 'type1'
+			},
+			{
+				entityId: 'id2',
+				relationship: 'rel2',
+				entityName: 'Name2',
+				entityType: 'type2'
+			}
+		];
+
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Current', type: 'character' },
+				onNavigate,
+				onClear: vi.fn()
+			}
+		});
+
+		const firstSegment = screen.getByText('Name1');
+		await fireEvent.click(firstSegment);
+
+		expect(onNavigate).toHaveBeenCalledWith(0);
+
+		const secondSegment = screen.getByText('Name2');
+		await fireEvent.click(secondSegment);
+
+		expect(onNavigate).toHaveBeenCalledWith(1);
+	});
+
+	it('should NOT call onNavigate when current entity is clicked', async () => {
+		const onNavigate = vi.fn();
+		const segments: BreadcrumbSegment[] = [
+			{
+				entityId: 'abc123',
+				relationship: 'knows',
+				entityName: 'Gandalf',
+				entityType: 'npc'
+			}
+		];
+
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate,
+				onClear: vi.fn()
+			}
+		});
+
+		const currentEntity = screen.getByText('Frodo');
+		await fireEvent.click(currentEntity);
+
+		expect(onNavigate).not.toHaveBeenCalled();
+	});
+
+	it('should render breadcrumb segments as clickable links', () => {
+		const segments: BreadcrumbSegment[] = [
+			{
+				entityId: 'abc123',
+				relationship: 'knows',
+				entityName: 'Gandalf',
+				entityType: 'npc'
+			}
+		];
+
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		const link = screen.getByText('Gandalf');
+		expect(link.tagName).toBe('BUTTON');
+		expect(link).toHaveAttribute('type', 'button');
+	});
+
+	it('should render current entity as non-clickable text', () => {
+		const segments: BreadcrumbSegment[] = [
+			{
+				entityId: 'abc123',
+				relationship: 'knows',
+				entityName: 'Gandalf',
+				entityType: 'npc'
+			}
+		];
+
+		const { container } = render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		const currentEntityElement = screen.getByText('Frodo');
+		expect(currentEntityElement.tagName).not.toBe('BUTTON');
+		expect(currentEntityElement.tagName).not.toBe('A');
+	});
+
+	it('should handle multiple clicks on same segment', async () => {
+		const onNavigate = vi.fn();
+		const segments: BreadcrumbSegment[] = [
+			{
+				entityId: 'abc123',
+				relationship: 'knows',
+				entityName: 'Gandalf',
+				entityType: 'npc'
+			}
+		];
+
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate,
+				onClear: vi.fn()
+			}
+		});
+
+		const link = screen.getByText('Gandalf');
+		await fireEvent.click(link);
+		await fireEvent.click(link);
+		await fireEvent.click(link);
+
+		expect(onNavigate).toHaveBeenCalledTimes(3);
+	});
+});
+
+describe('RelationshipBreadcrumbs Component - Clear Button', () => {
+	it('should render clear button when segments exist', () => {
+		const segments: BreadcrumbSegment[] = [
+			{
+				entityId: 'abc123',
+				relationship: 'knows',
+				entityName: 'Gandalf',
+				entityType: 'npc'
+			}
+		];
+
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		const clearButton = screen.getByRole('button', { name: /clear/i });
+		expect(clearButton).toBeInTheDocument();
+	});
+
+	it('should NOT render clear button when no segments exist', () => {
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments: [],
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		const clearButton = screen.queryByRole('button', { name: /clear/i });
+		expect(clearButton).not.toBeInTheDocument();
+	});
+
+	it('should call onClear when clear button is clicked', async () => {
+		const onClear = vi.fn();
+		const segments: BreadcrumbSegment[] = [
+			{
+				entityId: 'abc123',
+				relationship: 'knows',
+				entityName: 'Gandalf',
+				entityType: 'npc'
+			}
+		];
+
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear
+			}
+		});
+
+		const clearButton = screen.getByRole('button', { name: /clear/i });
+		await fireEvent.click(clearButton);
+
+		expect(onClear).toHaveBeenCalledTimes(1);
+	});
+
+	it('should have accessible label on clear button', () => {
+		const segments: BreadcrumbSegment[] = [
+			{
+				entityId: 'abc123',
+				relationship: 'knows',
+				entityName: 'Gandalf',
+				entityType: 'npc'
+			}
+		];
+
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		const clearButton = screen.getByRole('button', { name: /clear/i });
+		expect(clearButton).toHaveAccessibleName();
+	});
+
+	it('should have clear icon on clear button', () => {
+		const segments: BreadcrumbSegment[] = [
+			{
+				entityId: 'abc123',
+				relationship: 'knows',
+				entityName: 'Gandalf',
+				entityType: 'npc'
+			}
+		];
+
+		const { container } = render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		const clearButton = screen.getByRole('button', { name: /clear/i });
+		const icon = clearButton.querySelector('svg');
+		expect(icon).toBeInTheDocument();
+	});
+
+	it('should position clear button at end of breadcrumbs', () => {
+		const segments: BreadcrumbSegment[] = [
+			{
+				entityId: 'abc123',
+				relationship: 'knows',
+				entityName: 'Gandalf',
+				entityType: 'npc'
+			}
+		];
+
+		const { container } = render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		const clearButton = screen.getByRole('button', { name: /clear/i });
+		const nav = container.querySelector('nav');
+
+		// Clear button should be inside the nav element
+		expect(nav).toContainElement(clearButton);
+	});
+});
+
+describe('RelationshipBreadcrumbs Component - Responsive Behavior', () => {
+	it('should have responsive layout classes', () => {
+		const { container } = render(RelationshipBreadcrumbs, {
+			props: {
+				segments: [],
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		const nav = container.querySelector('nav');
+		// Should have responsive flex/wrap classes
+		expect(nav).toHaveClass(/flex|wrap/);
+	});
+
+	it('should handle very long entity names gracefully', () => {
+		const segments: BreadcrumbSegment[] = [
+			{
+				entityId: 'abc123',
+				relationship: 'knows',
+				entityName: 'A Very Long Entity Name That Goes On And On And On',
+				entityType: 'npc'
+			}
+		];
+
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		expect(screen.getByText(/A Very Long Entity Name/i)).toBeInTheDocument();
+	});
+
+	it('should apply truncation or ellipsis to long entity names', () => {
+		const segments: BreadcrumbSegment[] = [
+			{
+				entityId: 'abc123',
+				relationship: 'knows',
+				entityName: 'A Very Long Entity Name That Should Be Truncated',
+				entityType: 'npc'
+			}
+		];
+
+		const { container } = render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		const nameElement = screen.getByText(/A Very Long Entity Name/i);
+		// Should have truncate or max-width classes
+		expect(nameElement).toHaveClass(/truncate|max-w/);
+	});
+});
+
+describe('RelationshipBreadcrumbs Component - Styling', () => {
+	it('should have different styling for clickable vs current breadcrumb', () => {
+		const segments: BreadcrumbSegment[] = [
+			{
+				entityId: 'abc123',
+				relationship: 'knows',
+				entityName: 'Gandalf',
+				entityType: 'npc'
+			}
+		];
+
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		const clickableSegment = screen.getByText('Gandalf');
+		const currentSegment = screen.getByText('Frodo');
+
+		// Current should have different styling (e.g., bold, different color)
+		expect(currentSegment.className).not.toBe(clickableSegment.className);
+	});
+
+	it('should have hover state styling on clickable breadcrumbs', () => {
+		const segments: BreadcrumbSegment[] = [
+			{
+				entityId: 'abc123',
+				relationship: 'knows',
+				entityName: 'Gandalf',
+				entityType: 'npc'
+			}
+		];
+
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		const clickableSegment = screen.getByText('Gandalf');
+
+		// Should have hover classes
+		expect(clickableSegment).toHaveClass(/hover/);
+	});
+
+	it('should have appropriate spacing between breadcrumb items', () => {
+		const segments: BreadcrumbSegment[] = [
+			{
+				entityId: 'id1',
+				relationship: 'rel1',
+				entityName: 'Name1',
+				entityType: 'type1'
+			},
+			{
+				entityId: 'id2',
+				relationship: 'rel2',
+				entityName: 'Name2',
+				entityType: 'type2'
+			}
+		];
+
+		const { container } = render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Current', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		const list = screen.getByRole('list');
+		// Should have gap or space classes
+		expect(list).toHaveClass(/gap|space/);
+	});
+});
+
+describe('RelationshipBreadcrumbs Component - Accessibility', () => {
+	it('should have proper ARIA role for navigation', () => {
+		const { container } = render(RelationshipBreadcrumbs, {
+			props: {
+				segments: [],
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		const nav = container.querySelector('nav');
+		expect(nav).toHaveAttribute('aria-label', 'Breadcrumb navigation');
+	});
+
+	it('should have accessible labels for all interactive elements', () => {
+		const segments: BreadcrumbSegment[] = [
+			{
+				entityId: 'abc123',
+				relationship: 'knows',
+				entityName: 'Gandalf',
+				entityType: 'npc'
+			}
+		];
+
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		const buttons = screen.getAllByRole('button');
+		buttons.forEach((button) => {
+			expect(button).toHaveAccessibleName();
+		});
+	});
+
+	it('should support keyboard navigation', () => {
+		const segments: BreadcrumbSegment[] = [
+			{
+				entityId: 'abc123',
+				relationship: 'knows',
+				entityName: 'Gandalf',
+				entityType: 'npc'
+			}
+		];
+
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		const buttons = screen.getAllByRole('button');
+		buttons.forEach((button) => {
+			expect(button).toHaveAttribute('type', 'button');
+		});
+	});
+
+	it('should mark current page in breadcrumbs with aria-current', () => {
+		const segments: BreadcrumbSegment[] = [
+			{
+				entityId: 'abc123',
+				relationship: 'knows',
+				entityName: 'Gandalf',
+				entityType: 'npc'
+			}
+		];
+
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		const currentElement = screen.getByText('Frodo');
+		expect(currentElement).toHaveAttribute('aria-current', 'page');
+	});
+
+	it('should have list items for each breadcrumb segment', () => {
+		const segments: BreadcrumbSegment[] = [
+			{ entityId: 'id1', relationship: 'rel1', entityName: 'Name1', entityType: 'type1' },
+			{ entityId: 'id2', relationship: 'rel2', entityName: 'Name2', entityType: 'type2' }
+		];
+
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Current', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		const listItems = screen.getAllByRole('listitem');
+		// Should have at least 2 segments + current entity = 3 list items
+		expect(listItems.length).toBeGreaterThanOrEqual(3);
+	});
+});
+
+describe('RelationshipBreadcrumbs Component - Edge Cases', () => {
+	it('should handle empty segments array', () => {
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments: [],
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		expect(screen.getByText('Frodo')).toBeInTheDocument();
+	});
+
+	it('should handle segments with empty entity names', () => {
+		const segments: BreadcrumbSegment[] = [
+			{
+				entityId: 'abc123',
+				relationship: 'knows',
+				entityName: '',
+				entityType: 'npc'
+			}
+		];
+
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		// Should render without crashing
+		expect(screen.getByText('Frodo')).toBeInTheDocument();
+	});
+
+	it('should handle current entity with special characters in name', () => {
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments: [],
+				currentEntity: { id: 'current', name: "Frodo O'Brien (the Great)", type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		expect(screen.getByText("Frodo O'Brien (the Great)")).toBeInTheDocument();
+	});
+
+	it('should handle maxVisible of 0', () => {
+		const segments: BreadcrumbSegment[] = [
+			{ entityId: 'id1', relationship: 'rel1', entityName: 'Name1', entityType: 'type1' }
+		];
+
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Current', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn(),
+				maxVisible: 0
+			}
+		});
+
+		// Should show ellipsis and current entity at minimum
+		expect(screen.getByText('Current')).toBeInTheDocument();
+	});
+
+	it('should handle very large maxVisible value', () => {
+		const segments: BreadcrumbSegment[] = [
+			{ entityId: 'id1', relationship: 'rel1', entityName: 'Name1', entityType: 'type1' },
+			{ entityId: 'id2', relationship: 'rel2', entityName: 'Name2', entityType: 'type2' }
+		];
+
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Current', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn(),
+				maxVisible: 1000
+			}
+		});
+
+		expect(screen.getByText('Name1')).toBeInTheDocument();
+		expect(screen.getByText('Name2')).toBeInTheDocument();
+	});
+
+	it('should handle rapid clicks on different segments', async () => {
+		const onNavigate = vi.fn();
+		const segments: BreadcrumbSegment[] = [
+			{ entityId: 'id1', relationship: 'rel1', entityName: 'Name1', entityType: 'type1' },
+			{ entityId: 'id2', relationship: 'rel2', entityName: 'Name2', entityType: 'type2' }
+		];
+
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Current', type: 'character' },
+				onNavigate,
+				onClear: vi.fn()
+			}
+		});
+
+		const first = screen.getByText('Name1');
+		const second = screen.getByText('Name2');
+
+		await fireEvent.click(first);
+		await fireEvent.click(second);
+		await fireEvent.click(first);
+
+		expect(onNavigate).toHaveBeenCalledTimes(3);
+	});
+});
+
+describe('RelationshipBreadcrumbs Component - Props Validation', () => {
+	it('should render with all required props', () => {
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments: [],
+				currentEntity: { id: 'current', name: 'Frodo', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+			}
+		});
+
+		expect(screen.getByText('Frodo')).toBeInTheDocument();
+	});
+
+	it('should use default maxVisible when not provided', () => {
+		const segments: BreadcrumbSegment[] = [
+			{ entityId: 'id1', relationship: 'rel1', entityName: 'Name1', entityType: 'type1' },
+			{ entityId: 'id2', relationship: 'rel2', entityName: 'Name2', entityType: 'type2' },
+			{ entityId: 'id3', relationship: 'rel3', entityName: 'Name3', entityType: 'type3' }
+		];
+
+		render(RelationshipBreadcrumbs, {
+			props: {
+				segments,
+				currentEntity: { id: 'current', name: 'Current', type: 'character' },
+				onNavigate: vi.fn(),
+				onClear: vi.fn()
+				// maxVisible not provided
+			}
+		});
+
+		// All 3 should be visible with default maxVisible of 5
+		expect(screen.getByText('Name1')).toBeInTheDocument();
+		expect(screen.getByText('Name2')).toBeInTheDocument();
+		expect(screen.getByText('Name3')).toBeInTheDocument();
+	});
+});

--- a/src/lib/components/navigation/index.ts
+++ b/src/lib/components/navigation/index.ts
@@ -1,0 +1,1 @@
+export { default as RelationshipBreadcrumbs } from './RelationshipBreadcrumbs.svelte';

--- a/src/lib/utils/breadcrumbUtils.test.ts
+++ b/src/lib/utils/breadcrumbUtils.test.ts
@@ -1,0 +1,946 @@
+/**
+ * Tests for Breadcrumb Utility Functions
+ *
+ * Issue #79: Relationship Navigation Breadcrumbs
+ *
+ * RED Phase (TDD): These tests define expected behavior before implementation.
+ * Tests should FAIL until breadcrumbUtils.ts is properly implemented.
+ *
+ * These utilities manage the navigation breadcrumb trail when users navigate
+ * through relationship chains, allowing them to see where they've been and
+ * navigate back through the relationship hierarchy.
+ *
+ * Covers:
+ * - Parsing breadcrumb path from URL parameters
+ * - Serializing breadcrumb segments to URL format
+ * - Truncating breadcrumb paths to max length
+ * - Building navigation URLs with breadcrumb paths
+ * - URL encoding/decoding of special characters
+ * - Edge cases (null, empty arrays, max length boundaries)
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+	parseBreadcrumbPath,
+	serializeBreadcrumbPath,
+	truncatePath,
+	buildNavigationUrl,
+	type BreadcrumbSegment
+} from './breadcrumbUtils';
+
+describe('breadcrumbUtils - parseBreadcrumbPath', () => {
+	describe('Valid path parsing', () => {
+		it('should parse valid single segment path', () => {
+			const result = parseBreadcrumbPath('abc123:allied_with:Gandalf:npc');
+
+			expect(result).toEqual([
+				{
+					entityId: 'abc123',
+					relationship: 'allied_with',
+					entityName: 'Gandalf',
+					entityType: 'npc'
+				}
+			]);
+		});
+
+		it('should parse valid multi-segment path', () => {
+			const result = parseBreadcrumbPath(
+				'abc123:allied_with:Gandalf:npc,def456:resides_at:Rivendell:location'
+			);
+
+			expect(result).toEqual([
+				{
+					entityId: 'abc123',
+					relationship: 'allied_with',
+					entityName: 'Gandalf',
+					entityType: 'npc'
+				},
+				{
+					entityId: 'def456',
+					relationship: 'resides_at',
+					entityName: 'Rivendell',
+					entityType: 'location'
+				}
+			]);
+		});
+
+		it('should parse path with URL-encoded characters in relationship name', () => {
+			const result = parseBreadcrumbPath('abc123:friend%20of:Sam%20Gamgee:npc');
+
+			expect(result).toEqual([
+				{
+					entityId: 'abc123',
+					relationship: 'friend of',
+					entityName: 'Sam Gamgee',
+					entityType: 'npc'
+				}
+			]);
+		});
+
+		it('should parse path with URL-encoded characters in entity name', () => {
+			const result = parseBreadcrumbPath('xyz789:member_of:The%20Fellowship:faction');
+
+			expect(result).toEqual([
+				{
+					entityId: 'xyz789',
+					relationship: 'member_of',
+					entityName: 'The Fellowship',
+					entityType: 'faction'
+				}
+			]);
+		});
+
+		it('should parse path with special characters in relationship', () => {
+			const result = parseBreadcrumbPath('abc123:son%2Fdaughter_of:Elrond:npc');
+
+			expect(result).toEqual([
+				{
+					entityId: 'abc123',
+					relationship: 'son/daughter_of',
+					entityName: 'Elrond',
+					entityType: 'npc'
+				}
+			]);
+		});
+
+		it('should parse path with multiple URL-encoded segments', () => {
+			const result = parseBreadcrumbPath(
+				'id1:rel%201:Name%201:type1,id2:rel%202:Name%202:type2'
+			);
+
+			expect(result).toEqual([
+				{
+					entityId: 'id1',
+					relationship: 'rel 1',
+					entityName: 'Name 1',
+					entityType: 'type1'
+				},
+				{
+					entityId: 'id2',
+					relationship: 'rel 2',
+					entityName: 'Name 2',
+					entityType: 'type2'
+				}
+			]);
+		});
+
+		it('should parse path with numeric entity ID', () => {
+			const result = parseBreadcrumbPath('12345:knows:Alice:character');
+
+			expect(result).toEqual([
+				{
+					entityId: '12345',
+					relationship: 'knows',
+					entityName: 'Alice',
+					entityType: 'character'
+				}
+			]);
+		});
+
+		it('should parse path with UUID entity ID', () => {
+			const result = parseBreadcrumbPath(
+				'550e8400-e29b-41d4-a716-446655440000:allied_with:Bob:npc'
+			);
+
+			expect(result).toEqual([
+				{
+					entityId: '550e8400-e29b-41d4-a716-446655440000',
+					relationship: 'allied_with',
+					entityName: 'Bob',
+					entityType: 'npc'
+				}
+			]);
+		});
+
+		it('should preserve order of segments', () => {
+			const result = parseBreadcrumbPath('id1:rel1:Name1:type1,id2:rel2:Name2:type2,id3:rel3:Name3:type3');
+
+			expect(result).toHaveLength(3);
+			expect(result[0].entityId).toBe('id1');
+			expect(result[1].entityId).toBe('id2');
+			expect(result[2].entityId).toBe('id3');
+		});
+
+		it('should handle entity names with apostrophes', () => {
+			const result = parseBreadcrumbPath('abc123:knows:O%27Brien:npc');
+
+			expect(result).toEqual([
+				{
+					entityId: 'abc123',
+					relationship: 'knows',
+					entityName: "O'Brien",
+					entityType: 'npc'
+				}
+			]);
+		});
+
+		it('should handle entity names with parentheses', () => {
+			const result = parseBreadcrumbPath('abc123:knows:Bob%20%28the%20Great%29:npc');
+
+			expect(result).toEqual([
+				{
+					entityId: 'abc123',
+					relationship: 'knows',
+					entityName: 'Bob (the Great)',
+					entityType: 'npc'
+				}
+			]);
+		});
+	});
+
+	describe('Empty and null handling', () => {
+		it('should return empty array for null input', () => {
+			const result = parseBreadcrumbPath(null);
+
+			expect(result).toEqual([]);
+		});
+
+		it('should return empty array for undefined input', () => {
+			const result = parseBreadcrumbPath(undefined as any);
+
+			expect(result).toEqual([]);
+		});
+
+		it('should return empty array for empty string', () => {
+			const result = parseBreadcrumbPath('');
+
+			expect(result).toEqual([]);
+		});
+
+		it('should return empty array for whitespace-only string', () => {
+			const result = parseBreadcrumbPath('   ');
+
+			expect(result).toEqual([]);
+		});
+	});
+
+	describe('Malformed input handling', () => {
+		it('should handle segment with missing relationship', () => {
+			// Malformed: only entityId and entityName
+			const result = parseBreadcrumbPath('abc123::Gandalf:npc');
+
+			expect(result).toEqual([
+				{
+					entityId: 'abc123',
+					relationship: '',
+					entityName: 'Gandalf',
+					entityType: 'npc'
+				}
+			]);
+		});
+
+		it('should handle segment with missing entity name', () => {
+			const result = parseBreadcrumbPath('abc123:allied_with::npc');
+
+			expect(result).toEqual([
+				{
+					entityId: 'abc123',
+					relationship: 'allied_with',
+					entityName: '',
+					entityType: 'npc'
+				}
+			]);
+		});
+
+		it('should handle segment with missing entity type', () => {
+			const result = parseBreadcrumbPath('abc123:allied_with:Gandalf:');
+
+			expect(result).toEqual([
+				{
+					entityId: 'abc123',
+					relationship: 'allied_with',
+					entityName: 'Gandalf',
+					entityType: ''
+				}
+			]);
+		});
+
+		it('should handle segment with too few parts', () => {
+			const result = parseBreadcrumbPath('abc123:allied_with');
+
+			// Implementation decision: skip malformed segments or return partial data
+			// This test documents the expected behavior
+			expect(result).toEqual([]);
+		});
+
+		it('should handle segment with too many parts', () => {
+			const result = parseBreadcrumbPath('abc123:allied_with:Gandalf:npc:extra:parts');
+
+			// Should only use first 4 parts
+			expect(result).toEqual([
+				{
+					entityId: 'abc123',
+					relationship: 'allied_with',
+					entityName: 'Gandalf',
+					entityType: 'npc'
+				}
+			]);
+		});
+
+		it('should handle mixed valid and invalid segments', () => {
+			const result = parseBreadcrumbPath('abc123:knows:Alice:npc,invalid,def456:likes:Bob:character');
+
+			// Should skip invalid segment
+			expect(result).toEqual([
+				{
+					entityId: 'abc123',
+					relationship: 'knows',
+					entityName: 'Alice',
+					entityType: 'npc'
+				},
+				{
+					entityId: 'def456',
+					relationship: 'likes',
+					entityName: 'Bob',
+					entityType: 'character'
+				}
+			]);
+		});
+
+		it('should handle trailing comma', () => {
+			const result = parseBreadcrumbPath('abc123:knows:Alice:npc,');
+
+			expect(result).toEqual([
+				{
+					entityId: 'abc123',
+					relationship: 'knows',
+					entityName: 'Alice',
+					entityType: 'npc'
+				}
+			]);
+		});
+
+		it('should handle leading comma', () => {
+			const result = parseBreadcrumbPath(',abc123:knows:Alice:npc');
+
+			expect(result).toEqual([
+				{
+					entityId: 'abc123',
+					relationship: 'knows',
+					entityName: 'Alice',
+					entityType: 'npc'
+				}
+			]);
+		});
+
+		it('should handle multiple consecutive commas', () => {
+			const result = parseBreadcrumbPath('abc123:knows:Alice:npc,,def456:likes:Bob:character');
+
+			expect(result).toEqual([
+				{
+					entityId: 'abc123',
+					relationship: 'knows',
+					entityName: 'Alice',
+					entityType: 'npc'
+				},
+				{
+					entityId: 'def456',
+					relationship: 'likes',
+					entityName: 'Bob',
+					entityType: 'character'
+				}
+			]);
+		});
+	});
+});
+
+describe('breadcrumbUtils - serializeBreadcrumbPath', () => {
+	describe('Valid serialization', () => {
+		it('should serialize single segment to URL format', () => {
+			const segments: BreadcrumbSegment[] = [
+				{
+					entityId: 'abc123',
+					relationship: 'allied_with',
+					entityName: 'Gandalf',
+					entityType: 'npc'
+				}
+			];
+
+			const result = serializeBreadcrumbPath(segments);
+
+			expect(result).toBe('abc123:allied_with:Gandalf:npc');
+		});
+
+		it('should serialize multiple segments to URL format', () => {
+			const segments: BreadcrumbSegment[] = [
+				{
+					entityId: 'abc123',
+					relationship: 'allied_with',
+					entityName: 'Gandalf',
+					entityType: 'npc'
+				},
+				{
+					entityId: 'def456',
+					relationship: 'resides_at',
+					entityName: 'Rivendell',
+					entityType: 'location'
+				}
+			];
+
+			const result = serializeBreadcrumbPath(segments);
+
+			expect(result).toBe('abc123:allied_with:Gandalf:npc,def456:resides_at:Rivendell:location');
+		});
+
+		it('should URL-encode spaces in relationship names', () => {
+			const segments: BreadcrumbSegment[] = [
+				{
+					entityId: 'abc123',
+					relationship: 'friend of',
+					entityName: 'Sam',
+					entityType: 'npc'
+				}
+			];
+
+			const result = serializeBreadcrumbPath(segments);
+
+			expect(result).toBe('abc123:friend%20of:Sam:npc');
+		});
+
+		it('should URL-encode spaces in entity names', () => {
+			const segments: BreadcrumbSegment[] = [
+				{
+					entityId: 'abc123',
+					relationship: 'member_of',
+					entityName: 'The Fellowship',
+					entityType: 'faction'
+				}
+			];
+
+			const result = serializeBreadcrumbPath(segments);
+
+			expect(result).toBe('abc123:member_of:The%20Fellowship:faction');
+		});
+
+		it('should URL-encode special characters', () => {
+			const segments: BreadcrumbSegment[] = [
+				{
+					entityId: 'abc123',
+					relationship: 'son/daughter_of',
+					entityName: "O'Brien",
+					entityType: 'npc'
+				}
+			];
+
+			const result = serializeBreadcrumbPath(segments);
+
+			expect(result).toBe('abc123:son%2Fdaughter_of:O%27Brien:npc');
+		});
+
+		it('should serialize segments with UUID IDs', () => {
+			const segments: BreadcrumbSegment[] = [
+				{
+					entityId: '550e8400-e29b-41d4-a716-446655440000',
+					relationship: 'knows',
+					entityName: 'Alice',
+					entityType: 'character'
+				}
+			];
+
+			const result = serializeBreadcrumbPath(segments);
+
+			expect(result).toBe('550e8400-e29b-41d4-a716-446655440000:knows:Alice:character');
+		});
+
+		it('should preserve segment order', () => {
+			const segments: BreadcrumbSegment[] = [
+				{ entityId: 'id1', relationship: 'rel1', entityName: 'Name1', entityType: 'type1' },
+				{ entityId: 'id2', relationship: 'rel2', entityName: 'Name2', entityType: 'type2' },
+				{ entityId: 'id3', relationship: 'rel3', entityName: 'Name3', entityType: 'type3' }
+			];
+
+			const result = serializeBreadcrumbPath(segments);
+
+			expect(result).toBe('id1:rel1:Name1:type1,id2:rel2:Name2:type2,id3:rel3:Name3:type3');
+		});
+
+		it('should handle parentheses in entity names', () => {
+			const segments: BreadcrumbSegment[] = [
+				{
+					entityId: 'abc123',
+					relationship: 'knows',
+					entityName: 'Bob (the Great)',
+					entityType: 'npc'
+				}
+			];
+
+			const result = serializeBreadcrumbPath(segments);
+
+			expect(result).toBe('abc123:knows:Bob%20%28the%20Great%29:npc');
+		});
+	});
+
+	describe('Empty array handling', () => {
+		it('should return empty string for empty array', () => {
+			const result = serializeBreadcrumbPath([]);
+
+			expect(result).toBe('');
+		});
+
+		it('should handle array with empty string values', () => {
+			const segments: BreadcrumbSegment[] = [
+				{
+					entityId: '',
+					relationship: '',
+					entityName: '',
+					entityType: ''
+				}
+			];
+
+			const result = serializeBreadcrumbPath(segments);
+
+			expect(result).toBe(':::');
+		});
+	});
+
+	describe('Round-trip consistency', () => {
+		it('should be reversible with parseBreadcrumbPath for single segment', () => {
+			const original: BreadcrumbSegment[] = [
+				{
+					entityId: 'abc123',
+					relationship: 'allied_with',
+					entityName: 'Gandalf',
+					entityType: 'npc'
+				}
+			];
+
+			const serialized = serializeBreadcrumbPath(original);
+			const parsed = parseBreadcrumbPath(serialized);
+
+			expect(parsed).toEqual(original);
+		});
+
+		it('should be reversible with parseBreadcrumbPath for multiple segments', () => {
+			const original: BreadcrumbSegment[] = [
+				{
+					entityId: 'abc123',
+					relationship: 'friend of',
+					entityName: 'Sam Gamgee',
+					entityType: 'npc'
+				},
+				{
+					entityId: 'def456',
+					relationship: 'resides_at',
+					entityName: 'The Shire',
+					entityType: 'location'
+				}
+			];
+
+			const serialized = serializeBreadcrumbPath(original);
+			const parsed = parseBreadcrumbPath(serialized);
+
+			expect(parsed).toEqual(original);
+		});
+
+		it('should be reversible with special characters', () => {
+			const original: BreadcrumbSegment[] = [
+				{
+					entityId: 'xyz789',
+					relationship: 'son/daughter_of',
+					entityName: "O'Brien (the Elder)",
+					entityType: 'npc'
+				}
+			];
+
+			const serialized = serializeBreadcrumbPath(original);
+			const parsed = parseBreadcrumbPath(serialized);
+
+			expect(parsed).toEqual(original);
+		});
+	});
+});
+
+describe('breadcrumbUtils - truncatePath', () => {
+	describe('Basic truncation', () => {
+		it('should keep all segments when count is under max', () => {
+			const segments: BreadcrumbSegment[] = [
+				{ entityId: 'id1', relationship: 'rel1', entityName: 'Name1', entityType: 'type1' },
+				{ entityId: 'id2', relationship: 'rel2', entityName: 'Name2', entityType: 'type2' }
+			];
+
+			const result = truncatePath(segments, 5);
+
+			expect(result).toEqual(segments);
+			expect(result).toHaveLength(2);
+		});
+
+		it('should keep all segments when count equals max', () => {
+			const segments: BreadcrumbSegment[] = [
+				{ entityId: 'id1', relationship: 'rel1', entityName: 'Name1', entityType: 'type1' },
+				{ entityId: 'id2', relationship: 'rel2', entityName: 'Name2', entityType: 'type2' },
+				{ entityId: 'id3', relationship: 'rel3', entityName: 'Name3', entityType: 'type3' }
+			];
+
+			const result = truncatePath(segments, 3);
+
+			expect(result).toEqual(segments);
+			expect(result).toHaveLength(3);
+		});
+
+		it('should truncate from start when count exceeds max', () => {
+			const segments: BreadcrumbSegment[] = [
+				{ entityId: 'id1', relationship: 'rel1', entityName: 'Name1', entityType: 'type1' },
+				{ entityId: 'id2', relationship: 'rel2', entityName: 'Name2', entityType: 'type2' },
+				{ entityId: 'id3', relationship: 'rel3', entityName: 'Name3', entityType: 'type3' },
+				{ entityId: 'id4', relationship: 'rel4', entityName: 'Name4', entityType: 'type4' },
+				{ entityId: 'id5', relationship: 'rel5', entityName: 'Name5', entityType: 'type5' }
+			];
+
+			const result = truncatePath(segments, 3);
+
+			// Should keep the MOST RECENT segments (last 3)
+			expect(result).toEqual([
+				{ entityId: 'id3', relationship: 'rel3', entityName: 'Name3', entityType: 'type3' },
+				{ entityId: 'id4', relationship: 'rel4', entityName: 'Name4', entityType: 'type4' },
+				{ entityId: 'id5', relationship: 'rel5', entityName: 'Name5', entityType: 'type5' }
+			]);
+			expect(result).toHaveLength(3);
+		});
+
+		it('should keep most recent segment when max is 1', () => {
+			const segments: BreadcrumbSegment[] = [
+				{ entityId: 'id1', relationship: 'rel1', entityName: 'Name1', entityType: 'type1' },
+				{ entityId: 'id2', relationship: 'rel2', entityName: 'Name2', entityType: 'type2' },
+				{ entityId: 'id3', relationship: 'rel3', entityName: 'Name3', entityType: 'type3' }
+			];
+
+			const result = truncatePath(segments, 1);
+
+			expect(result).toEqual([
+				{ entityId: 'id3', relationship: 'rel3', entityName: 'Name3', entityType: 'type3' }
+			]);
+			expect(result).toHaveLength(1);
+		});
+
+		it('should truncate to exact max length', () => {
+			const segments: BreadcrumbSegment[] = [
+				{ entityId: 'id1', relationship: 'rel1', entityName: 'Name1', entityType: 'type1' },
+				{ entityId: 'id2', relationship: 'rel2', entityName: 'Name2', entityType: 'type2' },
+				{ entityId: 'id3', relationship: 'rel3', entityName: 'Name3', entityType: 'type3' },
+				{ entityId: 'id4', relationship: 'rel4', entityName: 'Name4', entityType: 'type4' },
+				{ entityId: 'id5', relationship: 'rel5', entityName: 'Name5', entityType: 'type5' },
+				{ entityId: 'id6', relationship: 'rel6', entityName: 'Name6', entityType: 'type6' },
+				{ entityId: 'id7', relationship: 'rel7', entityName: 'Name7', entityType: 'type7' }
+			];
+
+			const result = truncatePath(segments, 6);
+
+			expect(result).toHaveLength(6);
+			expect(result[0].entityId).toBe('id2'); // First kept segment
+			expect(result[5].entityId).toBe('id7'); // Last segment
+		});
+	});
+
+	describe('Edge cases', () => {
+		it('should return empty array for empty input', () => {
+			const result = truncatePath([], 5);
+
+			expect(result).toEqual([]);
+		});
+
+		it('should handle max length of 0', () => {
+			const segments: BreadcrumbSegment[] = [
+				{ entityId: 'id1', relationship: 'rel1', entityName: 'Name1', entityType: 'type1' }
+			];
+
+			const result = truncatePath(segments, 0);
+
+			expect(result).toEqual([]);
+		});
+
+		it('should handle negative max length as 0', () => {
+			const segments: BreadcrumbSegment[] = [
+				{ entityId: 'id1', relationship: 'rel1', entityName: 'Name1', entityType: 'type1' }
+			];
+
+			const result = truncatePath(segments, -5);
+
+			expect(result).toEqual([]);
+		});
+
+		it('should handle very large max length', () => {
+			const segments: BreadcrumbSegment[] = [
+				{ entityId: 'id1', relationship: 'rel1', entityName: 'Name1', entityType: 'type1' }
+			];
+
+			const result = truncatePath(segments, 1000);
+
+			expect(result).toEqual(segments);
+		});
+
+		it('should not mutate original array', () => {
+			const segments: BreadcrumbSegment[] = [
+				{ entityId: 'id1', relationship: 'rel1', entityName: 'Name1', entityType: 'type1' },
+				{ entityId: 'id2', relationship: 'rel2', entityName: 'Name2', entityType: 'type2' },
+				{ entityId: 'id3', relationship: 'rel3', entityName: 'Name3', entityType: 'type3' }
+			];
+			const originalLength = segments.length;
+
+			const result = truncatePath(segments, 1);
+
+			expect(segments).toHaveLength(originalLength); // Original unchanged
+			expect(result).toHaveLength(1); // Result is truncated
+		});
+	});
+});
+
+describe('breadcrumbUtils - buildNavigationUrl', () => {
+	describe('Basic URL building', () => {
+		it('should build URL with empty current path', () => {
+			const result = buildNavigationUrl(
+				'npc',
+				'abc123',
+				[],
+				'allied_with',
+				{ id: 'current-id', name: 'Frodo', type: 'character' }
+			);
+
+			expect(result).toBe('/entities/npc/abc123?navPath=current-id:allied_with:Frodo:character');
+		});
+
+		it('should build URL appending to existing path', () => {
+			const currentSegments: BreadcrumbSegment[] = [
+				{
+					entityId: 'entity1',
+					relationship: 'knows',
+					entityName: 'Gandalf',
+					entityType: 'npc'
+				}
+			];
+
+			const result = buildNavigationUrl(
+				'location',
+				'loc123',
+				currentSegments,
+				'resides_at',
+				{ id: 'entity2', name: 'Frodo', type: 'character' }
+			);
+
+			expect(result).toBe(
+				'/entities/location/loc123?navPath=entity1:knows:Gandalf:npc,entity2:resides_at:Frodo:character'
+			);
+		});
+
+		it('should URL-encode special characters in relationship', () => {
+			const result = buildNavigationUrl(
+				'npc',
+				'abc123',
+				[],
+				'friend of',
+				{ id: 'current-id', name: 'Sam', type: 'npc' }
+			);
+
+			expect(result).toContain('friend%20of');
+		});
+
+		it('should URL-encode special characters in entity name', () => {
+			const result = buildNavigationUrl(
+				'faction',
+				'fac123',
+				[],
+				'member_of',
+				{ id: 'current-id', name: 'The Fellowship', type: 'character' }
+			);
+
+			expect(result).toContain('The%20Fellowship');
+		});
+
+		it('should build correct URL path format', () => {
+			const result = buildNavigationUrl(
+				'npc',
+				'target-id',
+				[],
+				'knows',
+				{ id: 'source-id', name: 'Alice', type: 'character' }
+			);
+
+			expect(result).toMatch(/^\/entities\/npc\/target-id\?navPath=/);
+		});
+
+		it('should handle multiple existing segments', () => {
+			const currentSegments: BreadcrumbSegment[] = [
+				{ entityId: 'id1', relationship: 'rel1', entityName: 'Name1', entityType: 'type1' },
+				{ entityId: 'id2', relationship: 'rel2', entityName: 'Name2', entityType: 'type2' }
+			];
+
+			const result = buildNavigationUrl(
+				'npc',
+				'target-id',
+				currentSegments,
+				'rel3',
+				{ id: 'id3', name: 'Name3', type: 'type3' }
+			);
+
+			expect(result).toContain('id1:rel1:Name1:type1,id2:rel2:Name2:type2,id3:rel3:Name3:type3');
+		});
+	});
+
+	describe('Automatic truncation', () => {
+		it('should truncate when adding would exceed max of 6', () => {
+			const currentSegments: BreadcrumbSegment[] = [
+				{ entityId: 'id1', relationship: 'rel1', entityName: 'Name1', entityType: 'type1' },
+				{ entityId: 'id2', relationship: 'rel2', entityName: 'Name2', entityType: 'type2' },
+				{ entityId: 'id3', relationship: 'rel3', entityName: 'Name3', entityType: 'type3' },
+				{ entityId: 'id4', relationship: 'rel4', entityName: 'Name4', entityType: 'type4' },
+				{ entityId: 'id5', relationship: 'rel5', entityName: 'Name5', entityType: 'type5' },
+				{ entityId: 'id6', relationship: 'rel6', entityName: 'Name6', entityType: 'type6' }
+			];
+
+			const result = buildNavigationUrl(
+				'npc',
+				'target-id',
+				currentSegments,
+				'rel7',
+				{ id: 'id7', name: 'Name7', type: 'type7' }
+			);
+
+			// Should truncate to keep 6 most recent (id2 through id7)
+			expect(result).not.toContain('id1');
+			expect(result).toContain('id2');
+			expect(result).toContain('id7');
+
+			// Count segments in URL
+			const pathParam = result.split('navPath=')[1];
+			const segments = pathParam.split(',');
+			expect(segments).toHaveLength(6);
+		});
+
+		it('should keep exactly 6 segments when at capacity', () => {
+			const currentSegments: BreadcrumbSegment[] = [
+				{ entityId: 'id1', relationship: 'rel1', entityName: 'Name1', entityType: 'type1' },
+				{ entityId: 'id2', relationship: 'rel2', entityName: 'Name2', entityType: 'type2' },
+				{ entityId: 'id3', relationship: 'rel3', entityName: 'Name3', entityType: 'type3' },
+				{ entityId: 'id4', relationship: 'rel4', entityName: 'Name4', entityType: 'type4' },
+				{ entityId: 'id5', relationship: 'rel5', entityName: 'Name5', entityType: 'type5' }
+			];
+
+			const result = buildNavigationUrl(
+				'npc',
+				'target-id',
+				currentSegments,
+				'rel6',
+				{ id: 'id6', name: 'Name6', type: 'type6' }
+			);
+
+			const pathParam = result.split('navPath=')[1];
+			const segments = pathParam.split(',');
+			expect(segments).toHaveLength(6);
+		});
+
+		it('should not truncate when under capacity', () => {
+			const currentSegments: BreadcrumbSegment[] = [
+				{ entityId: 'id1', relationship: 'rel1', entityName: 'Name1', entityType: 'type1' },
+				{ entityId: 'id2', relationship: 'rel2', entityName: 'Name2', entityType: 'type2' }
+			];
+
+			const result = buildNavigationUrl(
+				'npc',
+				'target-id',
+				currentSegments,
+				'rel3',
+				{ id: 'id3', name: 'Name3', type: 'type3' }
+			);
+
+			const pathParam = result.split('navPath=')[1];
+			const segments = pathParam.split(',');
+			expect(segments).toHaveLength(3);
+			expect(result).toContain('id1'); // Should keep all segments
+		});
+	});
+
+	describe('Entity type handling', () => {
+		it('should handle different entity types in URL path', () => {
+			const types = ['npc', 'location', 'faction', 'item', 'quest', 'character'];
+
+			types.forEach((type) => {
+				const result = buildNavigationUrl(
+					type,
+					'target-id',
+					[],
+					'rel',
+					{ id: 'source-id', name: 'Source', type: 'character' }
+				);
+
+				expect(result).toContain(`/entities/${type}/target-id`);
+			});
+		});
+	});
+
+	describe('Special character handling', () => {
+		it('should handle entity name with parentheses', () => {
+			const result = buildNavigationUrl(
+				'npc',
+				'target-id',
+				[],
+				'knows',
+				{ id: 'source-id', name: 'Bob (the Great)', type: 'npc' }
+			);
+
+			expect(result).toContain('Bob%20%28the%20Great%29');
+		});
+
+		it('should handle entity name with apostrophes', () => {
+			const result = buildNavigationUrl(
+				'npc',
+				'target-id',
+				[],
+				'knows',
+				{ id: 'source-id', name: "O'Brien", type: 'npc' }
+			);
+
+			expect(result).toContain('O%27Brien');
+		});
+
+		it('should handle relationship with slashes', () => {
+			const result = buildNavigationUrl(
+				'npc',
+				'target-id',
+				[],
+				'son/daughter_of',
+				{ id: 'source-id', name: 'Alice', type: 'character' }
+			);
+
+			expect(result).toContain('son%2Fdaughter_of');
+		});
+	});
+
+	describe('Edge cases', () => {
+		it('should handle empty entity name', () => {
+			const result = buildNavigationUrl(
+				'npc',
+				'target-id',
+				[],
+				'knows',
+				{ id: 'source-id', name: '', type: 'character' }
+			);
+
+			expect(result).toMatch(/navPath=source-id:knows::character$/);
+		});
+
+		it('should handle UUID entity IDs', () => {
+			const result = buildNavigationUrl(
+				'npc',
+				'550e8400-e29b-41d4-a716-446655440000',
+				[],
+				'knows',
+				{ id: 'abc-123-def-456', name: 'Alice', type: 'character' }
+			);
+
+			expect(result).toContain('550e8400-e29b-41d4-a716-446655440000');
+			expect(result).toContain('abc-123-def-456');
+		});
+
+		it('should handle numeric IDs', () => {
+			const result = buildNavigationUrl(
+				'npc',
+				'12345',
+				[],
+				'knows',
+				{ id: '67890', name: 'Alice', type: 'character' }
+			);
+
+			expect(result).toContain('/entities/npc/12345');
+			expect(result).toContain('67890:knows');
+		});
+	});
+});

--- a/src/lib/utils/breadcrumbUtils.ts
+++ b/src/lib/utils/breadcrumbUtils.ts
@@ -1,0 +1,172 @@
+/**
+ * Breadcrumb Utilities for Relationship Navigation
+ *
+ * Issue #79: Relationship Navigation Breadcrumbs
+ *
+ * These utilities manage the navigation breadcrumb trail when users navigate
+ * through relationship chains, allowing them to see where they've been and
+ * navigate back through the relationship hierarchy.
+ */
+
+export interface BreadcrumbSegment {
+	entityId: string;
+	relationship: string;
+	entityName: string;
+	entityType: string;
+}
+
+/**
+ * Parse breadcrumb path from URL parameter string.
+ * Format: "entityId:relationship:entityName:entityType,..."
+ *
+ * @param pathParam - URL parameter string containing breadcrumb path
+ * @returns Array of breadcrumb segments
+ */
+export function parseBreadcrumbPath(pathParam: string | null): BreadcrumbSegment[] {
+	// Handle null, undefined, empty, or whitespace-only input
+	if (!pathParam || typeof pathParam !== 'string' || !pathParam.trim()) {
+		return [];
+	}
+
+	const segments: BreadcrumbSegment[] = [];
+
+	// Split by comma to get individual segments
+	const parts = pathParam.split(',');
+
+	for (const part of parts) {
+		// Skip empty parts (from trailing commas, leading commas, or multiple consecutive commas)
+		if (!part.trim()) {
+			continue;
+		}
+
+		// Split segment by colon
+		const fields = part.split(':');
+
+		// Skip segments that don't have at least 4 parts
+		if (fields.length < 4) {
+			continue;
+		}
+
+		// Extract and URL-decode the fields
+		const [entityId, relationship, entityName, entityType] = fields.map((field) =>
+			decodeURIComponent(field)
+		);
+
+		segments.push({
+			entityId,
+			relationship,
+			entityName,
+			entityType
+		});
+	}
+
+	return segments;
+}
+
+/**
+ * Custom URL encoding that also encodes apostrophes and parentheses.
+ * Standard encodeURIComponent doesn't encode these characters.
+ *
+ * @param str - String to encode
+ * @returns URL-encoded string
+ */
+function encodeField(str: string): string {
+	return encodeURIComponent(str)
+		.replace(/'/g, '%27')
+		.replace(/\(/g, '%28')
+		.replace(/\)/g, '%29');
+}
+
+/**
+ * Serialize breadcrumb segments to URL parameter string.
+ * Format: "entityId:relationship:entityName:entityType,..."
+ *
+ * @param segments - Array of breadcrumb segments
+ * @returns URL parameter string
+ */
+export function serializeBreadcrumbPath(segments: BreadcrumbSegment[]): string {
+	if (!segments || segments.length === 0) {
+		return '';
+	}
+
+	return segments
+		.map((segment) => {
+			// URL-encode each field
+			const parts = [
+				encodeField(segment.entityId),
+				encodeField(segment.relationship),
+				encodeField(segment.entityName),
+				encodeField(segment.entityType)
+			];
+			return parts.join(':');
+		})
+		.join(',');
+}
+
+/**
+ * Truncate breadcrumb path to maximum length, keeping most recent entries.
+ *
+ * @param segments - Array of breadcrumb segments
+ * @param maxLength - Maximum number of segments to keep
+ * @returns Truncated array of breadcrumb segments
+ */
+export function truncatePath(
+	segments: BreadcrumbSegment[],
+	maxLength: number
+): BreadcrumbSegment[] {
+	if (!segments || segments.length === 0) {
+		return [];
+	}
+
+	// Handle max length of 0 or negative
+	if (maxLength <= 0) {
+		return [];
+	}
+
+	// If segments count is under or equal to max, return all
+	if (segments.length <= maxLength) {
+		return [...segments]; // Return a copy to avoid mutation
+	}
+
+	// Keep the most recent segments (from the end)
+	return segments.slice(-maxLength);
+}
+
+/**
+ * Build navigation URL with updated breadcrumb path.
+ * Automatically truncates to max of 6 segments when adding would exceed.
+ *
+ * @param targetType - Entity type for the URL path
+ * @param targetId - Entity ID for the URL path
+ * @param currentSegments - Current breadcrumb segments
+ * @param relationship - Relationship type being navigated
+ * @param currentEntity - Current entity being navigated from
+ * @returns Complete navigation URL with breadcrumb path
+ */
+export function buildNavigationUrl(
+	targetType: string,
+	targetId: string,
+	currentSegments: BreadcrumbSegment[],
+	relationship: string,
+	currentEntity: { id: string; name: string; type: string }
+): string {
+	// Create new segment for current entity
+	const newSegment: BreadcrumbSegment = {
+		entityId: currentEntity.id,
+		relationship,
+		entityName: currentEntity.name,
+		entityType: currentEntity.type
+	};
+
+	// Combine current segments with new segment
+	const allSegments = [...currentSegments, newSegment];
+
+	// Truncate to max of 6 segments
+	const truncatedSegments = truncatePath(allSegments, 6);
+
+	// Serialize to URL parameter
+	const pathParam = serializeBreadcrumbPath(truncatedSegments);
+
+	// Build complete URL
+	return `/entities/${targetType}/${targetId}?navPath=${pathParam}`;
+}

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -23,3 +23,12 @@ export {
 	type CommandFilterContext,
 	type ParsedCommand
 } from './commandUtils';
+
+// Breadcrumb utilities
+export {
+	parseBreadcrumbPath,
+	serializeBreadcrumbPath,
+	truncatePath,
+	buildNavigationUrl,
+	type BreadcrumbSegment
+} from './breadcrumbUtils';


### PR DESCRIPTION
## Summary

- Adds breadcrumb navigation trail when exploring entity relationships
- Users can see their navigation path (e.g., `Entity A → Entity B → Current`) and click any segment to navigate back
- Path persists via URL parameters, enabling shareable links and browser back/forward support
- Maximum 6 segments with automatic truncation of older entries

## Changes

**New files:**
- `src/lib/utils/breadcrumbUtils.ts` - URL path parsing/serialization utilities
- `src/lib/components/navigation/RelationshipBreadcrumbs.svelte` - Breadcrumb display component
- 106 tests (63 unit + 43 component)

**Modified:**
- `RelationshipCard.svelte` - Added `onNavigate` callback prop
- Entity detail page - Integrated breadcrumb display and navigation handlers
- Documentation (USER_GUIDE.md, ARCHITECTURE.md)

## Test plan

- [x] All 106 breadcrumb tests pass
- [x] TypeScript check passes (no errors in breadcrumb files)
- [x] Production build succeeds
- [ ] Manual testing: Navigate through relationships and verify breadcrumbs appear
- [ ] Manual testing: Click breadcrumb segments to navigate back
- [ ] Manual testing: Clear button resets trail
- [ ] Manual testing: Browser back/forward preserves path

🤖 Generated with [Claude Code](https://claude.com/claude-code)