### PR TITLE
feat(#182): add GitHub Action to attach built files to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Create build artifact
+        run: |
+          cd build
+          zip -r ../director-assist-${{ github.ref_name }}-build.zip .
+          cd ..
+
       - name: Create Release Notes
         id: release_notes
         run: |
@@ -55,5 +61,6 @@ jobs:
             ${{ steps.release_notes.outputs.notes }}
           draft: false
           prerelease: ${{ contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc') }}
+          files: director-assist-${{ github.ref_name }}-build.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -20,12 +20,26 @@ Director Assist features a **system-aware architecture** with first-class suppor
 
 ## Quick Start
 
-### Prerequisites
+### Option 1: Download Pre-Built Files (No Node.js Required)
 
+The easiest way to self-host Director Assist is to download the pre-built files from the latest release:
+
+1. Go to [Releases](https://github.com/evanmiller2112/director-assist/releases)
+2. Download `director-assist-[version]-build.zip` from the latest release
+3. Extract the zip file to your web server directory
+4. Configure your web server for SPA routing (see [DEPLOYMENT.md](./docs/DEPLOYMENT.md))
+
+No build process needed - just download, extract, and deploy.
+
+### Option 2: Build from Source
+
+For development or to build from source:
+
+**Prerequisites:**
 - Node.js 18 or higher
 - npm or pnpm
 
-### Installation
+**Installation:**
 
 ```bash
 git clone https://github.com/evanmiller2112/director-assist.git
@@ -38,7 +52,7 @@ Open your browser to `http://localhost:5173`
 
 **After pulling updates**: Always run `npm install` after pulling new changes to ensure any new dependencies are installed.
 
-### Building for Production
+**Building for Production:**
 
 ```bash
 npm run build

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -4,6 +4,7 @@ This guide covers deploying Director Assist to various hosting environments. Dir
 
 ## Table of Contents
 
+- [Using Pre-Built Releases](#using-pre-built-releases)
 - [Building for Production](#building-for-production)
 - [Understanding SPA Routing](#understanding-spa-routing)
 - [Server Configurations](#server-configurations)
@@ -20,6 +21,44 @@ This guide covers deploying Director Assist to various hosting environments. Dir
   - [Data Storage](#data-storage)
   - [HTTPS Requirements](#https-requirements)
   - [Browser Compatibility](#browser-compatibility)
+
+## Using Pre-Built Releases
+
+The fastest way to deploy Director Assist is to download pre-built files from GitHub releases. This approach requires no Node.js installation or build process.
+
+### Steps
+
+1. Navigate to the [Releases page](https://github.com/evanmiller2112/director-assist/releases)
+2. Download `director-assist-[version]-build.zip` from the latest release
+3. Extract the zip file to your desired directory:
+   ```bash
+   unzip director-assist-v0.6.1-build.zip -d /var/www/director-assist
+   ```
+4. Configure your web server for SPA routing (see [Server Configurations](#server-configurations) below)
+5. Access the application through your web server
+
+### What's Included
+
+The pre-built zip file contains:
+- `index.html` - Main entry point
+- `_app/` - JavaScript, CSS, and other assets
+- `favicon.png` and other static files
+- All necessary files for a fully functional deployment
+
+### When to Use Pre-Built Releases
+
+Use pre-built releases when:
+- You want the fastest deployment path
+- You don't need to modify the source code
+- You're deploying to production and want official release builds
+- You don't have Node.js installed on your server
+
+### When to Build from Source
+
+Build from source when:
+- You're developing or testing changes
+- You need to modify the application
+- You want to use unreleased features from the main branch
 
 ## Building for Production
 

--- a/docs/RELEASE_WORKFLOW.md
+++ b/docs/RELEASE_WORKFLOW.md
@@ -109,10 +109,19 @@ The release workflow consists of 5 stages:
 - Attach release notes from changelog
 - Mark as latest release
 - Link related issues/PRs in release description
+- GitHub Actions automatically builds and attaches `director-assist-[version]-build.zip` to the release
 
 **When to Use:**
 - After tag is pushed
 - To publish the official GitHub release
+
+**Note on Build Artifacts:**
+When a version tag is pushed, the GitHub Actions workflow (`.github/workflows/release.yml`) automatically:
+1. Builds the application (`npm run build`)
+2. Creates a zip file of the build directory
+3. Attaches `director-assist-[version]-build.zip` to the GitHub release
+
+This allows users to download pre-built files without needing Node.js or npm.
 
 ---
 
@@ -150,6 +159,7 @@ Use this workflow when releasing a new version after completing features or fixe
    - Create release from tag
    - Add release notes
    - Publish release
+   - GitHub Actions automatically attaches build artifact
 ```
 
 ### Hotfix Release
@@ -174,6 +184,7 @@ Use this workflow for urgent bug fixes that need immediate release.
 5. GitHub Release (github-project-manager)
    - Create release marked as patch/hotfix
    - Add brief fix description
+   - GitHub Actions automatically attaches build artifact
 ```
 
 ---
@@ -239,9 +250,11 @@ Use this workflow for urgent bug fixes that need immediate release.
 #  ✓ Release v1.2.0 created
 #  ✓ Release notes attached
 #  ✓ Marked as latest release
+#  ✓ Build artifact will be attached automatically by GitHub Actions
 #  ✓ URL: https://github.com/user/repo/releases/tag/v1.2.0
 #
-#  Release complete!"
+#  Release complete! The GitHub Actions workflow will build and attach
+#  director-assist-v1.2.0-build.zip within a few minutes."
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Added automatic creation and attachment of build artifacts to GitHub releases
- Users can now download pre-built files and self-host without Node.js/npm
- Updated documentation with deployment instructions for pre-built releases

## Changes
- `.github/workflows/release.yml` - Added "Create build artifact" step and file attachment
- `README.md` - Added pre-built download option in Quick Start
- `docs/DEPLOYMENT.md` - Added "Using Pre-Built Releases" section
- `docs/RELEASE_WORKFLOW.md` - Updated to document automatic artifact attachment

## Test plan
- [ ] Verify workflow YAML syntax is valid
- [ ] Test with a pre-release tag (e.g., `v0.8.0-alpha.1`) to confirm artifact creation
- [ ] Download and verify the zip file contains the expected build output
- [ ] Confirm zip can be extracted and served on a static host

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)