### PR TITLE
fix(#193): Constrain ConversationSidebar height to fix chat message area

### DIFF
--- a/src/lib/components/chat/ConversationSidebar.svelte
+++ b/src/lib/components/chat/ConversationSidebar.svelte
@@ -30,7 +30,7 @@
 	}
 </script>
 
-<div class="flex flex-col h-full border-b border-slate-200 dark:border-slate-700">
+<div class="flex flex-col max-h-48 border-b border-slate-200 dark:border-slate-700">
 	<!-- Header with New Conversation button -->
 	<div class="px-3 py-2 border-b border-slate-200 dark:border-slate-700">
 		<button


### PR DESCRIPTION
## Summary
- Fixes the **actual** root cause of #193 where the chat message area was only ~5% of panel height
- The previous fix (PR #196) added resize capability but didn't address the internal layout issue
- Root cause: `ConversationSidebar` had `h-full` (100% height) consuming all vertical space

## Changes
- Changed `h-full` → `max-h-48` in ConversationSidebar.svelte
- Sidebar now limited to 192px max height, remains scrollable
- Messages area properly expands via `flex: 1` to fill remaining space

## Test plan
- [ ] Verify chat message area now uses ~80% of panel height
- [ ] Verify conversation sidebar is scrollable when many conversations exist
- [ ] Verify messages area scrolls properly with long conversations

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)