### PR TITLE
feat(#16): add Draw Steel character sheet fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,13 @@ Director Assist includes 11 built-in entity types:
 Each entity type has custom fields relevant to its purpose. When you select a game system for your campaign, entity types automatically gain system-specific fields:
 
 **Draw Steel System Enhancements:**
-- **Characters**: Ancestry, Class, Kit, Heroic Resource
+- **Characters**:
+  - Identity: Ancestry, Heritage, Ancestry Trait
+  - Class: Class, Kit, Heroic Resource, Class Features
+  - Characteristics: Might, Agility, Reason, Intuition, Presence
+  - Skills with training levels (Trained, Expert, Master)
+  - Health: Max HP, Current HP, Vitality, Conditions
+  - Resources: XP, Gold, Weapons, Armor
 - **NPCs**: Threat Level (minion/standard/elite/boss/solo), Combat Role (ambusher, artillery, brute, etc.)
 - **Encounters**: Victory Points, Negotiation DC, system-specific encounter types (combat, negotiation, montage, exploration)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -275,11 +275,17 @@ interface SystemTerminology {
 
 2. **Draw Steel**
    - ID: `'draw-steel'`
-   - Custom fields for characters: ancestry, class, kit, heroicResource
+   - Custom fields for characters:
+     - Identity: ancestry, heritage, ancestryTrait
+     - Class: class, kit, heroicResource, classFeatures
+     - Characteristics: might, agility, reason, intuition, presence
+     - Skills: skills (with training levels)
+     - Health: maxHP, currentHP, vitality, conditions
+     - Resources: xp, gold, weapons, armor
    - Custom fields for NPCs: threatLevel (minion/standard/elite/boss/solo), role
    - Custom fields for encounters: victoryPoints, negotiationDC
    - Encounter types: combat, negotiation, montage, exploration, social, puzzle, trap
-   - Terminology: "Director" instead of "GM"
+   - Terminology: "Director" instead of "GM", "Characteristics" instead of "Ability Scores"
    - AI context includes Draw Steel mechanics and concepts
 
 **How System Profiles Work:**
@@ -339,9 +345,15 @@ async setSystemProfile(systemId: string): Promise<void>
 
 When a campaign uses the Draw Steel system profile, creating a character shows:
 - All standard character fields (background, goals, secrets)
-- Draw Steel-specific fields: Ancestry (dropdown), Class (dropdown), Kit (text), Heroic Resource (rich text)
+- Draw Steel-specific fields organized by category:
+  - Identity: Ancestry (dropdown), Heritage (text), Ancestry Trait (rich text)
+  - Class: Class (dropdown), Kit (text), Class Features (rich text), Heroic Resource (rich text)
+  - Characteristics: Might, Agility, Reason, Intuition, Presence (all number fields)
+  - Skills (rich text for listing skills with training levels)
+  - Health: Max HP, Current HP, Vitality (numbers), Conditions (tags)
+  - Resources: XP, Gold (numbers), Weapons, Armor (rich text)
 - Field order controlled by the `order` property in field definitions
-- AI generation understands Draw Steel terminology and mechanics
+- AI generation understands Draw Steel terminology and mechanics (e.g., "Characteristics" instead of "Ability Scores")
 
 #### BaseEntity
 All entity types extend this base structure.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -846,8 +846,14 @@ Director Assist supports multiple game systems with system-specific fields and t
 When you select a game system, entity forms automatically adapt to show system-appropriate fields:
 
 **Draw Steel System Adds:**
-- **Characters**: Ancestry, Class, Kit, Heroic Resource fields
-- **NPCs**: Threat Level (minion/standard/elite/boss/solo), Combat Role (ambusher, artillery, brute, controller, defender, harrier, hexer, lurker, skulker, support)
+- **Characters**:
+  - Identity: Ancestry, Heritage, Ancestry Trait
+  - Class: Class, Kit, Heroic Resource, Class Features
+  - Characteristics: Might, Agility, Reason, Intuition, Presence
+  - Skills with training levels (Trained, Expert, Master)
+  - Health: Max HP, Current HP, Vitality, Conditions
+  - Resources: XP, Gold, Weapons, Armor
+- **NPCs**: Threat Level (minion/standard/elite/boss/solo), Combat Role (ambusher, artillery, brute, controller, defender, harrier, hexer, leader, mount, support)
 - **Encounters**: Victory Points, Negotiation DC, system-specific encounter types (combat, negotiation, montage, exploration)
 
 **System Agnostic:**

--- a/src/lib/config/systems.test.ts
+++ b/src/lib/config/systems.test.ts
@@ -111,7 +111,8 @@ describe('systems.ts - System Profile Configuration', () => {
 				expect(ancestryField?.type).toBe('select');
 				expect(ancestryField?.options).toContain('Human');
 				expect(ancestryField?.options).toContain('Dwarf');
-				expect(ancestryField?.options).toContain('Elf');
+				expect(ancestryField?.options).toContain('High Elf');
+				expect(ancestryField?.options).toContain('Wode Elf');
 				expect(ancestryField?.options).toContain('Orc');
 				expect(ancestryField?.options).toContain('Dragon Knight');
 				expect(ancestryField?.options).toContain('Revenant');
@@ -135,6 +136,7 @@ describe('systems.ts - System Profile Configuration', () => {
 				expect(classField?.options).toContain('Censor');
 				expect(classField?.options).toContain('Conduit');
 				expect(classField?.options).toContain('Null');
+				expect(classField?.options).toContain('Troubadour');
 			});
 
 			it('should have heroicResource field as richtext type', () => {
@@ -146,6 +148,378 @@ describe('systems.ts - System Profile Configuration', () => {
 
 				expect(heroicResourceField).toBeDefined();
 				expect(heroicResourceField?.type).toBe('richtext');
+			});
+
+			// RED Phase Tests for Issue #16: Customize Character Sheet Fields
+			// These tests define new character fields that will be added to Draw Steel profile
+
+			describe('Identity Fields (order 14-15)', () => {
+				it('should have heritage field as text type with correct properties', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+					const heritageField = characterMods?.additionalFields?.find((f) => f.key === 'heritage');
+
+					expect(heritageField).toBeDefined();
+					expect(heritageField?.label).toBe('Heritage');
+					expect(heritageField?.type).toBe('text');
+					expect(heritageField?.order).toBe(14);
+					expect(heritageField?.required).toBe(false);
+				});
+
+				it('should have ancestryTrait field as richtext type with correct properties', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+					const ancestryTraitField = characterMods?.additionalFields?.find(
+						(f) => f.key === 'ancestryTrait'
+					);
+
+					expect(ancestryTraitField).toBeDefined();
+					expect(ancestryTraitField?.label).toBe('Ancestry Trait');
+					expect(ancestryTraitField?.type).toBe('richtext');
+					expect(ancestryTraitField?.order).toBe(15);
+					expect(ancestryTraitField?.required).toBe(false);
+				});
+			});
+
+			describe('Ability Scores (order 20-24)', () => {
+				it('should have might field as number type with correct properties', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+					const mightField = characterMods?.additionalFields?.find((f) => f.key === 'might');
+
+					expect(mightField).toBeDefined();
+					expect(mightField?.label).toBe('Might');
+					expect(mightField?.type).toBe('number');
+					expect(mightField?.order).toBe(20);
+					expect(mightField?.required).toBe(false);
+				});
+
+				it('should have agility field as number type with correct properties', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+					const agilityField = characterMods?.additionalFields?.find((f) => f.key === 'agility');
+
+					expect(agilityField).toBeDefined();
+					expect(agilityField?.label).toBe('Agility');
+					expect(agilityField?.type).toBe('number');
+					expect(agilityField?.order).toBe(21);
+					expect(agilityField?.required).toBe(false);
+				});
+
+				it('should have reason field as number type with correct properties', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+					const reasonField = characterMods?.additionalFields?.find((f) => f.key === 'reason');
+
+					expect(reasonField).toBeDefined();
+					expect(reasonField?.label).toBe('Reason');
+					expect(reasonField?.type).toBe('number');
+					expect(reasonField?.order).toBe(22);
+					expect(reasonField?.required).toBe(false);
+				});
+
+				it('should have intuition field as number type with correct properties', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+					const intuitionField = characterMods?.additionalFields?.find((f) => f.key === 'intuition');
+
+					expect(intuitionField).toBeDefined();
+					expect(intuitionField?.label).toBe('Intuition');
+					expect(intuitionField?.type).toBe('number');
+					expect(intuitionField?.order).toBe(23);
+					expect(intuitionField?.required).toBe(false);
+				});
+
+				it('should have presence field as number type with correct properties', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+					const presenceField = characterMods?.additionalFields?.find((f) => f.key === 'presence');
+
+					expect(presenceField).toBeDefined();
+					expect(presenceField?.label).toBe('Presence');
+					expect(presenceField?.type).toBe('number');
+					expect(presenceField?.order).toBe(24);
+					expect(presenceField?.required).toBe(false);
+				});
+
+				it('should have all five ability scores in sequential order', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+					const fields = characterMods?.additionalFields ?? [];
+
+					const abilityScores = [
+						{ key: 'might', order: 20 },
+						{ key: 'agility', order: 21 },
+						{ key: 'reason', order: 22 },
+						{ key: 'intuition', order: 23 },
+						{ key: 'presence', order: 24 }
+					];
+
+					abilityScores.forEach(({ key, order }) => {
+						const field = fields.find((f) => f.key === key);
+						expect(field).toBeDefined();
+						expect(field?.order).toBe(order);
+						expect(field?.type).toBe('number');
+					});
+				});
+			});
+
+			describe('Skills & Abilities (order 30)', () => {
+				it('should have skills field as richtext type with correct properties', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+					const skillsField = characterMods?.additionalFields?.find((f) => f.key === 'skills');
+
+					expect(skillsField).toBeDefined();
+					expect(skillsField?.label).toBe('Skills');
+					expect(skillsField?.type).toBe('richtext');
+					expect(skillsField?.order).toBe(30);
+					expect(skillsField?.required).toBe(false);
+				});
+			});
+
+			describe('Health & Vitality (order 40-43)', () => {
+				it('should have maxHP field as number type with correct properties', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+					const maxHPField = characterMods?.additionalFields?.find((f) => f.key === 'maxHP');
+
+					expect(maxHPField).toBeDefined();
+					expect(maxHPField?.label).toBe('Max HP');
+					expect(maxHPField?.type).toBe('number');
+					expect(maxHPField?.order).toBe(40);
+					expect(maxHPField?.required).toBe(false);
+				});
+
+				it('should have currentHP field as number type with correct properties', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+					const currentHPField = characterMods?.additionalFields?.find((f) => f.key === 'currentHP');
+
+					expect(currentHPField).toBeDefined();
+					expect(currentHPField?.label).toBe('Current HP');
+					expect(currentHPField?.type).toBe('number');
+					expect(currentHPField?.order).toBe(41);
+					expect(currentHPField?.required).toBe(false);
+				});
+
+				it('should have vitality field as number type with correct properties', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+					const vitalityField = characterMods?.additionalFields?.find((f) => f.key === 'vitality');
+
+					expect(vitalityField).toBeDefined();
+					expect(vitalityField?.label).toBe('Vitality');
+					expect(vitalityField?.type).toBe('number');
+					expect(vitalityField?.order).toBe(42);
+					expect(vitalityField?.required).toBe(false);
+				});
+
+				it('should have conditions field as tags type with correct properties', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+					const conditionsField = characterMods?.additionalFields?.find((f) => f.key === 'conditions');
+
+					expect(conditionsField).toBeDefined();
+					expect(conditionsField?.label).toBe('Conditions');
+					expect(conditionsField?.type).toBe('tags');
+					expect(conditionsField?.order).toBe(43);
+					expect(conditionsField?.required).toBe(false);
+				});
+
+				it('should have all health & vitality fields in sequential order', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+					const fields = characterMods?.additionalFields ?? [];
+
+					const healthFields = [
+						{ key: 'maxHP', order: 40, type: 'number' },
+						{ key: 'currentHP', order: 41, type: 'number' },
+						{ key: 'vitality', order: 42, type: 'number' },
+						{ key: 'conditions', order: 43, type: 'tags' }
+					];
+
+					healthFields.forEach(({ key, order, type }) => {
+						const field = fields.find((f) => f.key === key);
+						expect(field).toBeDefined();
+						expect(field?.order).toBe(order);
+						expect(field?.type).toBe(type);
+					});
+				});
+			});
+
+			describe('Resources (order 50-53)', () => {
+				it('should have xp field as number type with correct properties', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+					const xpField = characterMods?.additionalFields?.find((f) => f.key === 'xp');
+
+					expect(xpField).toBeDefined();
+					expect(xpField?.label).toBe('XP');
+					expect(xpField?.type).toBe('number');
+					expect(xpField?.order).toBe(50);
+					expect(xpField?.required).toBe(false);
+				});
+
+				it('should have gold field as number type with correct properties', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+					const goldField = characterMods?.additionalFields?.find((f) => f.key === 'gold');
+
+					expect(goldField).toBeDefined();
+					expect(goldField?.label).toBe('Gold');
+					expect(goldField?.type).toBe('number');
+					expect(goldField?.order).toBe(51);
+					expect(goldField?.required).toBe(false);
+				});
+
+				it('should have weapons field as richtext type with correct properties', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+					const weaponsField = characterMods?.additionalFields?.find((f) => f.key === 'weapons');
+
+					expect(weaponsField).toBeDefined();
+					expect(weaponsField?.label).toBe('Weapons');
+					expect(weaponsField?.type).toBe('richtext');
+					expect(weaponsField?.order).toBe(52);
+					expect(weaponsField?.required).toBe(false);
+				});
+
+				it('should have armor field as richtext type with correct properties', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+					const armorField = characterMods?.additionalFields?.find((f) => f.key === 'armor');
+
+					expect(armorField).toBeDefined();
+					expect(armorField?.label).toBe('Armor');
+					expect(armorField?.type).toBe('richtext');
+					expect(armorField?.order).toBe(53);
+					expect(armorField?.required).toBe(false);
+				});
+
+				it('should have all resource fields in sequential order', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+					const fields = characterMods?.additionalFields ?? [];
+
+					const resourceFields = [
+						{ key: 'xp', order: 50, type: 'number' },
+						{ key: 'gold', order: 51, type: 'number' },
+						{ key: 'weapons', order: 52, type: 'richtext' },
+						{ key: 'armor', order: 53, type: 'richtext' }
+					];
+
+					resourceFields.forEach(({ key, order, type }) => {
+						const field = fields.find((f) => f.key === key);
+						expect(field).toBeDefined();
+						expect(field?.order).toBe(order);
+						expect(field?.type).toBe(type);
+					});
+				});
+			});
+
+			describe('Class Features (order 60)', () => {
+				it('should have classFeatures field as richtext type with correct properties', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+					const classFeaturesField = characterMods?.additionalFields?.find(
+						(f) => f.key === 'classFeatures'
+					);
+
+					expect(classFeaturesField).toBeDefined();
+					expect(classFeaturesField?.label).toBe('Class Features');
+					expect(classFeaturesField?.type).toBe('richtext');
+					expect(classFeaturesField?.order).toBe(60);
+					expect(classFeaturesField?.required).toBe(false);
+				});
+			});
+
+			describe('Field Organization and Ordering', () => {
+				it('should maintain logical order ranges for all new fields', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+					const fields = characterMods?.additionalFields ?? [];
+
+					// Verify order ranges are respected
+					const identityFields = fields.filter((f) => f.order >= 14 && f.order <= 15);
+					const abilityFields = fields.filter((f) => f.order >= 20 && f.order <= 24);
+					const skillFields = fields.filter((f) => f.order === 30);
+					const healthFields = fields.filter((f) => f.order >= 40 && f.order <= 43);
+					const resourceFields = fields.filter((f) => f.order >= 50 && f.order <= 53);
+					const featureFields = fields.filter((f) => f.order === 60);
+
+					// Verify expected counts for new fields
+					expect(identityFields.length).toBeGreaterThanOrEqual(2);
+					expect(abilityFields.length).toBeGreaterThanOrEqual(5);
+					expect(skillFields.length).toBeGreaterThanOrEqual(1);
+					expect(healthFields.length).toBeGreaterThanOrEqual(4);
+					expect(resourceFields.length).toBeGreaterThanOrEqual(4);
+					expect(featureFields.length).toBeGreaterThanOrEqual(1);
+				});
+
+				it('should have all new fields with unique keys', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+					const fields = characterMods?.additionalFields ?? [];
+
+					const newFieldKeys = [
+						'heritage',
+						'ancestryTrait',
+						'might',
+						'agility',
+						'reason',
+						'intuition',
+						'presence',
+						'skills',
+						'maxHP',
+						'currentHP',
+						'vitality',
+						'conditions',
+						'xp',
+						'gold',
+						'weapons',
+						'armor',
+						'classFeatures'
+					];
+
+					newFieldKeys.forEach((key) => {
+						const matchingFields = fields.filter((f) => f.key === key);
+						expect(matchingFields.length).toBeLessThanOrEqual(1);
+					});
+				});
+
+				it('should have all new fields as non-required', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+					const fields = characterMods?.additionalFields ?? [];
+
+					const newFieldKeys = [
+						'heritage',
+						'ancestryTrait',
+						'might',
+						'agility',
+						'reason',
+						'intuition',
+						'presence',
+						'skills',
+						'maxHP',
+						'currentHP',
+						'vitality',
+						'conditions',
+						'xp',
+						'gold',
+						'weapons',
+						'armor',
+						'classFeatures'
+					];
+
+					newFieldKeys.forEach((key) => {
+						const field = fields.find((f) => f.key === key);
+						if (field) {
+							expect(field.required).toBe(false);
+						}
+					});
+				});
 			});
 
 			it('should have threatLevel field as select type with specific options', () => {

--- a/src/lib/config/systems.ts
+++ b/src/lib/config/systems.ts
@@ -16,19 +16,18 @@ export const DRAW_STEEL_PROFILE: SystemProfile = {
 					label: 'Ancestry',
 					type: 'select',
 					options: [
-						'Human',
+						'Devil',
+						'Dragon Knight',
 						'Dwarf',
-						'Elf',
-						'Wode Elf',
+						'Hakaan',
 						'High Elf',
+						'Human',
+						'Memonek',
 						'Orc',
 						'Polder',
-						'Dragon Knight',
-						'Devil',
-						'Hakaan',
-						'Memonek',
 						'Revenant',
-						'Time Raider'
+						'Time Raider',
+						'Wode Elf'
 					],
 					required: false,
 					order: 10
@@ -38,14 +37,15 @@ export const DRAW_STEEL_PROFILE: SystemProfile = {
 					label: 'Class',
 					type: 'select',
 					options: [
-						'Tactician',
-						'Fury',
-						'Shadow',
-						'Elementalist',
-						'Talent',
 						'Censor',
 						'Conduit',
-						'Null'
+						'Elementalist',
+						'Fury',
+						'Null',
+						'Shadow',
+						'Tactician',
+						'Talent',
+						'Troubadour'
 					],
 					required: false,
 					order: 11
@@ -57,12 +57,146 @@ export const DRAW_STEEL_PROFILE: SystemProfile = {
 					required: false,
 					order: 12
 				},
+				// Identity Fields
+				{
+					key: 'heritage',
+					label: 'Heritage',
+					type: 'text',
+					helpText: 'Your character\'s specific subspecies or cultural variant within their ancestry',
+					required: false,
+					order: 14
+				},
+				{
+					key: 'ancestryTrait',
+					label: 'Ancestry Trait',
+					type: 'richtext',
+					helpText: 'The mechanical benefit granted by your ancestry',
+					required: false,
+					order: 15
+				},
+				// Ability Scores
+				{
+					key: 'might',
+					label: 'Might',
+					type: 'number',
+					helpText: 'Physical power and strength (typically ranges from -2 to +4)',
+					required: false,
+					order: 20
+				},
+				{
+					key: 'agility',
+					label: 'Agility',
+					type: 'number',
+					helpText: 'Speed, reflexes, and coordination',
+					required: false,
+					order: 21
+				},
+				{
+					key: 'reason',
+					label: 'Reason',
+					type: 'number',
+					helpText: 'Logic, education, and mental acuity',
+					required: false,
+					order: 22
+				},
+				{
+					key: 'intuition',
+					label: 'Intuition',
+					type: 'number',
+					helpText: 'Instincts, experience, and awareness',
+					required: false,
+					order: 23
+				},
+				{
+					key: 'presence',
+					label: 'Presence',
+					type: 'number',
+					helpText: 'Personality, charisma, and social influence',
+					required: false,
+					order: 24
+				},
+				// Skills
+				{
+					key: 'skills',
+					label: 'Skills',
+					type: 'richtext',
+					helpText: 'List your skills with their training levels (Trained, Expert, Master)',
+					required: false,
+					order: 30
+				},
+				// Health & Vitality
+				{
+					key: 'maxHP',
+					label: 'Max HP',
+					type: 'number',
+					required: false,
+					order: 40
+				},
+				{
+					key: 'currentHP',
+					label: 'Current HP',
+					type: 'number',
+					required: false,
+					order: 41
+				},
+				{
+					key: 'vitality',
+					label: 'Vitality',
+					type: 'number',
+					required: false,
+					order: 42
+				},
+				{
+					key: 'conditions',
+					label: 'Conditions',
+					type: 'tags',
+					helpText: 'Active conditions affecting the character',
+					required: false,
+					order: 43
+				},
+				// Resources
+				{
+					key: 'xp',
+					label: 'XP',
+					type: 'number',
+					required: false,
+					order: 50
+				},
+				{
+					key: 'gold',
+					label: 'Gold',
+					type: 'number',
+					required: false,
+					order: 51
+				},
+				{
+					key: 'weapons',
+					label: 'Weapons',
+					type: 'richtext',
+					required: false,
+					order: 52
+				},
+				{
+					key: 'armor',
+					label: 'Armor',
+					type: 'richtext',
+					required: false,
+					order: 53
+				},
+				// Class Features
+				{
+					key: 'classFeatures',
+					label: 'Class Features',
+					type: 'richtext',
+					required: false,
+					order: 60
+				},
 				{
 					key: 'heroicResource',
 					label: 'Heroic Resource',
 					type: 'richtext',
 					required: false,
-					order: 13
+					order: 61
 				}
 			]
 		},
@@ -131,12 +265,18 @@ export const DRAW_STEEL_PROFILE: SystemProfile = {
 		systemDescription:
 			'Draw Steel is a tactical fantasy RPG with hero-focused combat, tactical positioning, and narrative flexibility.',
 		keyMechanics: [
+			'Characteristics: Might, Agility, Reason, Intuition, Presence (typically ranging from -2 to +4)',
 			'Heroic resources for unique character abilities',
+			'Skills with training levels: Trained, Expert, Master',
+			'HP (hit points), Vitality for recovering damage',
+			'Conditions for status effects',
 			'Victory points for dynamic combat objectives',
 			'Negotiation encounters with DC-based resolution',
 			'Montage scenes for downtime activities',
 			'Threat levels: Minion, Standard, Elite, Boss, Solo',
-			'Combat roles: Ambusher, Artillery, Brute, Controller, Defender, Harrier, Hexer, Leader, Mount, Support'
+			'Combat roles: Ambusher, Artillery, Brute, Controller, Defender, Harrier, Hexer, Leader, Mount, Support',
+			'Character identity: Ancestry, Heritage, Ancestry Traits',
+			'Class features and Kits for character customization'
 		],
 		preferredTerms: {
 			gm: 'Director',


### PR DESCRIPTION
## Summary
- Adds 17 new character fields to Draw Steel system profile for comprehensive character sheet support
- Implements proper Draw Steel terminology (Characteristics: Might, Agility, Reason, Intuition, Presence)
- Adds Troubadour class and fixes ancestry list accuracy

## Changes
### New Character Fields
| Category | Fields | Type |
|----------|--------|------|
| Identity | heritage, ancestryTrait | text, richtext |
| Characteristics | might, agility, reason, intuition, presence | number |
| Skills | skills | richtext |
| Health | maxHP, currentHP, vitality, conditions | number, tags |
| Resources | xp, gold, weapons, armor | number, richtext |
| Class | classFeatures | richtext |

### Draw Steel Accuracy Fixes
- Renamed "Intellect" → "Reason", "Will" → "Intuition" (correct Draw Steel terminology)
- Removed generic "Elf" ancestry (only High Elf, Wode Elf exist in official rules)
- Added "Troubadour" class (now 9 classes total, alphabetically sorted)
- Updated aiContext.keyMechanics with "Characteristics" terminology

## Test plan
- [x] All 62 systems.test.ts tests pass
- [x] Verified field types, labels, and ordering
- [x] Verified Draw Steel accuracy via draw-steel-web-reviewer agent

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)