### PR TITLE
feat(#62, #134): Add relationship context UI with cache status and regeneration

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -954,12 +954,33 @@ When editing an entity that has relationships, you can choose to include informa
 
 **How to Use:**
 
-When editing an entity with relationships, a checkbox appears below the tags field:
+When editing an entity with relationships, an expandable Relationship Context panel appears below the tags field. This panel provides granular control over which relationships to include.
 
-- **Include relationship context** - When enabled, the AI receives information about entities connected to the one you're editing
-- The checkbox shows how many relationships exist
-- When enabled, displays an estimated token cost
-- Only appears when the entity has relationships and AI features are enabled
+**The Relationship Context Panel:**
+
+- **Expand/Collapse**: Click the header to show or hide the relationship list
+- **Relationship count**: Badge shows total number of relationships
+- **Cache status summary**: Displays how many relationship summaries are valid, stale, or missing
+- **Select All/Select None**: Quick controls to toggle all relationships at once
+- **Total token count**: Shows estimated tokens for all selected relationships
+
+**Individual Relationship Cards:**
+
+Each relationship displays:
+- **Checkbox**: Include or exclude this relationship from context
+- **Entity name and type**: Target entity and relationship type
+- **Cache status badge**:
+  - "Valid" (green): Summary is up-to-date
+  - "Stale" (yellow): Entity changed since summary was cached
+  - "No Cache" (gray): No summary generated yet
+- **Cache age**: When the summary was last generated (e.g., "Cached 2 hours ago")
+- **Summary preview**: First two lines of the cached relationship summary
+- **Token count**: Estimated tokens this relationship contributes
+- **Regenerate button**: Click to generate a fresh summary for this relationship
+
+**Smart Selection:**
+
+Only appears when the entity has relationships and AI features are enabled. The panel remembers which relationships you've selected for future generations.
 
 **Smart Field Detection:**
 
@@ -994,13 +1015,14 @@ Relationship context works best for:
 
 **What Gets Included:**
 
-When relationship context is enabled:
-- Names and descriptions of related entities
-- Relationship types (how entities are connected)
-- Non-hidden fields from related entities
-- Up to the maximum number of entities configured in Settings (default: 20)
+For each selected relationship:
+- Cached summary of the related entity (if available)
+- Or raw entity data if no summary exists
+- Relationship type and metadata
+- Non-hidden fields only
+- Token budget controlled by field priority (see Smart Field Detection below)
 
-**Example:**
+**Example Workflow:**
 
 ```
 1. You have an NPC "Elena the Bard" with relationships:
@@ -1008,27 +1030,47 @@ When relationship context is enabled:
    - knows: "Grimwald the Wise" (NPC)
    - enemy_of: "Shadow Guild" (Faction)
 
-2. You click Generate on the "personality" field (high priority)
+2. Open the Relationship Context panel:
+   - All three relationships appear with cache status
+   - The Silver Circle: "Valid" (green badge) - Cached 1 hour ago
+   - Grimwald the Wise: "Stale" (yellow badge) - Cached 3 days ago
+   - Shadow Guild: "No Cache" (gray badge)
 
-3. The AI receives:
+3. Select relationships to include:
+   - Check "The Silver Circle" and "Grimwald the Wise"
+   - Optionally click Regenerate on Grimwald to refresh stale summary
+   - Total token count updates: "2,450 tokens"
+
+4. Click Generate on the "personality" field (high priority)
+
+5. The AI receives:
    - Elena's existing fields (name, description, tags)
    - Campaign context
-   - Relationship context showing her three connections
+   - Summaries for the two selected relationships
    - Character budget: ~3000 characters for relationships
 
-4. Generated personality reflects her relationships:
+6. Generated personality reflects selected relationships:
    "Elena is fiercely loyal to the Silver Circle and their cause,
-   drawing wisdom from her friendship with Grimwald while harboring
-   a deep-seated grudge against the Shadow Guild..."
+   drawing wisdom from her friendship with Grimwald..."
 ```
 
 **When Relationship Context is NOT Included:**
 
 - Creating new entities (they have no relationships yet)
 - Fields that don't benefit from relationship awareness (equipment, stats, etc.)
-- When relationship context is disabled in Settings or the checkbox is unchecked
+- When no relationships are selected in the panel
+- When relationship context is disabled in Settings
 - When the entity has no relationships
 - For entity types that don't benefit from social context (items, encounters, etc.)
+
+**Cache Regeneration:**
+
+When you click the Regenerate button:
+- AI creates a fresh summary for that specific relationship
+- Cache status updates to "Valid" with current timestamp
+- Summary preview updates with new content
+- Token count recalculates
+- The regenerated summary is immediately available for AI generation
 
 **Privacy Protection:**
 
@@ -1036,7 +1078,13 @@ Hidden fields (secrets) from related entities are never included, protecting you
 
 **Default Behavior:**
 
-The default setting for this checkbox is configured in Settings under "Relationship Context". You can set whether relationship context is included by default for all entities
+Settings under "Relationship Context" control:
+- Whether the panel is visible by default
+- Maximum number of relationships to show
+- Maximum characters per relationship summary
+- Context budget allocation between entity and relationships
+
+You can override these defaults on a per-entity basis using the panel controls.
 
 ### Privacy and AI
 

--- a/src/lib/components/entity/RelationshipContextItem.svelte
+++ b/src/lib/components/entity/RelationshipContextItem.svelte
@@ -1,0 +1,211 @@
+<script lang="ts">
+	/**
+	 * RelationshipContextItem Component
+	 *
+	 * Issue #62 & #134: Relationship Context UI with Cache Status
+	 *
+	 * Displays a single relationship with checkbox, summary preview, cache status,
+	 * and regenerate button. Used within RelationshipContextSelector.
+	 */
+	import type { BaseEntity, EntityLink } from '$lib/types';
+	import type { CacheStatus } from '$lib/types/cache';
+	import { formatRelativeTime } from '$lib/utils/timeFormat';
+	import { RefreshCw } from 'lucide-svelte';
+
+	interface Props {
+		targetEntity: BaseEntity;
+		relationship: EntityLink;
+		included: boolean;
+		cacheStatus: CacheStatus;
+		summary?: string;
+		generatedAt?: Date;
+		tokenCount?: number;
+		regenerating?: boolean;
+		onToggle?: () => void;
+		onRegenerate?: () => void;
+	}
+
+	let {
+		targetEntity,
+		relationship,
+		included,
+		cacheStatus,
+		summary,
+		generatedAt,
+		tokenCount,
+		regenerating = false,
+		onToggle,
+		onRegenerate
+	}: Props = $props();
+
+	// Format relationship type for display (convert underscores to spaces)
+	const formattedRelationship = $derived(
+		relationship.relationship.replace(/_/g, ' ')
+	);
+
+	// Get cache status badge configuration
+	const cacheStatusConfig = $derived.by(() => {
+		switch (cacheStatus) {
+			case 'valid':
+				return {
+					label: 'Valid',
+					classes: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300 green success'
+				};
+			case 'stale':
+				return {
+					label: 'Stale',
+					classes: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-300 yellow warning amber'
+				};
+			case 'missing':
+				return {
+					label: 'No Cache',
+					classes: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300 gray muted neutral'
+				};
+		}
+	});
+
+	// Format token count with separator
+	const formattedTokenCount = $derived(
+		tokenCount !== undefined ? tokenCount.toLocaleString('en-US') : undefined
+	);
+
+	function handleToggle() {
+		onToggle?.();
+	}
+
+	function handleRegenerate() {
+		if (!regenerating) {
+			onRegenerate?.();
+		}
+	}
+</script>
+
+<div
+	data-testid="relationship-item"
+	class="p-3 rounded-lg border border-slate-200 dark:border-slate-700 transition-colors"
+	class:selected={included}
+	class:active={included}
+	class:included={included}
+	class:bg-white={included}
+	class:dark:bg-slate-800={included}
+	class:muted={!included}
+	class:inactive={!included}
+	class:disabled={!included}
+	class:bg-slate-50={!included}
+	class:dark:bg-slate-900={!included}
+	class:opacity-60={!included}
+	class:stale={cacheStatus === 'stale'}
+	class:warning={cacheStatus === 'stale'}
+	class:border-yellow-300={cacheStatus === 'stale' && included}
+	class:dark:border-yellow-600={cacheStatus === 'stale' && included}
+>
+	<div class="flex items-start gap-3">
+		<!-- Checkbox -->
+		<input
+			type="checkbox"
+			checked={included}
+			onchange={handleToggle}
+			aria-label="Include {targetEntity.name} in context"
+			class="mt-1 w-4 h-4 rounded border-slate-300 dark:border-slate-600 text-blue-600 focus:ring-blue-500"
+		/>
+
+		<!-- Content -->
+		<div class="flex-1 min-w-0">
+			<!-- Entity name and type -->
+			<div class="flex items-start justify-between gap-2 mb-1">
+				<div class="flex-1 min-w-0">
+					<h4 class="text-sm font-medium text-slate-900 dark:text-white truncate">
+						{targetEntity.name}
+					</h4>
+					<div class="flex items-center gap-2 mt-0.5">
+						<span class="text-xs text-slate-500 dark:text-slate-400">
+							{targetEntity.type} · {formattedRelationship}
+						</span>
+					</div>
+				</div>
+
+				<!-- Cache status badge -->
+				<div class="flex items-center gap-2">
+					<span
+						data-testid="cache-status"
+						class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium {cacheStatusConfig.classes} badge"
+					>
+						{cacheStatusConfig.label}
+					</span>
+					{#if generatedAt}
+						<span class="text-xs text-slate-500 dark:text-slate-400">
+							· Cached {formatRelativeTime(generatedAt)}
+						</span>
+					{/if}
+				</div>
+			</div>
+
+			<!-- Summary or placeholder -->
+			{#if summary}
+				<p
+					data-testid="summary"
+					class="text-sm text-slate-700 dark:text-slate-300 line-clamp-2 mb-2"
+				>
+					{summary}
+				</p>
+			{:else}
+				<p class="text-sm text-slate-400 dark:text-slate-500 italic mb-2">
+					No summary generated
+				</p>
+			{/if}
+
+			<!-- Footer: Token count and regenerate button -->
+			<div class="flex items-center justify-between">
+				<!-- Token count -->
+				{#if tokenCount !== undefined}
+					<span class="text-xs text-slate-500 dark:text-slate-400">
+						{formattedTokenCount} tokens
+					</span>
+				{:else}
+					<span></span>
+				{/if}
+
+				<!-- Regenerate button -->
+				<button
+					type="button"
+					onclick={handleRegenerate}
+					disabled={regenerating}
+					aria-label="Regenerate relationship summary"
+					aria-busy={regenerating}
+					class="flex items-center gap-1.5 px-2 py-1 text-xs font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+				>
+					{#if regenerating}
+						<span role="status" class="w-3.5 h-3.5 animate-spin">
+							<RefreshCw class="w-3.5 h-3.5" />
+						</span>
+					{:else}
+						<RefreshCw class="w-3.5 h-3.5" />
+					{/if}
+					{regenerating ? 'Regenerating...' : 'Regenerate'}
+				</button>
+			</div>
+		</div>
+	</div>
+</div>
+
+<style>
+	.line-clamp-2 {
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+
+	@keyframes spin {
+		from {
+			transform: rotate(0deg);
+		}
+		to {
+			transform: rotate(360deg);
+		}
+	}
+
+	.animate-spin {
+		animation: spin 1s linear infinite;
+	}
+</style>

--- a/src/lib/components/entity/RelationshipContextItem.test.ts
+++ b/src/lib/components/entity/RelationshipContextItem.test.ts
@@ -1,0 +1,768 @@
+/**
+ * Tests for RelationshipContextItem Component
+ *
+ * Issue #62 & #134: Relationship Context UI with Cache Status
+ *
+ * Displays a single relationship with checkbox, summary preview, cache status,
+ * and regenerate button. Used within RelationshipContextSelector.
+ *
+ * These are FAILING tests written following TDD principles (RED phase).
+ * They define the expected behavior before implementation.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import RelationshipContextItem from './RelationshipContextItem.svelte';
+import type { BaseEntity, EntityLink } from '$lib/types';
+import type { CacheStatus } from '$lib/types/cache';
+
+describe('RelationshipContextItem Component', () => {
+	// Mock entities
+	const mockSourceEntity: BaseEntity = {
+		id: 'npc-1',
+		type: 'npc',
+		name: 'Aldric the Brave',
+		description: 'A noble knight',
+		summary: 'A brave knight',
+		tags: [],
+		fields: {},
+		links: [],
+		notes: '',
+		createdAt: new Date('2024-01-01'),
+		updatedAt: new Date('2024-01-10'),
+		metadata: {}
+	};
+
+	const mockTargetEntity: BaseEntity = {
+		id: 'faction-1',
+		type: 'faction',
+		name: 'Order of the Silver Dawn',
+		description: 'A religious order',
+		summary: 'A holy order',
+		tags: [],
+		fields: {},
+		links: [],
+		notes: '',
+		createdAt: new Date('2024-01-01'),
+		updatedAt: new Date('2024-01-10'),
+		metadata: {}
+	};
+
+	const mockRelationship: EntityLink = {
+		id: 'link-1',
+		sourceId: 'npc-1',
+		targetId: 'faction-1',
+		targetType: 'faction',
+		relationship: 'member_of',
+		bidirectional: false
+	};
+
+	describe('Basic Rendering', () => {
+		it('should render without crashing', () => {
+			const { container } = render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'valid',
+					summary: 'Aldric is a loyal member of the Order',
+					generatedAt: new Date()
+				}
+			});
+			expect(container).toBeInTheDocument();
+		});
+
+		it('should display target entity name', () => {
+			render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'valid',
+					summary: 'Test summary'
+				}
+			});
+
+			expect(screen.getByText('Order of the Silver Dawn')).toBeInTheDocument();
+		});
+
+		it('should display target entity type', () => {
+			render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'valid',
+					summary: 'Test summary'
+				}
+			});
+
+			expect(screen.getByText(/faction/i)).toBeInTheDocument();
+		});
+
+		it('should display relationship type', () => {
+			render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'valid',
+					summary: 'Test summary'
+				}
+			});
+
+			expect(screen.getByText(/member_of|member of/i)).toBeInTheDocument();
+		});
+
+		it('should format relationship type for display', () => {
+			render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: { ...mockRelationship, relationship: 'ally_of' },
+					included: true,
+					cacheStatus: 'valid',
+					summary: 'Test summary'
+				}
+			});
+
+			// Should convert underscores to spaces or similar formatting
+			const text = screen.getByText(/ally/i);
+			expect(text).toBeInTheDocument();
+		});
+	});
+
+	describe('Checkbox State', () => {
+		it('should render checkbox', () => {
+			render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'valid',
+					summary: 'Test summary'
+				}
+			});
+
+			const checkbox = screen.getByRole('checkbox');
+			expect(checkbox).toBeInTheDocument();
+		});
+
+		it('should show checked checkbox when included is true', () => {
+			render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'valid',
+					summary: 'Test summary'
+				}
+			});
+
+			const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+			expect(checkbox.checked).toBe(true);
+		});
+
+		it('should show unchecked checkbox when included is false', () => {
+			render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: false,
+					cacheStatus: 'valid',
+					summary: 'Test summary'
+				}
+			});
+
+			const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+			expect(checkbox.checked).toBe(false);
+		});
+
+		it('should call onToggle when checkbox is clicked', async () => {
+			const onToggle = vi.fn();
+
+			render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'valid',
+					summary: 'Test summary',
+					onToggle
+				}
+			});
+
+			const checkbox = screen.getByRole('checkbox');
+			await fireEvent.click(checkbox);
+
+			expect(onToggle).toHaveBeenCalledTimes(1);
+		});
+
+		it('should toggle checkbox state when clicked', async () => {
+			const onToggle = vi.fn();
+
+			const { rerender } = render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'valid',
+					summary: 'Test summary',
+					onToggle
+				}
+			});
+
+			const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+			expect(checkbox.checked).toBe(true);
+
+			await fireEvent.click(checkbox);
+			expect(onToggle).toHaveBeenCalled();
+
+			// Re-render with updated state
+			rerender({
+				targetEntity: mockTargetEntity,
+				relationship: mockRelationship,
+				included: false,
+				cacheStatus: 'valid',
+				summary: 'Test summary',
+				onToggle
+			});
+
+			expect((screen.getByRole('checkbox') as HTMLInputElement).checked).toBe(false);
+		});
+	});
+
+	describe('Cache Status Badge', () => {
+		it('should show "Valid" badge with green styling for valid cache', () => {
+			const { container } = render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'valid',
+					summary: 'Test summary',
+					generatedAt: new Date()
+				}
+			});
+
+			const badge = screen.getByTestId('cache-status');
+			expect(badge).toBeInTheDocument();
+			expect(badge).toHaveTextContent('Valid');
+			// Should have green/success styling
+			expect(badge).toHaveClass(/green|success/);
+		});
+
+		it('should show "Stale" badge with yellow styling for stale cache', () => {
+			const { container } = render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'stale',
+					summary: 'Test summary',
+					generatedAt: new Date()
+				}
+			});
+
+			const badge = screen.getByTestId('cache-status');
+			expect(badge).toBeInTheDocument();
+			expect(badge).toHaveTextContent('Stale');
+			// Should have yellow/warning styling
+			expect(badge).toHaveClass(/yellow|warning|amber/);
+		});
+
+		it('should show "No Cache" badge with gray styling for missing cache', () => {
+			const { container } = render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'missing',
+					summary: undefined
+				}
+			});
+
+			expect(screen.getByText(/no cache|missing|not cached/i)).toBeInTheDocument();
+			// Should have gray/muted styling
+			const badge = container.querySelector('[data-testid="cache-status"], [class*="badge"]');
+			expect(badge).toHaveClass(/gray|muted|neutral/);
+		});
+	});
+
+	describe('Cache Age Display', () => {
+		it('should show "Cached X ago" when generatedAt is provided', () => {
+			const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+
+			render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'valid',
+					summary: 'Test summary',
+					generatedAt: twoHoursAgo
+				}
+			});
+
+			expect(screen.getByText(/cached.*ago/i)).toBeInTheDocument();
+		});
+
+		it('should show relative time for cache age', () => {
+			const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000);
+
+			render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'valid',
+					summary: 'Test summary',
+					generatedAt: fiveMinutesAgo
+				}
+			});
+
+			// Should use formatRelativeTime utility
+			expect(screen.getByText(/5 minutes ago/i)).toBeInTheDocument();
+		});
+
+		it('should not show cache age when generatedAt is missing', () => {
+			render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'missing',
+					summary: undefined
+				}
+			});
+
+			expect(screen.queryByText(/cached.*ago/i)).not.toBeInTheDocument();
+		});
+
+		it('should show "No summary" when cache is missing', () => {
+			render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'missing',
+					summary: undefined
+				}
+			});
+
+			expect(screen.getByText(/no summary|not generated/i)).toBeInTheDocument();
+		});
+	});
+
+	describe('Summary Display', () => {
+		it('should display relationship summary when provided', () => {
+			render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'valid',
+					summary: 'Aldric is a dedicated member of the Order, sworn to protect the innocent.',
+					generatedAt: new Date()
+				}
+			});
+
+			expect(
+				screen.getByText(/Aldric is a dedicated member of the Order/i)
+			).toBeInTheDocument();
+		});
+
+		it('should truncate long summaries with ellipsis', () => {
+			const longSummary =
+				'This is a very long summary that should be truncated to avoid taking up too much space in the UI. It contains lots of detail about the relationship between these entities, including their history, current status, and future plans.';
+
+			const { container } = render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'valid',
+					summary: longSummary,
+					generatedAt: new Date()
+				}
+			});
+
+			// Should either truncate or use CSS to limit lines
+			const summaryElement = container.querySelector('[data-testid="summary"], [class*="summary"]');
+			expect(summaryElement).toBeInTheDocument();
+		});
+
+		it('should show placeholder when summary is missing', () => {
+			render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'missing',
+					summary: undefined
+				}
+			});
+
+			expect(screen.getByText(/no summary|not generated/i)).toBeInTheDocument();
+		});
+	});
+
+	describe('Regenerate Button', () => {
+		it('should render regenerate button', () => {
+			render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'valid',
+					summary: 'Test summary',
+					generatedAt: new Date()
+				}
+			});
+
+			const button = screen.getByRole('button', { name: /regenerate/i });
+			expect(button).toBeInTheDocument();
+		});
+
+		it('should call onRegenerate when regenerate button is clicked', async () => {
+			const onRegenerate = vi.fn();
+
+			render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'valid',
+					summary: 'Test summary',
+					generatedAt: new Date(),
+					onRegenerate
+				}
+			});
+
+			const button = screen.getByRole('button', { name: /regenerate/i });
+			await fireEvent.click(button);
+
+			expect(onRegenerate).toHaveBeenCalledTimes(1);
+		});
+
+		it('should show loading spinner when regenerating', () => {
+			const { container } = render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'valid',
+					summary: 'Test summary',
+					generatedAt: new Date(),
+					regenerating: true
+				}
+			});
+
+			// Should show spinner in button
+			const spinner = container.querySelector('[role="status"], [class*="spin"]');
+			expect(spinner).toBeInTheDocument();
+		});
+
+		it('should disable regenerate button when regenerating', () => {
+			render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'valid',
+					summary: 'Test summary',
+					generatedAt: new Date(),
+					regenerating: true
+				}
+			});
+
+			const button = screen.getByRole('button', { name: /regenerate/i });
+			expect(button).toBeDisabled();
+		});
+
+		it('should not call onRegenerate when already regenerating', async () => {
+			const onRegenerate = vi.fn();
+
+			render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'valid',
+					summary: 'Test summary',
+					generatedAt: new Date(),
+					regenerating: true,
+					onRegenerate
+				}
+			});
+
+			const button = screen.getByRole('button', { name: /regenerate/i });
+			await fireEvent.click(button);
+
+			expect(onRegenerate).not.toHaveBeenCalled();
+		});
+
+		it('should show different text or icon when regenerating', () => {
+			render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'valid',
+					summary: 'Test summary',
+					generatedAt: new Date(),
+					regenerating: true
+				}
+			});
+
+			// Should show "Regenerating..." or similar
+			expect(screen.getByText(/regenerating/i)).toBeInTheDocument();
+		});
+	});
+
+	describe('Visual States', () => {
+		it('should have different styling when included', () => {
+			const { container } = render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'valid',
+					summary: 'Test summary',
+					generatedAt: new Date()
+				}
+			});
+
+			const item = container.querySelector('[data-testid="relationship-item"]');
+			expect(item).toHaveClass(/selected|active|included/);
+		});
+
+		it('should have muted styling when not included', () => {
+			const { container } = render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: false,
+					cacheStatus: 'valid',
+					summary: 'Test summary',
+					generatedAt: new Date()
+				}
+			});
+
+			const item = container.querySelector('[data-testid="relationship-item"]');
+			expect(item).toHaveClass(/muted|inactive|disabled/);
+		});
+
+		it('should highlight stale cache entries', () => {
+			const { container } = render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'stale',
+					summary: 'Test summary',
+					generatedAt: new Date()
+				}
+			});
+
+			// Should have warning/stale styling
+			const item = container.querySelector('[data-testid="relationship-item"]');
+			expect(item).toHaveClass(/stale|warning/);
+		});
+	});
+
+	describe('Accessibility', () => {
+		it('should have accessible checkbox label', () => {
+			render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'valid',
+					summary: 'Test summary',
+					generatedAt: new Date()
+				}
+			});
+
+			const checkbox = screen.getByRole('checkbox');
+			expect(checkbox).toHaveAccessibleName(/Order of the Silver Dawn/i);
+		});
+
+		it('should have accessible regenerate button', () => {
+			render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'valid',
+					summary: 'Test summary',
+					generatedAt: new Date()
+				}
+			});
+
+			const button = screen.getByRole('button', { name: /regenerate/i });
+			expect(button).toHaveAccessibleName();
+		});
+
+		it('should announce loading state for screen readers', () => {
+			render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'valid',
+					summary: 'Test summary',
+					generatedAt: new Date(),
+					regenerating: true
+				}
+			});
+
+			const button = screen.getByRole('button', { name: /regenerate/i });
+			expect(button).toHaveAttribute('aria-busy', 'true');
+		});
+	});
+
+	describe('Token Count Display', () => {
+		it('should show token count when provided', () => {
+			render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'valid',
+					summary: 'Test summary',
+					generatedAt: new Date(),
+					tokenCount: 45
+				}
+			});
+
+			expect(screen.getByText(/45.*tokens?/i)).toBeInTheDocument();
+		});
+
+		it('should not show token count when not provided', () => {
+			render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'valid',
+					summary: 'Test summary',
+					generatedAt: new Date()
+				}
+			});
+
+			expect(screen.queryByText(/tokens?/i)).not.toBeInTheDocument();
+		});
+
+		it('should format token count with separator for large numbers', () => {
+			render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'valid',
+					summary: 'Test summary',
+					generatedAt: new Date(),
+					tokenCount: 1500
+				}
+			});
+
+			// Should show as "1,500 tokens" or similar
+			expect(screen.getByText(/1[,\s]500/)).toBeInTheDocument();
+		});
+	});
+
+	describe('Integration Scenarios', () => {
+		it('should handle complete valid cache scenario', () => {
+			const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+
+			render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'valid',
+					summary: 'Aldric serves the Order faithfully.',
+					generatedAt: oneHourAgo,
+					tokenCount: 42
+				}
+			});
+
+			// Should show all elements
+			expect(screen.getByText('Order of the Silver Dawn')).toBeInTheDocument();
+			expect(screen.getByTestId('cache-status')).toHaveTextContent('Valid');
+			expect(screen.getByText(/1 hour ago/i)).toBeInTheDocument();
+			expect(screen.getByText(/Aldric serves/i)).toBeInTheDocument();
+			expect(screen.getByText(/42.*tokens?/i)).toBeInTheDocument();
+			expect(screen.getByRole('checkbox')).toBeChecked();
+		});
+
+		it('should handle stale cache scenario', () => {
+			const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+
+			render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'stale',
+					summary: 'Outdated summary text.',
+					generatedAt: twoDaysAgo
+				}
+			});
+
+			expect(screen.getByTestId('cache-status')).toHaveTextContent('Stale');
+			expect(screen.getByText(/2 days ago/i)).toBeInTheDocument();
+		});
+
+		it('should handle missing cache scenario', () => {
+			render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: false,
+					cacheStatus: 'missing',
+					summary: undefined
+				}
+			});
+
+			expect(screen.getByText(/no cache|missing/i)).toBeInTheDocument();
+			expect(screen.getByText(/no summary|not generated/i)).toBeInTheDocument();
+			expect(screen.getByRole('checkbox')).not.toBeChecked();
+		});
+
+		it('should handle regeneration workflow', async () => {
+			const onRegenerate = vi.fn();
+			const { rerender } = render(RelationshipContextItem, {
+				props: {
+					targetEntity: mockTargetEntity,
+					relationship: mockRelationship,
+					included: true,
+					cacheStatus: 'stale',
+					summary: 'Old summary',
+					generatedAt: new Date(),
+					regenerating: false,
+					onRegenerate
+				}
+			});
+
+			// Click regenerate
+			const button = screen.getByRole('button', { name: /regenerate/i });
+			await fireEvent.click(button);
+			expect(onRegenerate).toHaveBeenCalled();
+
+			// Parent sets regenerating to true
+			rerender({
+				targetEntity: mockTargetEntity,
+				relationship: mockRelationship,
+				included: true,
+				cacheStatus: 'stale',
+				summary: 'Old summary',
+				generatedAt: new Date(),
+				regenerating: true,
+				onRegenerate
+			});
+
+			expect(screen.getByRole('button', { name: /regenerate/i })).toBeDisabled();
+			expect(screen.getByText(/regenerating/i)).toBeInTheDocument();
+		});
+	});
+});

--- a/src/lib/components/entity/RelationshipContextSelector.svelte
+++ b/src/lib/components/entity/RelationshipContextSelector.svelte
@@ -1,0 +1,200 @@
+<script lang="ts">
+	/**
+	 * RelationshipContextSelector Component
+	 *
+	 * Issue #62 & #134: Relationship Context UI with Cache Status
+	 *
+	 * Main component for selecting which relationships to include in AI generation context.
+	 * Displays collapsible list of relationships with cache status, selection controls,
+	 * and token count estimate.
+	 */
+	import type { BaseEntity, EntityLink } from '$lib/types';
+	import type { CacheStatus } from '$lib/types/cache';
+	import { ChevronDown, ChevronUp, Network } from 'lucide-svelte';
+	import RelationshipContextItem from './RelationshipContextItem.svelte';
+
+	export interface RelationshipContextData {
+		relationship: EntityLink;
+		targetEntity: BaseEntity;
+		cacheStatus: CacheStatus;
+		summary?: string;
+		generatedAt?: Date;
+		tokenCount?: number;
+		included?: boolean;
+		regenerating?: boolean;
+	}
+
+	interface Props {
+		sourceEntity: BaseEntity;
+		relationshipContext: RelationshipContextData[];
+		onContextChange?: (context: RelationshipContextData[]) => void;
+		onRegenerate?: (index: number) => void;
+	}
+
+	let { sourceEntity, relationshipContext, onContextChange, onRegenerate }: Props = $props();
+
+	let isExpanded = $state(false);
+
+	// Calculate total token count for included relationships
+	const totalTokens = $derived(
+		relationshipContext
+			.filter((ctx) => ctx.included)
+			.reduce((sum, ctx) => sum + (ctx.tokenCount || 0), 0)
+	);
+
+	// Calculate cache status summary
+	const cacheStatusSummary = $derived.by(() => {
+		const summary = {
+			valid: 0,
+			stale: 0,
+			missing: 0
+		};
+
+		for (const ctx of relationshipContext) {
+			summary[ctx.cacheStatus]++;
+		}
+
+		return summary;
+	});
+
+	function toggleExpanded() {
+		isExpanded = !isExpanded;
+	}
+
+	function handleSelectAll() {
+		const updatedContext = relationshipContext.map((ctx) => ({
+			...ctx,
+			included: true
+		}));
+		onContextChange?.(updatedContext);
+	}
+
+	function handleSelectNone() {
+		const updatedContext = relationshipContext.map((ctx) => ({
+			...ctx,
+			included: false
+		}));
+		onContextChange?.(updatedContext);
+	}
+
+	function handleToggleItem(index: number) {
+		const updatedContext = relationshipContext.map((ctx, i) =>
+			i === index ? { ...ctx, included: !ctx.included } : ctx
+		);
+		onContextChange?.(updatedContext);
+	}
+</script>
+
+<div class="border-b border-slate-200 dark:border-slate-700">
+	<!-- Header / Toggle -->
+	<button
+		type="button"
+		onclick={toggleExpanded}
+		aria-expanded={isExpanded}
+		class="w-full px-4 py-2 flex items-center justify-between text-sm text-slate-600 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors"
+	>
+		<span class="flex items-center gap-2">
+			<Network class="w-4 h-4" />
+			Relationship Context
+			<span
+				class="bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 px-2 py-0.5 rounded-full text-xs font-medium"
+			>
+				{relationshipContext.length}
+			</span>
+		</span>
+		<div data-testid="chevron" class={isExpanded ? 'rotate-180 transform' : ''}>
+			{#if isExpanded}
+				<ChevronDown class="w-4 h-4 transition-transform" />
+			{:else}
+				<ChevronDown class="w-4 h-4 transition-transform" />
+			{/if}
+		</div>
+	</button>
+
+	<!-- Expanded content -->
+	<div
+		data-testid="relationship-list"
+		role="region"
+		aria-label="Relationship Context"
+		class="px-4 pb-3 space-y-3"
+		class:hidden={!isExpanded}
+		style={isExpanded ? '' : 'display: none;'}
+	>
+			{#if relationshipContext.length === 0}
+				<p class="text-sm text-slate-400 dark:text-slate-500 text-center py-4">
+					No relationships found
+				</p>
+			{:else}
+				<!-- Controls: Select All / Select None -->
+				<div class="flex items-center justify-between pt-2">
+					<div class="flex items-center gap-2">
+						<button
+							type="button"
+							onclick={handleSelectAll}
+							class="text-xs font-medium text-blue-600 dark:text-blue-400 hover:underline"
+						>
+							Select All
+						</button>
+						<span class="text-slate-300 dark:text-slate-600">|</span>
+						<button
+							type="button"
+							onclick={handleSelectNone}
+							class="text-xs font-medium text-blue-600 dark:text-blue-400 hover:underline"
+						>
+							Select None
+						</button>
+					</div>
+				</div>
+
+				<!-- Cache Status Summary -->
+				<div class="flex items-center gap-3 text-xs text-slate-500 dark:text-slate-400">
+					{#if cacheStatusSummary.valid > 0}
+						<span class="flex items-center gap-1">
+							<span class="w-2 h-2 rounded-full bg-green-500"></span>
+							{cacheStatusSummary.valid} valid
+						</span>
+					{/if}
+					{#if cacheStatusSummary.stale > 0}
+						<span class="flex items-center gap-1">
+							<span class="w-2 h-2 rounded-full bg-yellow-500"></span>
+							{cacheStatusSummary.stale} stale
+						</span>
+					{/if}
+					{#if cacheStatusSummary.missing > 0}
+						<span class="flex items-center gap-1">
+							<span class="w-2 h-2 rounded-full bg-gray-400"></span>
+							{cacheStatusSummary.missing} missing
+						</span>
+					{/if}
+				</div>
+
+				<!-- Relationship list -->
+				<div class="space-y-2">
+					{#each relationshipContext as ctx, index}
+						<RelationshipContextItem
+							targetEntity={ctx.targetEntity}
+							relationship={ctx.relationship}
+							included={ctx.included ?? false}
+							cacheStatus={ctx.cacheStatus}
+							summary={ctx.summary}
+							generatedAt={ctx.generatedAt}
+							tokenCount={ctx.tokenCount}
+							regenerating={ctx.regenerating}
+							onToggle={() => handleToggleItem(index)}
+							onRegenerate={ctx.regenerating ? undefined : () => onRegenerate?.(index)}
+						/>
+					{/each}
+				</div>
+
+				<!-- Token count estimate -->
+				<div
+					class="flex items-center justify-between pt-3 border-t border-slate-200 dark:border-slate-700"
+				>
+					<span class="text-xs text-slate-500 dark:text-slate-400">
+						Total context: {totalTokens.toLocaleString('en-US')} token{totalTokens === 1 ? '' : 's'}
+					</span>
+				</div>
+			{/if}
+		</div>
+</div>
+

--- a/src/lib/components/entity/RelationshipContextSelector.test.ts
+++ b/src/lib/components/entity/RelationshipContextSelector.test.ts
@@ -1,0 +1,844 @@
+/**
+ * Tests for RelationshipContextSelector Component
+ *
+ * Issue #62 & #134: Relationship Context UI with Cache Status
+ *
+ * Main component for selecting which relationships to include in AI generation context.
+ * Displays collapsible list of relationships with cache status, selection controls,
+ * and token count estimate.
+ *
+ * These are FAILING tests written following TDD principles (RED phase).
+ * They define the expected behavior before implementation.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/svelte';
+import RelationshipContextSelector from './RelationshipContextSelector.svelte';
+import type { BaseEntity, EntityLink } from '$lib/types';
+import type { CacheStatus } from '$lib/types/cache';
+
+describe('RelationshipContextSelector Component', () => {
+	// Mock source entity
+	const mockSourceEntity: BaseEntity = {
+		id: 'npc-1',
+		type: 'npc',
+		name: 'Aldric the Brave',
+		description: 'A noble knight',
+		summary: 'A brave knight',
+		tags: [],
+		fields: {},
+		links: [
+			{
+				id: 'link-1',
+				sourceId: 'npc-1',
+				targetId: 'faction-1',
+				targetType: 'faction',
+				relationship: 'member_of',
+				bidirectional: false
+			},
+			{
+				id: 'link-2',
+				sourceId: 'npc-1',
+				targetId: 'npc-2',
+				targetType: 'npc',
+				relationship: 'ally_of',
+				bidirectional: true
+			},
+			{
+				id: 'link-3',
+				sourceId: 'npc-1',
+				targetId: 'location-1',
+				targetType: 'location',
+				relationship: 'located_in',
+				bidirectional: false
+			}
+		],
+		notes: '',
+		createdAt: new Date('2024-01-01'),
+		updatedAt: new Date('2024-01-10'),
+		metadata: {}
+	};
+
+	// Mock related entities
+	const mockFaction: BaseEntity = {
+		id: 'faction-1',
+		type: 'faction',
+		name: 'Order of the Silver Dawn',
+		description: 'A religious order',
+		summary: 'A holy order',
+		tags: [],
+		fields: {},
+		links: [],
+		notes: '',
+		createdAt: new Date('2024-01-01'),
+		updatedAt: new Date('2024-01-10'),
+		metadata: {}
+	};
+
+	const mockAlly: BaseEntity = {
+		id: 'npc-2',
+		type: 'npc',
+		name: 'Sera the Wise',
+		description: 'A wise mage',
+		summary: 'A powerful mage',
+		tags: [],
+		fields: {},
+		links: [],
+		notes: '',
+		createdAt: new Date('2024-01-01'),
+		updatedAt: new Date('2024-01-10'),
+		metadata: {}
+	};
+
+	const mockLocation: BaseEntity = {
+		id: 'location-1',
+		type: 'location',
+		name: 'Silverkeep',
+		description: 'A fortified city',
+		summary: 'The capital city',
+		tags: [],
+		fields: {},
+		links: [],
+		notes: '',
+		createdAt: new Date('2024-01-01'),
+		updatedAt: new Date('2024-01-10'),
+		metadata: {}
+	};
+
+	const mockRelatedEntities = [mockFaction, mockAlly, mockLocation];
+
+	// Mock relationship context data
+	const mockRelationshipContext = [
+		{
+			relationship: mockSourceEntity.links[0],
+			targetEntity: mockFaction,
+			cacheStatus: 'valid' as CacheStatus,
+			summary: 'Aldric is a devoted member of the Order.',
+			generatedAt: new Date(Date.now() - 60 * 60 * 1000), // 1 hour ago
+			tokenCount: 42
+		},
+		{
+			relationship: mockSourceEntity.links[1],
+			targetEntity: mockAlly,
+			cacheStatus: 'stale' as CacheStatus,
+			summary: 'Aldric and Sera have fought together.',
+			generatedAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000), // 2 days ago
+			tokenCount: 38
+		},
+		{
+			relationship: mockSourceEntity.links[2],
+			targetEntity: mockLocation,
+			cacheStatus: 'missing' as CacheStatus,
+			summary: undefined,
+			generatedAt: undefined,
+			tokenCount: 0
+		}
+	];
+
+	describe('Basic Rendering', () => {
+		it('should render without crashing', () => {
+			const { container } = render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext
+				}
+			});
+			expect(container).toBeInTheDocument();
+		});
+
+		it('should render header with "Relationship Context" title', () => {
+			render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext
+				}
+			});
+
+			expect(screen.getByText(/relationship context/i)).toBeInTheDocument();
+		});
+
+		it('should show relationship count badge', () => {
+			render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext
+				}
+			});
+
+			expect(screen.getByText('3')).toBeInTheDocument();
+		});
+
+		it('should render collapsed by default', () => {
+			const { container } = render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext
+				}
+			});
+
+			// Content should be hidden
+			const content = container.querySelector('[data-testid="relationship-list"]');
+			expect(content).not.toBeVisible();
+		});
+	});
+
+	describe('Expand/Collapse Behavior', () => {
+		it('should expand when header is clicked', async () => {
+			const { container } = render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext
+				}
+			});
+
+			const header = screen.getByRole('button', { name: /relationship context/i });
+			await fireEvent.click(header);
+
+			const content = container.querySelector('[data-testid="relationship-list"]');
+			expect(content).toBeVisible();
+		});
+
+		it('should collapse when header is clicked again', async () => {
+			const { container } = render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext
+				}
+			});
+
+			const header = screen.getByRole('button', { name: /relationship context/i });
+
+			// Expand
+			await fireEvent.click(header);
+			let content = container.querySelector('[data-testid="relationship-list"]');
+			expect(content).toBeVisible();
+
+			// Collapse
+			await fireEvent.click(header);
+			content = container.querySelector('[data-testid="relationship-list"]');
+			expect(content).not.toBeVisible();
+		});
+
+		it('should show chevron icon indicating expand state', () => {
+			const { container } = render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext
+				}
+			});
+
+			const chevron = container.querySelector('[data-testid="chevron"], svg');
+			expect(chevron).toBeInTheDocument();
+		});
+
+		it('should rotate chevron when expanded', async () => {
+			const { container } = render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext
+				}
+			});
+
+			const header = screen.getByRole('button', { name: /relationship context/i });
+			await fireEvent.click(header);
+
+			const chevron = screen.getByTestId('chevron');
+			expect(chevron).toHaveClass('rotate-180', 'transform');
+		});
+	});
+
+	describe('Relationship List', () => {
+		it('should render all relationships when expanded', async () => {
+			render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext
+				}
+			});
+
+			const header = screen.getByRole('button', { name: /relationship context/i });
+			await fireEvent.click(header);
+
+			expect(screen.getByText('Order of the Silver Dawn')).toBeInTheDocument();
+			expect(screen.getByText('Sera the Wise')).toBeInTheDocument();
+			expect(screen.getByText('Silverkeep')).toBeInTheDocument();
+		});
+
+		it('should render RelationshipContextItem components', async () => {
+			const { container } = render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext
+				}
+			});
+
+			const header = screen.getByRole('button', { name: /relationship context/i });
+			await fireEvent.click(header);
+
+			const items = container.querySelectorAll('[data-testid="relationship-item"]');
+			expect(items).toHaveLength(3);
+		});
+
+		it('should show empty state when no relationships', async () => {
+			render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: { ...mockSourceEntity, links: [] },
+					relationshipContext: []
+				}
+			});
+
+			const header = screen.getByRole('button', { name: /relationship context/i });
+			await fireEvent.click(header);
+
+			expect(screen.getByText(/no relationships|no related entities/i)).toBeInTheDocument();
+		});
+	});
+
+	describe('Select All / Select None', () => {
+		it('should render "Select All" button when expanded', async () => {
+			render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext
+				}
+			});
+
+			const header = screen.getByRole('button', { name: /relationship context/i });
+			await fireEvent.click(header);
+
+			expect(screen.getByRole('button', { name: /select all/i })).toBeInTheDocument();
+		});
+
+		it('should render "Select None" button when expanded', async () => {
+			render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext
+				}
+			});
+
+			const header = screen.getByRole('button', { name: /relationship context/i });
+			await fireEvent.click(header);
+
+			expect(screen.getByRole('button', { name: /select none|deselect all/i })).toBeInTheDocument();
+		});
+
+		it('should select all relationships when "Select All" is clicked', async () => {
+			const onContextChange = vi.fn();
+
+			render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext,
+					onContextChange
+				}
+			});
+
+			const header = screen.getByRole('button', { name: /relationship context/i });
+			await fireEvent.click(header);
+
+			const selectAllButton = screen.getByRole('button', { name: /select all/i });
+			await fireEvent.click(selectAllButton);
+
+			expect(onContextChange).toHaveBeenCalledWith(
+				expect.arrayContaining([
+					expect.objectContaining({ relationship: mockSourceEntity.links[0], included: true }),
+					expect.objectContaining({ relationship: mockSourceEntity.links[1], included: true }),
+					expect.objectContaining({ relationship: mockSourceEntity.links[2], included: true })
+				])
+			);
+		});
+
+		it('should deselect all relationships when "Select None" is clicked', async () => {
+			const onContextChange = vi.fn();
+
+			render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext,
+					onContextChange
+				}
+			});
+
+			const header = screen.getByRole('button', { name: /relationship context/i });
+			await fireEvent.click(header);
+
+			const selectNoneButton = screen.getByRole('button', { name: /select none|deselect all/i });
+			await fireEvent.click(selectNoneButton);
+
+			expect(onContextChange).toHaveBeenCalledWith(
+				expect.arrayContaining([
+					expect.objectContaining({ relationship: mockSourceEntity.links[0], included: false }),
+					expect.objectContaining({ relationship: mockSourceEntity.links[1], included: false }),
+					expect.objectContaining({ relationship: mockSourceEntity.links[2], included: false })
+				])
+			);
+		});
+	});
+
+	describe('Individual Checkbox Toggle', () => {
+		it('should toggle individual relationship when checkbox is clicked', async () => {
+			const onContextChange = vi.fn();
+
+			render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext.map((ctx, i) => ({
+						...ctx,
+						included: i === 0 // Only first one included
+					})),
+					onContextChange
+				}
+			});
+
+			const header = screen.getByRole('button', { name: /relationship context/i });
+			await fireEvent.click(header);
+
+			const checkboxes = screen.getAllByRole('checkbox');
+			await fireEvent.click(checkboxes[1]); // Toggle second relationship
+
+			expect(onContextChange).toHaveBeenCalled();
+		});
+
+		it('should update included state when toggled', async () => {
+			const onContextChange = vi.fn();
+
+			const { rerender } = render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext.map((ctx) => ({
+						...ctx,
+						included: false
+					})),
+					onContextChange
+				}
+			});
+
+			const header = screen.getByRole('button', { name: /relationship context/i });
+			await fireEvent.click(header);
+
+			const checkboxes = screen.getAllByRole('checkbox');
+			expect(checkboxes[0]).not.toBeChecked();
+
+			await fireEvent.click(checkboxes[0]);
+			expect(onContextChange).toHaveBeenCalled();
+
+			// Re-render with updated state
+			rerender({
+				sourceEntity: mockSourceEntity,
+				relationshipContext: mockRelationshipContext.map((ctx, i) => ({
+					...ctx,
+					included: i === 0
+				})),
+				onContextChange
+			});
+
+			const updatedCheckboxes = screen.getAllByRole('checkbox');
+			expect(updatedCheckboxes[0]).toBeChecked();
+		});
+	});
+
+	describe('Token Count Estimate', () => {
+		it('should display total token count estimate', async () => {
+			render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext.map((ctx) => ({
+						...ctx,
+						included: true
+					}))
+				}
+			});
+
+			const header = screen.getByRole('button', { name: /relationship context/i });
+			await fireEvent.click(header);
+
+			// Total: 42 + 38 + 0 = 80 tokens
+			expect(screen.getByText(/80.*tokens?/i)).toBeInTheDocument();
+		});
+
+		it('should update token count when selection changes', async () => {
+			const onContextChange = vi.fn();
+
+			const { rerender } = render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext.map((ctx) => ({
+						...ctx,
+						included: true
+					})),
+					onContextChange
+				}
+			});
+
+			const header = screen.getByRole('button', { name: /relationship context/i });
+			await fireEvent.click(header);
+
+			// Initially all selected: 42 + 38 = 80 tokens
+			expect(screen.getByText(/Total context.*80/i)).toBeInTheDocument();
+
+			// Deselect one
+			const checkboxes = screen.getAllByRole('checkbox');
+			await fireEvent.click(checkboxes[1]);
+
+			// Re-render with updated selection
+			rerender({
+				sourceEntity: mockSourceEntity,
+				relationshipContext: mockRelationshipContext.map((ctx, i) => ({
+					...ctx,
+					included: i !== 1 // Deselect second item
+				})),
+				onContextChange
+			});
+
+			// Now: 42 + 0 = 42 tokens
+			expect(screen.getByText(/Total context.*42/i)).toBeInTheDocument();
+		});
+
+		it('should only count tokens for included relationships', async () => {
+			render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext.map((ctx, i) => ({
+						...ctx,
+						included: i === 0 // Only first one included
+					}))
+				}
+			});
+
+			const header = screen.getByRole('button', { name: /relationship context/i });
+			await fireEvent.click(header);
+
+			// Only first relationship: 42 tokens
+			expect(screen.getByText(/Total context.*42/i)).toBeInTheDocument();
+			expect(screen.queryByText(/Total context.*80/i)).not.toBeInTheDocument();
+		});
+
+		it('should show zero tokens when nothing selected', async () => {
+			render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext.map((ctx) => ({
+						...ctx,
+						included: false
+					}))
+				}
+			});
+
+			const header = screen.getByRole('button', { name: /relationship context/i });
+			await fireEvent.click(header);
+
+			expect(screen.getByText(/Total context.*0/i)).toBeInTheDocument();
+		});
+	});
+
+	describe('Regeneration State', () => {
+		it('should show loading state during regeneration', () => {
+			const { container } = render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext.map((ctx, i) => ({
+						...ctx,
+						regenerating: i === 0 // First one regenerating
+					}))
+				}
+			});
+
+			// Should show loading indicator
+			const spinner = container.querySelector('[role="status"], [class*="spin"]');
+			expect(spinner).toBeInTheDocument();
+		});
+
+		it('should pass regenerating state to RelationshipContextItem', async () => {
+			render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext.map((ctx, i) => ({
+						...ctx,
+						regenerating: i === 0,
+						included: true
+					}))
+				}
+			});
+
+			const header = screen.getByRole('button', { name: /relationship context/i });
+			await fireEvent.click(header);
+
+			// First item should be in regenerating state
+			const buttons = screen.getAllByRole('button', { name: /regenerate/i });
+			expect(buttons[0]).toBeDisabled();
+		});
+	});
+
+	describe('Cache Status Summary', () => {
+		it('should show summary of cache statuses', async () => {
+			render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext
+				}
+			});
+
+			const header = screen.getByRole('button', { name: /relationship context/i });
+			await fireEvent.click(header);
+
+			// Should show counts like "1 valid, 1 stale, 1 missing"
+			expect(screen.getByText(/1.*valid/i)).toBeInTheDocument();
+			expect(screen.getByText(/1.*stale/i)).toBeInTheDocument();
+			expect(screen.getByText(/1.*missing/i)).toBeInTheDocument();
+		});
+
+		it('should update cache status summary when statuses change', async () => {
+			const { rerender } = render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext
+				}
+			});
+
+			const header = screen.getByRole('button', { name: /relationship context/i });
+			await fireEvent.click(header);
+
+			expect(screen.getByText(/1.*valid/i)).toBeInTheDocument();
+
+			// All become valid
+			rerender({
+				sourceEntity: mockSourceEntity,
+				relationshipContext: mockRelationshipContext.map((ctx) => ({
+					...ctx,
+					cacheStatus: 'valid' as CacheStatus,
+					summary: 'Updated summary',
+					generatedAt: new Date()
+				}))
+			});
+
+			expect(screen.getByText(/3.*valid/i)).toBeInTheDocument();
+		});
+	});
+
+	describe('Accessibility', () => {
+		it('should have accessible expand/collapse button', () => {
+			render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext
+				}
+			});
+
+			const button = screen.getByRole('button', { name: /relationship context/i });
+			expect(button).toHaveAttribute('aria-expanded', 'false');
+		});
+
+		it('should update aria-expanded when toggled', async () => {
+			render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext
+				}
+			});
+
+			const button = screen.getByRole('button', { name: /relationship context/i });
+			expect(button).toHaveAttribute('aria-expanded', 'false');
+
+			await fireEvent.click(button);
+			expect(button).toHaveAttribute('aria-expanded', 'true');
+		});
+
+		it('should have accessible region for content', async () => {
+			render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext
+				}
+			});
+
+			const header = screen.getByRole('button', { name: /relationship context/i });
+			await fireEvent.click(header);
+
+			const region = screen.getByRole('region', { name: /relationship context/i });
+			expect(region).toBeInTheDocument();
+		});
+	});
+
+	describe('Context Change Callback', () => {
+		it('should call onContextChange with updated context', async () => {
+			const onContextChange = vi.fn();
+
+			render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext.map((ctx) => ({
+						...ctx,
+						included: false
+					})),
+					onContextChange
+				}
+			});
+
+			const header = screen.getByRole('button', { name: /relationship context/i });
+			await fireEvent.click(header);
+
+			const selectAllButton = screen.getByRole('button', { name: /select all/i });
+			await fireEvent.click(selectAllButton);
+
+			expect(onContextChange).toHaveBeenCalled();
+			const call = onContextChange.mock.calls[0][0];
+			expect(call).toHaveLength(3);
+			expect(call.every((ctx: any) => ctx.included)).toBe(true);
+		});
+
+		it('should include all context data in callback', async () => {
+			const onContextChange = vi.fn();
+
+			render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext.map((ctx) => ({
+						...ctx,
+						included: false
+					})),
+					onContextChange
+				}
+			});
+
+			const header = screen.getByRole('button', { name: /relationship context/i });
+			await fireEvent.click(header);
+
+			const checkboxes = screen.getAllByRole('checkbox');
+			await fireEvent.click(checkboxes[0]);
+
+			expect(onContextChange).toHaveBeenCalled();
+			const call = onContextChange.mock.calls[0][0];
+			expect(call[0]).toMatchObject({
+				relationship: expect.any(Object),
+				targetEntity: expect.any(Object),
+				cacheStatus: expect.any(String),
+				included: expect.any(Boolean)
+			});
+		});
+	});
+
+	describe('Integration Scenarios', () => {
+		it('should handle complete workflow with all features', async () => {
+			const onContextChange = vi.fn();
+
+			render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: mockSourceEntity,
+					relationshipContext: mockRelationshipContext.map((ctx) => ({
+						...ctx,
+						included: false
+					})),
+					onContextChange
+				}
+			});
+
+			// Start collapsed
+			let content = screen.queryByTestId('relationship-list');
+			expect(content).not.toBeVisible();
+
+			// Expand
+			const header = screen.getByRole('button', { name: /relationship context/i });
+			await fireEvent.click(header);
+			expect(screen.getByTestId('relationship-list')).toBeVisible();
+
+			// Check all items rendered
+			expect(screen.getByText('Order of the Silver Dawn')).toBeInTheDocument();
+			expect(screen.getByText('Sera the Wise')).toBeInTheDocument();
+			expect(screen.getByText('Silverkeep')).toBeInTheDocument();
+
+			// Select all
+			const selectAllButton = screen.getByRole('button', { name: /select all/i });
+			await fireEvent.click(selectAllButton);
+			expect(onContextChange).toHaveBeenCalled();
+
+			// Token count should be displayed
+			expect(screen.getByText(/Total context/i)).toBeInTheDocument();
+
+			// Cache status summary (status dots)
+			expect(screen.getByText(/1 valid/i)).toBeInTheDocument();
+			expect(screen.getByText(/1 stale/i)).toBeInTheDocument();
+		});
+
+		it('should handle empty relationships list', async () => {
+			render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: { ...mockSourceEntity, links: [] },
+					relationshipContext: []
+				}
+			});
+
+			const header = screen.getByRole('button', { name: /relationship context/i });
+			await fireEvent.click(header);
+
+			expect(screen.getByText(/no relationships|no related entities/i)).toBeInTheDocument();
+			expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+		});
+
+		it('should handle single relationship', async () => {
+			const singleContext = [mockRelationshipContext[0]];
+			const singleEntity = {
+				...mockSourceEntity,
+				links: [mockSourceEntity.links[0]]
+			};
+
+			render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: singleEntity,
+					relationshipContext: singleContext
+				}
+			});
+
+			expect(screen.getByText('1')).toBeInTheDocument();
+
+			const header = screen.getByRole('button', { name: /relationship context/i });
+			await fireEvent.click(header);
+
+			const checkboxes = screen.getAllByRole('checkbox');
+			expect(checkboxes).toHaveLength(1);
+		});
+	});
+
+	describe('Performance', () => {
+		it('should handle many relationships efficiently', async () => {
+			// Create 50 relationships
+			const manyLinks: EntityLink[] = Array.from({ length: 50 }, (_, i) => ({
+				id: `link-${i}`,
+				sourceId: 'npc-1',
+				targetId: `entity-${i}`,
+				targetType: 'npc',
+				relationship: 'knows',
+				bidirectional: false
+			}));
+
+			const manyContext = manyLinks.map((link, i) => ({
+				relationship: link,
+				targetEntity: {
+					...mockAlly,
+					id: `entity-${i}`,
+					name: `Entity ${i}`
+				},
+				cacheStatus: 'valid' as CacheStatus,
+				summary: `Summary ${i}`,
+				generatedAt: new Date(),
+				tokenCount: 40,
+				included: false
+			}));
+
+			const { container } = render(RelationshipContextSelector, {
+				props: {
+					sourceEntity: { ...mockSourceEntity, links: manyLinks },
+					relationshipContext: manyContext
+				}
+			});
+
+			expect(screen.getByText('50')).toBeInTheDocument();
+
+			const header = screen.getByRole('button', { name: /relationship context/i });
+			await fireEvent.click(header);
+
+			// Should render all items
+			const items = container.querySelectorAll('[data-testid="relationship-item"]');
+			expect(items).toHaveLength(50);
+		});
+	});
+});

--- a/src/lib/utils/timeFormat.test.ts
+++ b/src/lib/utils/timeFormat.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Tests for Time Formatting Utility
+ *
+ * Issue #62 & #134: Relationship Context UI with Cache Status
+ *
+ * Provides human-readable relative time formatting for displaying cache age.
+ * Used to show when relationship summaries were cached (e.g., "2 hours ago", "just now").
+ *
+ * These are FAILING tests written following TDD principles (RED phase).
+ * They define the expected behavior before implementation.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { formatRelativeTime } from './timeFormat';
+
+describe('formatRelativeTime', () => {
+	let now: Date;
+
+	beforeEach(() => {
+		// Set a fixed "now" for consistent testing
+		now = new Date('2024-01-20T12:00:00Z');
+		vi.useFakeTimers();
+		vi.setSystemTime(now);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	describe('Recent Times (< 60 seconds)', () => {
+		it('should return "just now" for 0 seconds ago', () => {
+			const timestamp = new Date('2024-01-20T12:00:00Z');
+			expect(formatRelativeTime(timestamp)).toBe('just now');
+		});
+
+		it('should return "just now" for 30 seconds ago', () => {
+			const timestamp = new Date('2024-01-20T11:59:30Z');
+			expect(formatRelativeTime(timestamp)).toBe('just now');
+		});
+
+		it('should return "just now" for 59 seconds ago', () => {
+			const timestamp = new Date('2024-01-20T11:59:01Z');
+			expect(formatRelativeTime(timestamp)).toBe('just now');
+		});
+
+		it('should return "just now" for 1 second ago', () => {
+			const timestamp = new Date('2024-01-20T11:59:59Z');
+			expect(formatRelativeTime(timestamp)).toBe('just now');
+		});
+	});
+
+	describe('Minutes Ago (< 60 minutes)', () => {
+		it('should return "1 minute ago" for exactly 1 minute', () => {
+			const timestamp = new Date('2024-01-20T11:59:00Z');
+			expect(formatRelativeTime(timestamp)).toBe('1 minute ago');
+		});
+
+		it('should return "2 minutes ago" for 2 minutes', () => {
+			const timestamp = new Date('2024-01-20T11:58:00Z');
+			expect(formatRelativeTime(timestamp)).toBe('2 minutes ago');
+		});
+
+		it('should return "5 minutes ago" for 5 minutes', () => {
+			const timestamp = new Date('2024-01-20T11:55:00Z');
+			expect(formatRelativeTime(timestamp)).toBe('5 minutes ago');
+		});
+
+		it('should return "30 minutes ago" for 30 minutes', () => {
+			const timestamp = new Date('2024-01-20T11:30:00Z');
+			expect(formatRelativeTime(timestamp)).toBe('30 minutes ago');
+		});
+
+		it('should return "59 minutes ago" for 59 minutes', () => {
+			const timestamp = new Date('2024-01-20T11:01:00Z');
+			expect(formatRelativeTime(timestamp)).toBe('59 minutes ago');
+		});
+
+		it('should use singular for 1 minute', () => {
+			const timestamp = new Date('2024-01-20T11:59:00Z');
+			const result = formatRelativeTime(timestamp);
+			expect(result).toBe('1 minute ago');
+			expect(result).not.toContain('minutes');
+		});
+
+		it('should use plural for multiple minutes', () => {
+			const timestamp = new Date('2024-01-20T11:58:00Z');
+			const result = formatRelativeTime(timestamp);
+			expect(result).toContain('minutes');
+		});
+	});
+
+	describe('Hours Ago (< 24 hours)', () => {
+		it('should return "1 hour ago" for exactly 1 hour', () => {
+			const timestamp = new Date('2024-01-20T11:00:00Z');
+			expect(formatRelativeTime(timestamp)).toBe('1 hour ago');
+		});
+
+		it('should return "2 hours ago" for 2 hours', () => {
+			const timestamp = new Date('2024-01-20T10:00:00Z');
+			expect(formatRelativeTime(timestamp)).toBe('2 hours ago');
+		});
+
+		it('should return "5 hours ago" for 5 hours', () => {
+			const timestamp = new Date('2024-01-20T07:00:00Z');
+			expect(formatRelativeTime(timestamp)).toBe('5 hours ago');
+		});
+
+		it('should return "12 hours ago" for 12 hours', () => {
+			const timestamp = new Date('2024-01-20T00:00:00Z');
+			expect(formatRelativeTime(timestamp)).toBe('12 hours ago');
+		});
+
+		it('should return "23 hours ago" for 23 hours', () => {
+			const timestamp = new Date('2024-01-19T13:00:00Z');
+			expect(formatRelativeTime(timestamp)).toBe('23 hours ago');
+		});
+
+		it('should use singular for 1 hour', () => {
+			const timestamp = new Date('2024-01-20T11:00:00Z');
+			const result = formatRelativeTime(timestamp);
+			expect(result).toBe('1 hour ago');
+			expect(result).not.toContain('hours');
+		});
+
+		it('should use plural for multiple hours', () => {
+			const timestamp = new Date('2024-01-20T10:00:00Z');
+			const result = formatRelativeTime(timestamp);
+			expect(result).toContain('hours');
+		});
+	});
+
+	describe('Days Ago (< 7 days)', () => {
+		it('should return "1 day ago" for exactly 1 day', () => {
+			const timestamp = new Date('2024-01-19T12:00:00Z');
+			expect(formatRelativeTime(timestamp)).toBe('1 day ago');
+		});
+
+		it('should return "2 days ago" for 2 days', () => {
+			const timestamp = new Date('2024-01-18T12:00:00Z');
+			expect(formatRelativeTime(timestamp)).toBe('2 days ago');
+		});
+
+		it('should return "3 days ago" for 3 days', () => {
+			const timestamp = new Date('2024-01-17T12:00:00Z');
+			expect(formatRelativeTime(timestamp)).toBe('3 days ago');
+		});
+
+		it('should return "6 days ago" for 6 days', () => {
+			const timestamp = new Date('2024-01-14T12:00:00Z');
+			expect(formatRelativeTime(timestamp)).toBe('6 days ago');
+		});
+
+		it('should use singular for 1 day', () => {
+			const timestamp = new Date('2024-01-19T12:00:00Z');
+			const result = formatRelativeTime(timestamp);
+			expect(result).toBe('1 day ago');
+			expect(result).not.toContain('days');
+		});
+
+		it('should use plural for multiple days', () => {
+			const timestamp = new Date('2024-01-18T12:00:00Z');
+			const result = formatRelativeTime(timestamp);
+			expect(result).toContain('days');
+		});
+	});
+
+	describe('Older Dates (>= 7 days)', () => {
+		it('should return formatted date for exactly 7 days ago', () => {
+			const timestamp = new Date('2024-01-13T12:00:00Z');
+			const result = formatRelativeTime(timestamp);
+			expect(result).not.toContain('ago');
+			expect(result).toMatch(/Jan|January/);
+			expect(result).toContain('13');
+		});
+
+		it('should return formatted date for 14 days ago', () => {
+			const timestamp = new Date('2024-01-06T12:00:00Z');
+			const result = formatRelativeTime(timestamp);
+			expect(result).not.toContain('ago');
+			expect(result).toMatch(/Jan|January/);
+			expect(result).toContain('6');
+		});
+
+		it('should return formatted date for 30 days ago', () => {
+			const timestamp = new Date('2023-12-21T12:00:00Z');
+			const result = formatRelativeTime(timestamp);
+			expect(result).not.toContain('ago');
+			expect(result).toMatch(/Dec|December/);
+			expect(result).toContain('21');
+		});
+
+		it('should return formatted date for 1 year ago', () => {
+			const timestamp = new Date('2023-01-20T12:00:00Z');
+			const result = formatRelativeTime(timestamp);
+			expect(result).not.toContain('ago');
+			expect(result).toContain('2023');
+		});
+
+		it('should include year for dates in different year', () => {
+			const timestamp = new Date('2023-12-25T12:00:00Z');
+			const result = formatRelativeTime(timestamp);
+			expect(result).toContain('2023');
+		});
+
+		it('should format date consistently', () => {
+			const timestamp = new Date('2024-01-13T12:00:00Z');
+			const result = formatRelativeTime(timestamp);
+			// Should be in format like "Jan 13" or "January 13" or "Jan 13, 2024"
+			expect(result).toMatch(/\w+\s+\d+/);
+		});
+	});
+
+	describe('Edge Cases', () => {
+		it('should handle future dates gracefully', () => {
+			const futureDate = new Date('2024-01-21T12:00:00Z');
+			// Should either return "just now" or handle as 0 time difference
+			const result = formatRelativeTime(futureDate);
+			expect(result).toBeDefined();
+			expect(typeof result).toBe('string');
+		});
+
+		it('should handle Date objects', () => {
+			const date = new Date('2024-01-20T11:30:00Z');
+			expect(formatRelativeTime(date)).toBe('30 minutes ago');
+		});
+
+		it('should handle timestamp numbers', () => {
+			const timestamp = new Date('2024-01-20T11:30:00Z').getTime();
+			expect(formatRelativeTime(timestamp)).toBe('30 minutes ago');
+		});
+
+		it('should handle ISO string dates', () => {
+			const isoString = '2024-01-20T11:30:00Z';
+			expect(formatRelativeTime(isoString)).toBe('30 minutes ago');
+		});
+
+		it('should handle very old dates', () => {
+			const veryOld = new Date('2020-01-01T00:00:00Z');
+			const result = formatRelativeTime(veryOld);
+			expect(result).toContain('2020');
+		});
+
+		it('should handle timestamps at midnight', () => {
+			const midnight = new Date('2024-01-20T00:00:00Z');
+			expect(formatRelativeTime(midnight)).toBe('12 hours ago');
+		});
+
+		it('should round down partial time units', () => {
+			// 1.5 minutes should be "1 minute ago"
+			const timestamp = new Date('2024-01-20T11:58:30Z');
+			expect(formatRelativeTime(timestamp)).toBe('1 minute ago');
+		});
+	});
+
+	describe('Boundary Conditions', () => {
+		it('should correctly handle 60 seconds boundary', () => {
+			const justUnderMinute = new Date('2024-01-20T11:59:01Z');
+			const exactlyOneMinute = new Date('2024-01-20T11:59:00Z');
+
+			expect(formatRelativeTime(justUnderMinute)).toBe('just now');
+			expect(formatRelativeTime(exactlyOneMinute)).toBe('1 minute ago');
+		});
+
+		it('should correctly handle 60 minutes boundary', () => {
+			const justUnderHour = new Date('2024-01-20T11:01:00Z');
+			const exactlyOneHour = new Date('2024-01-20T11:00:00Z');
+
+			expect(formatRelativeTime(justUnderHour)).toBe('59 minutes ago');
+			expect(formatRelativeTime(exactlyOneHour)).toBe('1 hour ago');
+		});
+
+		it('should correctly handle 24 hours boundary', () => {
+			const justUnderDay = new Date('2024-01-19T13:00:00Z');
+			const exactlyOneDay = new Date('2024-01-19T12:00:00Z');
+
+			expect(formatRelativeTime(justUnderDay)).toBe('23 hours ago');
+			expect(formatRelativeTime(exactlyOneDay)).toBe('1 day ago');
+		});
+
+		it('should correctly handle 7 days boundary', () => {
+			const sixDays = new Date('2024-01-14T12:00:00Z');
+			const sevenDays = new Date('2024-01-13T12:00:00Z');
+
+			expect(formatRelativeTime(sixDays)).toBe('6 days ago');
+			const sevenDaysResult = formatRelativeTime(sevenDays);
+			expect(sevenDaysResult).not.toContain('days ago');
+			expect(sevenDaysResult).toMatch(/Jan|January/);
+		});
+	});
+
+	describe('Integration with Cache Status', () => {
+		it('should format cache age for recently generated summary', () => {
+			const cacheGeneratedAt = new Date('2024-01-20T11:55:00Z');
+			expect(formatRelativeTime(cacheGeneratedAt)).toBe('5 minutes ago');
+		});
+
+		it('should format cache age for summary from hours ago', () => {
+			const cacheGeneratedAt = new Date('2024-01-20T09:00:00Z');
+			expect(formatRelativeTime(cacheGeneratedAt)).toBe('3 hours ago');
+		});
+
+		it('should format cache age for stale summary from days ago', () => {
+			const cacheGeneratedAt = new Date('2024-01-18T12:00:00Z');
+			expect(formatRelativeTime(cacheGeneratedAt)).toBe('2 days ago');
+		});
+
+		it('should format cache age for very old summary', () => {
+			const cacheGeneratedAt = new Date('2023-12-20T12:00:00Z');
+			const result = formatRelativeTime(cacheGeneratedAt);
+			expect(result).toContain('Dec');
+			expect(result).toContain('20');
+		});
+	});
+});

--- a/src/lib/utils/timeFormat.ts
+++ b/src/lib/utils/timeFormat.ts
@@ -1,0 +1,63 @@
+/**
+ * Time Formatting Utilities
+ *
+ * Issue #62 & #134: Relationship Context UI with Cache Status
+ *
+ * Provides human-readable relative time formatting for displaying cache age.
+ */
+
+/**
+ * Formats a timestamp as a human-readable relative time string
+ * @param timestamp - Date, timestamp number, or ISO string
+ * @returns Human-readable relative time (e.g., "2 hours ago", "just now")
+ */
+export function formatRelativeTime(timestamp: Date | number | string): string {
+	// Convert input to Date object
+	const date = timestamp instanceof Date ? timestamp : new Date(timestamp);
+	const now = new Date();
+
+	// Calculate difference in seconds
+	const diffMs = now.getTime() - date.getTime();
+	const diffSeconds = Math.floor(diffMs / 1000);
+
+	// Handle future dates or just now (< 60 seconds)
+	if (diffSeconds < 60) {
+		return 'just now';
+	}
+
+	// Minutes ago (< 60 minutes)
+	const diffMinutes = Math.floor(diffSeconds / 60);
+	if (diffMinutes < 60) {
+		return `${diffMinutes} ${diffMinutes === 1 ? 'minute' : 'minutes'} ago`;
+	}
+
+	// Hours ago (< 24 hours)
+	const diffHours = Math.floor(diffMinutes / 60);
+	if (diffHours < 24) {
+		return `${diffHours} ${diffHours === 1 ? 'hour' : 'hours'} ago`;
+	}
+
+	// Days ago (< 7 days)
+	const diffDays = Math.floor(diffHours / 24);
+	if (diffDays < 7) {
+		return `${diffDays} ${diffDays === 1 ? 'day' : 'days'} ago`;
+	}
+
+	// 7 days or older: format as date
+	const isCurrentYear = date.getFullYear() === now.getFullYear();
+
+	if (isCurrentYear) {
+		// Same year: "Jan 13" format
+		return date.toLocaleDateString('en-US', {
+			month: 'short',
+			day: 'numeric'
+		});
+	} else {
+		// Different year: "Jan 13, 2023" format
+		return date.toLocaleDateString('en-US', {
+			month: 'short',
+			day: 'numeric',
+			year: 'numeric'
+		});
+	}
+}


### PR DESCRIPTION
## Summary

- Adds expandable Relationship Context UI to entity edit page for previewing AI context
- Shows cache status (valid/stale/missing) and age for relationship summaries
- Allows selecting/deselecting individual relationships for AI generation
- Enables on-demand regeneration of relationship summaries
- Displays token count estimates for context size awareness

## Features

**RelationshipContextSelector component:**
- Expandable section with relationship count badge
- Select All / Select None controls
- Cache status summary (valid/stale/missing counts)
- Total token count for selected relationships

**RelationshipContextItem component:**
- Checkbox to include/exclude from AI context
- Cache status badge with color coding
- Cache age display ("Cached 2 hours ago")
- Summary preview with truncation
- Token count per relationship
- Regenerate button with loading state

**timeFormat utility:**
- Relative time formatting ("just now", "5 minutes ago", etc.)

## Test plan

- [x] 118 unit tests covering all new components and utilities
- [x] TypeScript type checking passes for new code
- [ ] Manual testing: Navigate to entity edit page with relationships, verify selector appears
- [ ] Manual testing: Toggle relationships and verify AI generation uses selected ones
- [ ] Manual testing: Click regenerate and verify summary updates

Closes #62
Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)