### PR TITLE
docs: add note about running npm install after pulling updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.0] - 2026-01-19
 
 ### Added
+
+**New Dependencies**: `svelte-dnd-action` - Run `npm install` after upgrading to this version.
 - Custom entity types with full field customization (Issue #25, PR #169)
   - Create custom entity types with 14 field types: text, number, date, boolean, select, multiselect, currency, percentage, rating, richtext, file, image, entity-ref, entity-refs
   - Computed fields with dynamic formula evaluation and automatic type inference

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ npm run dev
 
 Open your browser to `http://localhost:5173`
 
+**After pulling updates**: Always run `npm install` after pulling new changes to ensure any new dependencies are installed.
+
 ### Building for Production
 
 ```bash


### PR DESCRIPTION
## Summary

- Add reminder in README Installation section to run `npm install` after pulling changes
- Document `svelte-dnd-action` dependency in CHANGELOG v0.5.0 release notes

## Test plan

- [x] Verify README includes the new note in Installation section
- [x] Verify CHANGELOG mentions the new dependency

Fixes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)