### PR TITLE
feat(#59): add 'Include relationship context' option to entity generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `getCacheStatus()` checks if cached summary is valid or stale
   - `getStats()` provides cache usage statistics and monitoring
   - Database version 3 schema includes cache table with composite key index
+- "Include relationship context" checkbox on entity edit forms (Issue #59)
+  - Optional checkbox appears when entity has relationships and AI is enabled
+  - Shows relationship count and estimated token cost when enabled
+  - Includes information about related entities in AI generation context
+  - Default state controlled by "Include Related Entities" setting
+  - Privacy protected: hidden fields from related entities are excluded
+  - Provides richer, more contextually aware AI-generated content
 
 ### Fixed
 - Resolved Svelte 5 state_unsafe_mutation error in entity pages (Issue #98)

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -747,10 +747,10 @@ When generating content with AI, Director Assist can include information about r
 **Available Settings:**
 
 **Include Related Entities**
-- Checkbox to enable or disable relationship context in AI generation
+- Checkbox to enable or disable relationship context in AI generation by default
 - Default: On
-- When enabled, AI sees information about entities connected to the one you're generating content for
-- When disabled, AI only sees the current entity's data
+- When enabled, the "Include relationship context" checkbox on entity edit forms is checked by default
+- When disabled, the checkbox is unchecked by default (you can still enable it manually per entity)
 
 **Maximum Related Entities**
 - Controls how many related entities to include in generation context
@@ -793,15 +793,18 @@ When generating content with AI, Director Assist can include information about r
 - Lower maximum related entities to 5-10
 - Decrease context budget to 20-30%
 - Keep auto-generate summaries disabled
+- Disable "Include Related Entities" to turn off relationship context by default
 
 **Balance quality and cost:**
-- Use default settings (20 entities, 50% budget, summaries off)
+- Use default settings (20 entities, 50% budget, summaries off, relationship context enabled)
 - Adjust based on your specific needs
 
 **Technical Notes:**
 
 - Settings are stored in browser localStorage
 - Changes take effect immediately for new generation requests
+- The "Include Related Entities" setting controls the default state of the checkbox on entity forms
+- You can override the default on a per-entity basis when editing
 - Settings persist across browser sessions
 - Not included in backups (local preference only)
 
@@ -934,9 +937,48 @@ When generating content, the AI looks at:
 - Other fields you've already filled in
 - Your campaign setting and system
 - Field hints and placeholders
+- Related entities (if enabled)
 
 **Example**:
 If you create an NPC named "Grimwald the Wise" with the description "elderly wizard" and role "apothecary owner", then click generate on the Personality field, the AI will create a personality that fits an elderly wizard who runs an apothecary.
+
+### Including Relationship Context in Generation
+
+When editing an entity that has relationships, you can choose to include information about related entities in AI generation. This produces more contextually aware content that fits naturally with the rest of your campaign.
+
+**How to Use:**
+
+When editing an entity with relationships, a checkbox appears below the tags field:
+
+- **Include relationship context** - When enabled, the AI receives information about entities connected to the one you're editing
+- The checkbox shows how many relationships exist
+- When enabled, displays an estimated token cost
+- Only appears when the entity has relationships and AI features are enabled
+
+**What Gets Included:**
+
+When relationship context is enabled:
+- Names and descriptions of related entities
+- Relationship types (how entities are connected)
+- Non-hidden fields from related entities
+- Up to the maximum number of entities configured in Settings (default: 20)
+
+**What's Protected:**
+
+Hidden fields (secrets) from related entities are never included, protecting your campaign secrets.
+
+**Example:**
+
+Generating personality for an NPC who is:
+- Allied with "The Silver Circle" faction
+- Enemy of "Lord Vance"
+- Located at "The Crooked Wand" tavern
+
+With relationship context enabled, the AI generates a personality that reflects these connections, such as loyalty to the faction, hostility toward Lord Vance, and familiarity with the tavern setting.
+
+**Default Behavior:**
+
+The default setting for this checkbox is configured in Settings under "Relationship Context". You can set whether relationship context is included by default for all entities.
 
 ### Privacy and AI
 
@@ -1242,6 +1284,12 @@ Don't like what the AI created? Just click generate again for a new version.
 
 **Provide Good Context**:
 The more information you provide in name, description, and tags, the better the AI's output.
+
+**Use Relationship Context Strategically**:
+- Enable relationship context for entities deeply connected to your campaign (faction leaders, main NPCs, important locations)
+- Consider disabling it for isolated entities or quick one-offs to save tokens
+- Create relationships before generating to take full advantage of contextual awareness
+- Review the estimated token cost to manage API usage
 
 ### Performance Tips
 

--- a/src/lib/services/entityGenerationService.ts
+++ b/src/lib/services/entityGenerationService.ts
@@ -7,6 +7,8 @@ export interface GenerationContext {
 	description?: string;
 	tags?: string[];
 	fields: Record<string, FieldValue>;
+	/** Relationship context for this entity (Issue #59) */
+	relationshipContext?: string;
 }
 
 export interface GeneratedEntity {
@@ -78,9 +80,15 @@ function buildGenerationPrompt(
 `;
 	}
 
+	// Build relationship context (Issue #59)
+	let relationshipInfo = '';
+	if (context.relationshipContext && context.relationshipContext.trim()) {
+		relationshipInfo = `\nRelationships:\n${context.relationshipContext}\n`;
+	}
+
 	return `You are a TTRPG campaign assistant generating a ${typeName} for a tabletop roleplaying campaign.
 ${campaignInfo}
-${existingContext ? `\nThe user has provided some initial context:\n${existingContext}` : '\nGenerate a complete, original entity from scratch.'}
+${existingContext ? `\nThe user has provided some initial context:\n${existingContext}` : '\nGenerate a complete, original entity from scratch.'}${relationshipInfo}
 
 Generate a complete ${typeName} with creative, evocative content. Fill in ALL fields appropriately.
 

--- a/src/lib/services/fieldGenerationService.ts
+++ b/src/lib/services/fieldGenerationService.ts
@@ -38,6 +38,8 @@ export interface FieldGenerationContext {
 	};
 	/** Campaign information for additional context */
 	campaignContext?: { name: string; setting: string; system: string };
+	/** Relationship context for this entity (Issue #59) */
+	relationshipContext?: string;
 }
 
 /**
@@ -109,7 +111,7 @@ export function isGeneratableField(fieldTypeOrDefinition: FieldType | FieldDefin
  * @private
  */
 function buildFieldPrompt(context: FieldGenerationContext): string {
-	const { entityType, typeDefinition, targetField, currentValues, campaignContext } = context;
+	const { entityType, typeDefinition, targetField, currentValues, campaignContext, relationshipContext } = context;
 
 	// Build context from existing values (EXCLUDING hidden fields)
 	let existingContext = '';
@@ -153,6 +155,12 @@ function buildFieldPrompt(context: FieldGenerationContext): string {
 `;
 	}
 
+	// Build relationship context (Issue #59)
+	let relationshipInfo = '';
+	if (relationshipContext && relationshipContext.trim()) {
+		relationshipInfo = `\nRelationships:\n${relationshipContext}\n`;
+	}
+
 	// Build field-specific hints
 	let fieldHints = '';
 	if (targetField.placeholder) {
@@ -167,7 +175,7 @@ function buildFieldPrompt(context: FieldGenerationContext): string {
 
 	return `You are a TTRPG campaign assistant. Generate content for a single field of a ${entityLabel}.
 ${campaignInfo}
-${existingContext ? `\nExisting Context:\n${existingContext}` : ''}
+${existingContext ? `\nExisting Context:\n${existingContext}` : ''}${relationshipInfo}
 FIELD TO GENERATE: ${fieldLabel} (${targetField.key})
 Field Type: ${targetField.type}${fieldHints}
 
@@ -321,6 +329,8 @@ export interface CoreFieldGenerationContext {
 	};
 	/** Campaign information for additional context */
 	campaignContext?: { name: string; setting: string; system: string };
+	/** Relationship context for this entity (Issue #59) */
+	relationshipContext?: string;
 }
 
 /**
@@ -334,7 +344,7 @@ export interface CoreFieldGenerationContext {
  * @private
  */
 function buildSummaryPrompt(context: CoreFieldGenerationContext): string {
-	const { entityType, typeDefinition, currentValues, campaignContext } = context;
+	const { entityType, typeDefinition, currentValues, campaignContext, relationshipContext } = context;
 
 	// Build context from existing values (EXCLUDING hidden fields)
 	let existingContext = '';
@@ -378,11 +388,17 @@ function buildSummaryPrompt(context: CoreFieldGenerationContext): string {
 `;
 	}
 
+	// Build relationship context (Issue #59)
+	let relationshipInfo = '';
+	if (relationshipContext && relationshipContext.trim()) {
+		relationshipInfo = `\nRelationships:\n${relationshipContext}\n`;
+	}
+
 	const entityLabel = typeDefinition.label;
 
 	return `You are a TTRPG campaign assistant. Generate a brief summary for a ${entityLabel}.
 ${campaignInfo}
-${existingContext ? `\nExisting Context:\n${existingContext}` : ''}
+${existingContext ? `\nExisting Context:\n${existingContext}` : ''}${relationshipInfo}
 TASK: Generate a concise summary (1-2 sentences) that captures the essence of this ${entityLabel}.
 
 IMPORTANT RULES:
@@ -406,7 +422,7 @@ Respond with ONLY the summary text (no JSON, no markdown formatting, no explanat
  * @private
  */
 function buildDescriptionPrompt(context: CoreFieldGenerationContext): string {
-	const { entityType, typeDefinition, currentValues, campaignContext } = context;
+	const { entityType, typeDefinition, currentValues, campaignContext, relationshipContext } = context;
 
 	// Build context from existing values (EXCLUDING hidden fields)
 	let existingContext = '';
@@ -450,11 +466,17 @@ function buildDescriptionPrompt(context: CoreFieldGenerationContext): string {
 `;
 	}
 
+	// Build relationship context (Issue #59)
+	let relationshipInfo = '';
+	if (relationshipContext && relationshipContext.trim()) {
+		relationshipInfo = `\nRelationships:\n${relationshipContext}\n`;
+	}
+
 	const entityLabel = typeDefinition.label;
 
 	return `You are a TTRPG campaign assistant. Generate a detailed description for a ${entityLabel}.
 ${campaignInfo}
-${existingContext ? `\nExisting Context:\n${existingContext}` : ''}
+${existingContext ? `\nExisting Context:\n${existingContext}` : ''}${relationshipInfo}
 TASK: Generate a rich, evocative description (1-3 paragraphs) for this ${entityLabel}.
 
 IMPORTANT RULES:


### PR DESCRIPTION
## Summary
- Adds "Include relationship context" checkbox to entity edit forms
- When enabled, AI generation receives information about related entities for more contextually appropriate content
- Shows relationship count and estimated token cost in the UI
- Respects user settings for default behavior
- Privacy protected: hidden fields from related entities are not included

## Changes
- **Services**: Added `relationshipContext` to `FieldGenerationContext`, `CoreFieldGenerationContext`, and `GenerationContext` interfaces
- **Prompt Building**: Updated `buildFieldPrompt`, `buildSummaryPrompt`, `buildDescriptionPrompt`, and `buildGenerationPrompt` to include relationship context
- **UI**: Added checkbox with relationship count and token estimate display on entity edit page
- **Tests**: 14 new tests covering relationship context integration
- **Docs**: Updated USER_GUIDE.md and CHANGELOG.md

## Test plan
- [x] All existing tests pass
- [x] New relationship context tests pass (14 tests)
- [x] TypeScript compilation succeeds
- [x] Checkbox appears only when entity has relationships and AI is enabled
- [x] Token estimate displays correctly when checkbox is enabled
- [x] Generation includes relationship context when enabled
- [x] Generation works normally when checkbox is disabled (backward compatibility)

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)