### PR TITLE
fix(#172): prevent state mutation in dashboard template

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -129,7 +129,7 @@
 			</div>
 		{:else}
 			<div class="grid gap-3">
-				{#each entitiesStore.entities
+				{#each [...entitiesStore.entities]
 					.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
 					.slice(0, 5) as entity}
 					{@const typeInfo = BUILT_IN_ENTITY_TYPES.find((t) => t.type === entity.type)}


### PR DESCRIPTION
## Summary

- Fix critical `state_unsafe_mutation` error when opening dashboard with existing campaign data
- Copy entities array before sorting to avoid mutating `$state` inside a template expression

Fixes #172

## Test plan

- [ ] Open app with an existing campaign containing entities
- [ ] Verify dashboard loads without errors
- [ ] Verify Recent Entities section displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)