### PR TITLE
feat(#124): allow adding relationships during entity creation

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -207,7 +207,22 @@ One of Director Assist's most powerful features is the ability to create relatio
 
 ### Creating a Relationship
 
-**Method 1: From the Entity Detail Page**
+**Method 1: During Entity Creation**
+
+You can now add relationships while creating a new entity, before the first save:
+
+1. Fill in the entity creation form (name, description, etc.)
+2. Scroll to the "Relationships" section
+3. Click "Add Relationship"
+4. Select the target entity from the dropdown
+5. Choose a relationship type (knows, allied_with, located_at, etc.)
+6. Optionally make it bidirectional (both entities show the link)
+7. Add relationship strength (strong, moderate, weak)
+8. Add tags or tension level if relevant
+9. Click "Create Link"
+10. The relationship will be saved when you create the entity
+
+**Method 2: From the Entity Detail Page**
 
 1. View any entity's details
 2. Scroll to the "Relationships" section
@@ -219,13 +234,13 @@ One of Director Assist's most powerful features is the ability to create relatio
 8. Add tags or tension level if relevant
 9. Click "Create Link"
 
-**Method 2: Using the Command Palette**
+**Method 3: Using the Command Palette**
 
 1. View any entity's details
 2. Press Cmd+K (Mac) or Ctrl+K (Windows)
 3. Type "/relate"
 4. Press Enter
-5. Follow the same steps as Method 1
+5. Follow the same steps as Method 2
 
 ### Relationship Types
 

--- a/src/lib/components/entity/CreateRelateCommand.svelte
+++ b/src/lib/components/entity/CreateRelateCommand.svelte
@@ -1,0 +1,478 @@
+<script lang="ts">
+	import { entitiesStore } from '$lib/stores';
+	import { getEntityTypeDefinition } from '$lib/config/entityTypes';
+	import { campaignStore } from '$lib/stores';
+	import { X, Search, Check, EyeOff } from 'lucide-svelte';
+	import { nanoid } from 'nanoid';
+	import type { BaseEntity, EntityType, PendingRelationship } from '$lib/types';
+
+	interface Props {
+		entityType: EntityType;
+		open?: boolean;
+		onClose?: () => void;
+		onSubmit?: (relationship: PendingRelationship) => void;
+	}
+
+	let { entityType, open = $bindable(false), onClose, onSubmit }: Props = $props();
+
+	let searchQuery = $state('');
+	let selectedEntity = $state<BaseEntity | null>(null);
+	let relationship = $state('');
+	let notes = $state('');
+	let bidirectional = $state(true);
+	let strength = $state<'none' | 'strong' | 'moderate' | 'weak'>('none');
+	let tags = $state('');
+	let tension = $state(0);
+	let showAsymmetricOptions = $state(false);
+	let reverseRelationship = $state('');
+	let playerVisible = $state<boolean | undefined>(undefined);
+	let errorMessage = $state('');
+
+	// Common relationship options
+	const commonRelationships = [
+		'member_of',
+		'has_member',
+		'located_at',
+		'contains',
+		'owns',
+		'owned_by',
+		'allied_with',
+		'enemy_of',
+		'parent_of',
+		'child_of',
+		'knows',
+		'friend_of',
+		'created_by',
+		'leads'
+	];
+
+	// Filter entities based on search
+	const filteredEntities = $derived.by(() => {
+		const query = searchQuery.toLowerCase();
+
+		return entitiesStore.entities.filter((e) => {
+			// Apply search filter
+			if (query) {
+				return (
+					e.name.toLowerCase().includes(query) ||
+					e.description.toLowerCase().includes(query) ||
+					e.type.toLowerCase().includes(query)
+				);
+			}
+
+			return true;
+		});
+	});
+
+	function handleClose() {
+		searchQuery = '';
+		selectedEntity = null;
+		relationship = '';
+		notes = '';
+		bidirectional = true;
+		strength = 'none';
+		tags = '';
+		tension = 0;
+		showAsymmetricOptions = false;
+		reverseRelationship = '';
+		playerVisible = undefined;
+		errorMessage = '';
+		open = false;
+		onClose?.();
+	}
+
+	function selectEntity(entity: BaseEntity) {
+		selectedEntity = entity;
+		searchQuery = '';
+	}
+
+	function handleSubmit() {
+		if (!selectedEntity || !relationship.trim()) {
+			errorMessage = 'Please select an entity and enter a relationship';
+			return;
+		}
+
+		errorMessage = '';
+
+		// Parse strength: convert "none" to undefined
+		const finalStrength = strength === 'none' ? undefined : strength;
+
+		// Parse tags: split by comma, trim, and filter out empty strings
+		const parsedTags = tags.trim()
+			? tags
+					.split(',')
+					.map((t) => t.trim())
+					.filter((t) => t.length > 0)
+			: [];
+
+		// Build metadata object
+		const metadata: Record<string, any> = {};
+		if (parsedTags.length > 0) {
+			metadata.tags = parsedTags;
+		}
+		// Always include tension (even if 0)
+		if (tension !== 0) {
+			metadata.tension = tension;
+		}
+
+		// Parse reverseRelationship: pass trimmed value if asymmetric is enabled and non-empty
+		const finalReverseRelationship =
+			showAsymmetricOptions && reverseRelationship.trim()
+				? reverseRelationship.trim()
+				: undefined;
+
+		// Create pending relationship
+		const pendingRel: PendingRelationship = {
+			tempId: nanoid(),
+			targetId: selectedEntity.id,
+			targetType: selectedEntity.type,
+			relationship: relationship.trim(),
+			bidirectional,
+			notes: notes.trim() || undefined,
+			strength: finalStrength,
+			metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+			reverseRelationship: finalReverseRelationship,
+			playerVisible
+		};
+
+		onSubmit?.(pendingRel);
+		handleClose();
+	}
+
+	// Clear reverseRelationship when showAsymmetricOptions is unchecked
+	$effect(() => {
+		if (!showAsymmetricOptions) {
+			reverseRelationship = '';
+		}
+	});
+
+	// Close on escape key
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			handleClose();
+		}
+	}
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+{#if open}
+	<div
+		class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+		onclick={handleClose}
+		role="presentation"
+	>
+		<div
+			class="bg-white dark:bg-slate-800 rounded-lg shadow-xl max-w-2xl w-full max-h-[80vh] overflow-hidden"
+			onclick={(e) => e.stopPropagation()}
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="create-relate-command-title"
+		>
+			<!-- Header -->
+			<div
+				class="flex items-center justify-between p-4 border-b border-slate-200 dark:border-slate-700"
+			>
+				<h2
+					id="create-relate-command-title"
+					class="text-lg font-semibold text-slate-900 dark:text-white"
+				>
+					Add Relationship
+				</h2>
+				<button
+					onclick={handleClose}
+					class="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200"
+					aria-label="Close"
+				>
+					<X class="w-5 h-5" />
+				</button>
+			</div>
+
+			<!-- Content -->
+			<div class="p-4">
+				{#if !selectedEntity}
+					<!-- Search for entity -->
+					<div class="mb-4">
+						<label
+							class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2"
+						>
+							Search for entity to link
+						</label>
+						<div class="relative">
+							<Search
+								class="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-slate-400"
+							/>
+							<input
+								type="text"
+								bind:value={searchQuery}
+								placeholder="Search entities..."
+								class="w-full pl-10 pr-4 py-2 border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-700 text-slate-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+								autofocus
+							/>
+						</div>
+					</div>
+
+					<!-- Entity list -->
+					<div class="max-h-[400px] overflow-y-auto space-y-2">
+						{#if filteredEntities.length === 0}
+							<p class="text-center text-slate-500 dark:text-slate-400 py-8">
+								{searchQuery ? 'No entities found' : 'No available entities to link'}
+							</p>
+						{:else}
+							{#each filteredEntities as entity}
+								{@const typeDefinition = getEntityTypeDefinition(
+									entity.type,
+									campaignStore.customEntityTypes,
+									campaignStore.entityTypeOverrides
+								)}
+								<button
+									onclick={() => selectEntity(entity)}
+									class="w-full text-left p-3 rounded-lg border border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors"
+								>
+									<div class="flex items-center gap-3">
+										<div
+											class="w-2 h-2 rounded-full flex-shrink-0"
+											style="background-color: {typeDefinition?.color ?? '#94a3b8'}"
+										></div>
+										<div class="flex-1 min-w-0">
+											<div class="font-medium text-slate-900 dark:text-white truncate">
+												{entity.name}
+											</div>
+											<div class="text-sm text-slate-500 dark:text-slate-400 truncate">
+												{typeDefinition?.label ?? entity.type}
+												{#if entity.description}
+													&bull; {entity.description.substring(0, 100)}
+												{/if}
+											</div>
+										</div>
+									</div>
+								</button>
+							{/each}
+						{/if}
+					</div>
+				{:else}
+					<!-- Selected entity and relationship form -->
+					<div class="space-y-4">
+						<!-- Selected entity -->
+						{#if selectedEntity}
+							{@const typeDefinition = getEntityTypeDefinition(
+								selectedEntity.type,
+								campaignStore.customEntityTypes,
+								campaignStore.entityTypeOverrides
+							)}
+							<div
+								class="p-3 bg-slate-50 dark:bg-slate-700 rounded-lg border border-slate-200 dark:border-slate-600"
+							>
+								<div class="flex items-center justify-between">
+									<div>
+										<div class="font-medium text-slate-900 dark:text-white">
+											{selectedEntity.name}
+										</div>
+										<div class="text-sm text-slate-500 dark:text-slate-400">
+											{typeDefinition?.label ?? selectedEntity.type}
+										</div>
+									</div>
+									<button
+										onclick={() => (selectedEntity = null)}
+										class="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200"
+										aria-label="Clear selection"
+									>
+										<X class="w-5 h-5" />
+									</button>
+								</div>
+							</div>
+						{/if}
+
+						<!-- Relationship input -->
+						<div>
+							<label
+								for="relationship"
+								class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2"
+							>
+								Relationship
+							</label>
+							<input
+								id="relationship"
+								type="text"
+								bind:value={relationship}
+								placeholder="e.g., member_of, knows, located_at"
+								list="common-relationships"
+								class="w-full px-4 py-2 border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-700 text-slate-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+							/>
+							<datalist id="common-relationships">
+								{#each commonRelationships as rel}
+									<option value={rel}>{rel.replace(/_/g, ' ')}</option>
+								{/each}
+							</datalist>
+							<p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
+								How this entity relates to {selectedEntity.name}
+							</p>
+						</div>
+
+						<!-- Notes textarea -->
+						<div>
+							<label
+								for="notes"
+								class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2"
+							>
+								Notes
+							</label>
+							<textarea
+								id="notes"
+								bind:value={notes}
+								placeholder="Optional notes about this relationship..."
+								rows="3"
+								class="w-full px-4 py-2 border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-700 text-slate-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-y"
+							></textarea>
+						</div>
+
+						<!-- Strength selector -->
+						<div>
+							<label
+								for="strength"
+								class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2"
+							>
+								Strength
+							</label>
+							<select
+								id="strength"
+								bind:value={strength}
+								class="w-full px-4 py-2 border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-700 text-slate-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+							>
+								<option value="none">None</option>
+								<option value="strong">Strong</option>
+								<option value="moderate">Moderate</option>
+								<option value="weak">Weak</option>
+							</select>
+						</div>
+
+						<!-- Tags input -->
+						<div>
+							<label
+								for="tags"
+								class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2"
+							>
+								Tags
+							</label>
+							<input
+								id="tags"
+								type="text"
+								bind:value={tags}
+								placeholder="Enter comma-separated tags..."
+								class="w-full px-4 py-2 border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-700 text-slate-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+							/>
+						</div>
+
+						<!-- Tension slider -->
+						<div>
+							<label
+								for="tension"
+								class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2"
+							>
+								Tension: {tension}
+							</label>
+							<input
+								id="tension"
+								type="range"
+								min="0"
+								max="100"
+								bind:value={tension}
+								class="w-full h-2 bg-slate-200 dark:bg-slate-700 rounded-lg appearance-none cursor-pointer accent-blue-600"
+							/>
+						</div>
+
+						<!-- Bidirectional checkbox -->
+						<div class="flex items-center gap-2">
+							<input
+								id="bidirectional"
+								type="checkbox"
+								bind:checked={bidirectional}
+								class="w-4 h-4 text-blue-600 bg-white dark:bg-slate-700 border-slate-300 dark:border-slate-600 rounded focus:ring-blue-500"
+							/>
+							<label for="bidirectional" class="text-sm text-slate-700 dark:text-slate-300">
+								Bidirectional (also create reverse link)
+							</label>
+						</div>
+
+						<!-- Asymmetric relationship options (only shown when bidirectional is true) -->
+						{#if bidirectional}
+							<div class="flex items-center gap-2">
+								<input
+									id="asymmetric"
+									type="checkbox"
+									bind:checked={showAsymmetricOptions}
+									class="w-4 h-4 text-blue-600 bg-white dark:bg-slate-700 border-slate-300 dark:border-slate-600 rounded focus:ring-blue-500"
+								/>
+								<label for="asymmetric" class="text-sm text-slate-700 dark:text-slate-300">
+									Use different relationship for reverse link
+								</label>
+							</div>
+
+							{#if showAsymmetricOptions}
+								<div>
+									<label
+										for="reverse-relationship"
+										class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2"
+									>
+										Reverse Relationship
+									</label>
+									<input
+										id="reverse-relationship"
+										type="text"
+										bind:value={reverseRelationship}
+										placeholder="Reverse direction (e.g., has_member, employs)"
+										class="w-full px-4 py-2 border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-700 text-slate-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+									/>
+									<p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
+										How {selectedEntity.name} relates back to this entity
+									</p>
+								</div>
+							{/if}
+						{/if}
+
+						<!-- Player Visibility -->
+						<div class="flex items-center gap-2">
+							<input
+								id="player-visible"
+								type="checkbox"
+								checked={playerVisible === false}
+								onchange={(e) => {
+									playerVisible = e.currentTarget.checked ? false : undefined;
+								}}
+								class="w-4 h-4 text-blue-600 bg-white dark:bg-slate-700 border-slate-300 dark:border-slate-600 rounded focus:ring-blue-500"
+							/>
+							<label
+								for="player-visible"
+								class="flex items-center gap-1 text-sm text-slate-700 dark:text-slate-300"
+							>
+								<EyeOff class="w-4 h-4 text-amber-500" />
+								Hide from players (DM only)
+							</label>
+						</div>
+
+						{#if errorMessage}
+							<div
+								class="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-red-700 dark:text-red-300 text-sm"
+							>
+								{errorMessage}
+							</div>
+						{/if}
+
+						<!-- Submit buttons -->
+						<div class="flex gap-2 justify-end">
+							<button onclick={handleClose} class="btn btn-ghost"> Cancel </button>
+							<button
+								onclick={handleSubmit}
+								class="btn btn-primary"
+								disabled={!relationship.trim()}
+							>
+								<Check class="w-4 h-4" />
+								Add Relationship
+							</button>
+						</div>
+					</div>
+				{/if}
+			</div>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/entity/PendingRelationshipList.svelte
+++ b/src/lib/components/entity/PendingRelationshipList.svelte
@@ -1,0 +1,166 @@
+<script lang="ts">
+	import { X, ArrowRight, ArrowLeftRight } from 'lucide-svelte';
+	import { entitiesStore } from '$lib/stores';
+	import { getEntityTypeDefinition } from '$lib/config/entityTypes';
+	import { campaignStore } from '$lib/stores';
+	import type { PendingRelationship } from '$lib/types';
+
+	interface Props {
+		relationships: PendingRelationship[];
+		onRemove: (tempId: string) => void;
+	}
+
+	let { relationships, onRemove }: Props = $props();
+
+	function getEntityName(entityId: string): string {
+		const entity = entitiesStore.getById(entityId);
+		return entity?.name || '(Unknown)';
+	}
+
+	function getEntityType(entityId: string): string {
+		const entity = entitiesStore.getById(entityId);
+		if (!entity) return '';
+		const typeDef = getEntityTypeDefinition(
+			entity.type,
+			campaignStore.customEntityTypes,
+			campaignStore.entityTypeOverrides
+		);
+		return typeDef?.label ?? entity.type;
+	}
+
+	function getStrengthClasses(strength: 'strong' | 'moderate' | 'weak' | undefined): string {
+		switch (strength) {
+			case 'strong':
+				return 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300';
+			case 'moderate':
+				return 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-300';
+			case 'weak':
+				return 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300';
+			default:
+				return '';
+		}
+	}
+</script>
+
+{#if relationships.length === 0}
+	<div class="text-center py-8 text-slate-500 dark:text-slate-400">
+		<p>No relationships added yet</p>
+		<p class="text-sm mt-1">Add relationships to link this entity when it's created</p>
+	</div>
+{:else}
+	<div class="space-y-3">
+		{#each relationships as rel}
+			<div
+				class="border border-slate-200 dark:border-slate-700 rounded-lg p-3 bg-white dark:bg-slate-800 hover:shadow-md transition-shadow group relative"
+			>
+				<!-- Header with entity name and type -->
+				<div class="flex items-start justify-between mb-2">
+					<div class="flex-1 min-w-0">
+						<div class="text-base font-semibold text-slate-900 dark:text-white">
+							{getEntityName(rel.targetId)}
+						</div>
+						<div class="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+							{getEntityType(rel.targetId)}
+						</div>
+					</div>
+
+					<!-- Remove button -->
+					<button
+						onclick={() => onRemove(rel.tempId)}
+						class="opacity-0 group-hover:opacity-100 transition-opacity p-1.5 hover:bg-red-50 dark:hover:bg-red-900/20 rounded text-red-600 dark:text-red-400"
+						aria-label="Remove relationship"
+						type="button"
+					>
+						<X class="w-4 h-4" />
+					</button>
+				</div>
+
+				<!-- Relationship -->
+				<div class="flex items-center gap-2 mb-2">
+					<span class="text-sm font-medium text-slate-600 dark:text-slate-400">
+						{rel.relationship}
+					</span>
+
+					{#if rel.bidirectional}
+						{#if rel.reverseRelationship && rel.reverseRelationship !== rel.relationship}
+							<span title="Bidirectional asymmetric">
+								<ArrowLeftRight class="w-3.5 h-3.5 text-blue-500" />
+							</span>
+							<span class="text-xs text-blue-500 dark:text-blue-400">
+								{rel.reverseRelationship}
+							</span>
+						{:else}
+							<span title="Bidirectional">
+								<ArrowLeftRight class="w-3.5 h-3.5 text-slate-400" />
+							</span>
+						{/if}
+					{:else}
+						<span title="Unidirectional">
+							<ArrowRight class="w-3.5 h-3.5 text-slate-400" />
+						</span>
+					{/if}
+				</div>
+
+				<!-- Strength badge -->
+				{#if rel.strength}
+					<div class="mb-2">
+						<span
+							class="inline-block px-2 py-1 rounded-md text-xs font-medium {getStrengthClasses(
+								rel.strength
+							)}"
+						>
+							{rel.strength}
+						</span>
+					</div>
+				{/if}
+
+				<!-- Notes -->
+				{#if rel.notes && rel.notes.trim()}
+					<div class="mb-2">
+						<p class="text-sm text-slate-700 dark:text-slate-300 whitespace-pre-wrap">
+							{rel.notes}
+						</p>
+					</div>
+				{/if}
+
+				<!-- Tags -->
+				{#if rel.metadata?.tags && rel.metadata.tags.length > 0}
+					<div class="mb-2">
+						<div class="flex flex-wrap gap-1.5">
+							{#each rel.metadata.tags as tag}
+								<span
+									class="inline-block px-2 py-0.5 rounded-full text-xs bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"
+								>
+									{tag}
+								</span>
+							{/each}
+						</div>
+					</div>
+				{/if}
+
+				<!-- Tension indicator -->
+				{#if rel.metadata?.tension !== undefined && rel.metadata.tension !== null}
+					<div class="mb-2">
+						<div class="flex items-center justify-between text-xs mb-1">
+							<span class="font-medium text-slate-500 dark:text-slate-400">Tension</span>
+							<span class="font-semibold text-slate-700 dark:text-slate-300"
+								>{rel.metadata.tension}</span
+							>
+						</div>
+						<div
+							class="w-full h-2 bg-slate-200 dark:bg-slate-700 rounded-full overflow-hidden"
+						>
+							<div
+								class="h-full rounded-full transition-all duration-300"
+								class:bg-green-500={rel.metadata.tension < 30}
+								class:bg-yellow-500={rel.metadata.tension >= 30 && rel.metadata.tension < 70}
+								class:bg-red-500={rel.metadata.tension >= 70}
+								style="width: {rel.metadata.tension}%"
+							></div>
+						</div>
+					</div>
+				{/if}
+			</div>
+		{/each}
+	</div>
+{/if}

--- a/src/lib/components/entity/index.ts
+++ b/src/lib/components/entity/index.ts
@@ -3,3 +3,5 @@ export { default as RelateCommand } from './RelateCommand.svelte';
 export { default as FieldGenerateButton } from './FieldGenerateButton.svelte';
 export { default as RelationshipCard } from './RelationshipCard.svelte';
 export { default as EditRelationshipModal } from './EditRelationshipModal.svelte';
+export { default as PendingRelationshipList } from './PendingRelationshipList.svelte';
+export { default as CreateRelateCommand } from './CreateRelateCommand.svelte';

--- a/src/lib/stores/entities.svelte.ts
+++ b/src/lib/stores/entities.svelte.ts
@@ -200,6 +200,15 @@ function createEntitiesStore() {
 			return entity;
 		},
 
+		async createWithRelationships(
+			newEntity: NewEntity,
+			pendingLinks: import('$lib/types').PendingRelationship[]
+		): Promise<BaseEntity> {
+			const entity = await entityRepository.createWithLinks(newEntity, pendingLinks);
+			// The live query will automatically update the entities array
+			return entity;
+		},
+
 		async update(id: string, changes: Partial<BaseEntity>): Promise<void> {
 			await entityRepository.update(id, changes);
 		},

--- a/src/lib/types/entities.ts
+++ b/src/lib/types/entities.ts
@@ -121,6 +121,20 @@ export interface EntityTypeOverride {
 // Helper type for creating new entities
 export type NewEntity = Omit<BaseEntity, 'id' | 'createdAt' | 'updatedAt'>;
 
+// Pending relationship for entity creation (Issue #124)
+export interface PendingRelationship {
+	tempId: string;
+	targetId: string;
+	targetType: EntityType;
+	relationship: string;
+	bidirectional: boolean;
+	notes?: string;
+	strength?: 'strong' | 'moderate' | 'weak';
+	metadata?: { tags?: string[]; tension?: number; [key: string]: unknown };
+	reverseRelationship?: string;
+	playerVisible?: boolean;
+}
+
 // Relationship chain types for graph traversal
 export interface ChainNode {
 	entity: BaseEntity;


### PR DESCRIPTION
## Summary
- Enables users to add relationships while creating entities, before the first save
- Relationships are saved atomically with the entity in a single transaction
- Adds collapsible "Relationships" section to entity create forms

## Changes

### New Components
- `PendingRelationshipList.svelte` - Displays pending relationships on create form
- `CreateRelateCommand.svelte` - Relationship picker for unsaved entities

### Core Implementation
- `PendingRelationship` type for storing relationship data before entity exists
- `createWithLinks()` repository method - atomic entity + relationships creation
- `createWithRelationships()` store method wrapper

### Form Integration
- Updated `/entities/[type]/new` with relationships section
- Badge shows count of pending relationships
- Full feature parity with edit page (bidirectional, strength, notes, tags, tension)

## Test plan
- [x] 24 new tests (19 repository + 5 store) - all passing
- [x] TypeScript type checking passes
- [x] Production build succeeds
- [x] QA validation against all acceptance criteria

## Acceptance Criteria (from issue)
- [x] Relationships section appears on entity create forms
- [x] Can add one or more relationships before saving
- [x] Relationships are saved atomically with entity creation
- [x] UI matches the edit page relationship management
- [x] Works for all entity types
- [x] Proper error handling if relationship target doesn't exist

Closes #124

🤖 Generated with [Claude Code](https://claude.ai/code)