### PR TITLE
feat(#210): add clone utility and template library for custom entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+**Custom Entity Clone and Template System (Issue #210, Phase 3)**
+- Clone utility for duplicating existing entity types as starting points for new custom types
+- Field template library for saving and sharing reusable field definition collections
+- Export/import service for sharing entity types and field templates as JSON files
+- `cloneEntityType()` function creates deep copies with type reset and "(Copy)" label suffix
+- Field template CRUD operations in campaign store: `addFieldTemplate()`, `updateFieldTemplate()`, `deleteFieldTemplate()`, `getFieldTemplate()`
+- `fieldTemplates` getter in campaign store for retrieving all templates
+- `exportEntityType()` and `exportFieldTemplate()` functions for standardized JSON export
+- `validateImport()` function for import validation with version checking and conflict detection
+- Export format version 1.0.0 with metadata support (author, license, source URL)
+- Import preview system shows name, field count, and potential conflicts before importing
+- Deep cloning ensures immutability (modifications to clones don't affect originals)
+- Backend foundation for UI components in future phases
+
 ## [0.9.0] - 2026-01-21
 
 ### Added

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -221,6 +221,7 @@ interface CampaignMetadata {
   systemId?: string;           // System profile ID ('draw-steel', 'system-agnostic')
   customEntityTypes?: EntityTypeDefinition[];
   entityTypeOverrides?: EntityTypeOverride[];
+  fieldTemplates?: FieldTemplate[];  // Reusable field definition templates (Issue #210)
   settings?: CampaignSettings;
 }
 
@@ -3272,6 +3273,11 @@ Manages campaigns as first-class entities via the entity repository:
 - `deleteCustomEntityType(type)`: Remove custom entity type from campaign
 - `setEntityTypeOverride(override)`: Set entity type override
 - `removeEntityTypeOverride(type)`: Remove entity type override
+- `addFieldTemplate(template)`: Add field template to campaign library (Issue #210)
+- `updateFieldTemplate(id, updates)`: Update existing field template (Issue #210)
+- `deleteFieldTemplate(id)`: Remove field template from campaign library (Issue #210)
+- `getFieldTemplate(id)`: Retrieve field template by ID (Issue #210)
+- `fieldTemplates`: Getter for all field templates in campaign (Issue #210)
 - `deleteCampaign(id)`: Delete campaign (protected: cannot delete last campaign)
 - `reload()`: Reload campaigns from database
 - `reset()`: Reset store to initial state (for testing)

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -513,6 +513,148 @@ If you want to temporarily disable a custom type without deleting it:
 2. Toggle "Hidden from Sidebar"
 3. The type won't appear in navigation but existing entities remain accessible
 
+**Cloning Entity Types**
+
+Create a new custom entity type based on an existing one:
+
+1. Open Settings
+2. Find the entity type you want to clone (built-in or custom)
+3. Click "Clone"
+4. The cloned type appears with "(Copy)" suffix and empty type key
+5. Provide a unique type key
+6. Customize labels, fields, and properties as needed
+7. Save the new entity type
+
+Cloning creates a complete deep copy of all field definitions, relationships, and settings. The clone is fully independent - changes to it don't affect the original.
+
+**Use Cases for Cloning:**
+- Create variants of built-in types (e.g., clone NPC to create "Monster")
+- Adapt existing custom types for new purposes
+- Save time when creating similar entity types
+- Preserve complex field configurations while making minor changes
+
+### Field Template Library
+
+Field templates let you save and reuse collections of field definitions across multiple entity types. This feature is particularly useful for common field patterns.
+
+**Creating Field Templates**
+
+Save a reusable set of fields:
+
+1. Open Settings
+2. Navigate to "Field Template Library"
+3. Click "Create Field Template"
+4. Provide template information:
+   - Name: Display name (e.g., "Combat Stats")
+   - Description: What this template contains
+   - Category: Organization category (e.g., "draw-steel", "user")
+5. Add field definitions to the template
+6. Save the template
+
+**Using Field Templates**
+
+Apply a template when creating or editing entity types:
+
+1. When editing an entity type, click "Apply Template"
+2. Select a template from the library
+3. Choose whether to append fields or replace existing fields
+4. Template fields are added to your entity type
+5. Customize individual fields as needed
+
+**Managing Field Templates**
+
+- Edit templates to update field definitions
+- Delete templates no longer needed
+- Export templates as JSON files to share with others
+- Import templates from JSON files
+
+**Example Templates:**
+
+**Combat Stats Template**
+```
+Fields:
+- ac (number): Armor Class
+- hp (number): Hit Points
+- currentHP (number): Current HP
+- speed (number): Speed in feet
+- initiative (number): Initiative bonus
+```
+
+**Draw Steel Threat Template**
+```
+Fields:
+- threatLevel (select): Minion, Standard, Elite, Boss, Solo
+- combatRole (select): Ambusher, Artillery, Brute, Controller, Defender, Harrier, Hexer, Leader, Mount, Support
+- size (select): Tiny, Small, Medium, Large, Huge, Gargantuan
+- ac (number): Armor Class
+- stamina (number): Stamina
+- stability (number): Stability
+- speed (number): Speed
+- immunities (tags): Damage immunities
+- weaknesses (tags): Damage weaknesses
+```
+
+**Benefits of Field Templates:**
+- Consistency across related entity types
+- Faster entity type creation
+- Share common field patterns with other campaigns
+- Maintain standardized field definitions
+- Reduce repetitive configuration
+
+### Export and Import
+
+Share custom entity types and field templates with other campaigns or users via JSON export/import.
+
+**Exporting Entity Types**
+
+1. Open Settings
+2. Find the entity type to export
+3. Click "Export"
+4. Choose whether to include metadata (author, license, source URL)
+5. Download the JSON file
+
+The exported file contains the complete entity type definition with all field configurations.
+
+**Exporting Field Templates**
+
+1. Open Settings
+2. Navigate to "Field Template Library"
+3. Find the template to export
+4. Click "Export"
+5. Add optional metadata
+6. Download the JSON file
+
+**Importing Entity Types or Templates**
+
+1. Open Settings
+2. Click "Import Entity Type" or "Import Field Template"
+3. Select a JSON file
+4. Review the import preview showing:
+   - Name and type being imported
+   - Number of fields
+   - Potential conflicts with existing types/templates
+5. Resolve any conflicts (rename keys if needed)
+6. Confirm import
+
+**Export Format:**
+- Version: 1.0.0 (standardized format)
+- Generator: Application name and version
+- Metadata: Author, license, source URL (optional)
+- Data: Complete entity type or field template
+
+**Import Validation:**
+- Version compatibility checking
+- Data structure validation
+- Conflict detection with existing types/templates
+- Preview before committing changes
+
+**Sharing Best Practices:**
+- Add metadata (author, license) to exports for attribution
+- Include descriptive template names and descriptions
+- Test imported types before using in production campaigns
+- Document any dependencies or required field types
+- Consider licensing (CC-BY-4.0, MIT, etc.) for community sharing
+
 ### Validation and Error Prevention
 
 Director Assist validates custom entity types to prevent errors:

--- a/src/lib/services/entityTypeExportService.test.ts
+++ b/src/lib/services/entityTypeExportService.test.ts
@@ -1,0 +1,1087 @@
+/**
+ * Tests for Entity Type Export/Import Service (TDD RED Phase)
+ * GitHub Issue #210: Add clone and template library for custom entities
+ *
+ * Tests the export and import functionality for entity types and field templates.
+ * Allows users to share custom entity types and field templates as JSON files.
+ *
+ * RED Phase: These tests SHOULD FAIL until implementation is complete.
+ *
+ * Covers:
+ * - Exporting entity types to JSON format
+ * - Exporting field templates to JSON format
+ * - Validating import data structure
+ * - Detecting conflicts with existing types
+ * - Providing preview information
+ * - Round-trip import/export data integrity
+ * - Version compatibility
+ * - Metadata handling
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+	exportEntityType,
+	exportFieldTemplate,
+	validateImport,
+	EXPORT_VERSION
+} from './entityTypeExportService';
+import type {
+	EntityTypeDefinition,
+	FieldTemplate,
+	EntityTypeExport,
+	ImportValidationResult
+} from '$lib/types';
+
+describe('entityTypeExportService', () => {
+	describe('exportEntityType', () => {
+		it('should export entity type with correct structure', () => {
+			const entityType: EntityTypeDefinition = {
+				type: 'custom_monster',
+				label: 'Custom Monster',
+				labelPlural: 'Custom Monsters',
+				description: 'Track monsters and creatures',
+				icon: 'skull',
+				color: 'red',
+				isBuiltIn: false,
+				fieldDefinitions: [
+					{
+						key: 'threat_level',
+						label: 'Threat Level',
+						type: 'select',
+						required: false,
+						options: ['low', 'medium', 'high'],
+						order: 1
+					},
+					{
+						key: 'ac',
+						label: 'AC',
+						type: 'number',
+						required: false,
+						order: 2
+					}
+				],
+				defaultRelationships: ['located_at']
+			};
+
+			const exported = exportEntityType(entityType);
+
+			expect(exported.version).toBe('1.0.0');
+			expect(exported.type).toBe('entity-type');
+			expect(exported.data).toEqual(entityType);
+			expect(exported.exportedAt).toBeInstanceOf(Date);
+			expect(exported.generator.name).toBe('Director Assist');
+			expect(exported.generator.version).toBeDefined();
+		});
+
+		it('should include metadata when provided', () => {
+			const entityType: EntityTypeDefinition = {
+				type: 'quest',
+				label: 'Quest',
+				labelPlural: 'Quests',
+				icon: 'scroll',
+				color: 'amber',
+				isBuiltIn: false,
+				fieldDefinitions: [],
+				defaultRelationships: []
+			};
+
+			const metadata = {
+				author: 'John Doe',
+				sourceUrl: 'https://example.com/quest-type',
+				license: 'CC-BY-4.0'
+			};
+
+			const exported = exportEntityType(entityType, metadata);
+
+			expect(exported.metadata).toEqual(metadata);
+			expect(exported.metadata.author).toBe('John Doe');
+			expect(exported.metadata.sourceUrl).toBe('https://example.com/quest-type');
+			expect(exported.metadata.license).toBe('CC-BY-4.0');
+		});
+
+		it('should include empty metadata object when not provided', () => {
+			const entityType: EntityTypeDefinition = {
+				type: 'test',
+				label: 'Test',
+				labelPlural: 'Tests',
+				icon: 'test-tube',
+				color: 'gray',
+				isBuiltIn: false,
+				fieldDefinitions: [],
+				defaultRelationships: []
+			};
+
+			const exported = exportEntityType(entityType);
+
+			expect(exported.metadata).toEqual({});
+		});
+
+		it('should include current app version in generator', () => {
+			const entityType: EntityTypeDefinition = {
+				type: 'test',
+				label: 'Test',
+				labelPlural: 'Tests',
+				icon: 'test-tube',
+				color: 'gray',
+				isBuiltIn: false,
+				fieldDefinitions: [],
+				defaultRelationships: []
+			};
+
+			const exported = exportEntityType(entityType);
+
+			expect(exported.generator.version).toBeDefined();
+			expect(typeof exported.generator.version).toBe('string');
+			// Version should be semver format (e.g., "0.8.0")
+			expect(exported.generator.version).toMatch(/^\d+\.\d+\.\d+/);
+		});
+
+		it('should set exportedAt to current timestamp', () => {
+			const entityType: EntityTypeDefinition = {
+				type: 'test',
+				label: 'Test',
+				labelPlural: 'Tests',
+				icon: 'test-tube',
+				color: 'gray',
+				isBuiltIn: false,
+				fieldDefinitions: [],
+				defaultRelationships: []
+			};
+
+			const before = new Date();
+			const exported = exportEntityType(entityType);
+			const after = new Date();
+
+			expect(exported.exportedAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+			expect(exported.exportedAt.getTime()).toBeLessThanOrEqual(after.getTime());
+		});
+
+		it('should export complex entity type with all features', () => {
+			const complexType: EntityTypeDefinition = {
+				type: 'ds-monster-threat',
+				label: 'Monster/Threat',
+				labelPlural: 'Monsters/Threats',
+				description: 'Draw Steel monster with full stats',
+				icon: 'skull',
+				color: 'red',
+				isBuiltIn: false,
+				fieldDefinitions: [
+					{
+						key: 'threat_level',
+						label: 'Threat Level',
+						type: 'select',
+						required: false,
+						options: ['minion', 'standard', 'boss'],
+						helpText: 'Monster threat level',
+						order: 1
+					},
+					{
+						key: 'abilities',
+						label: 'Abilities',
+						type: 'richtext',
+						required: false,
+						placeholder: 'Enter abilities',
+						section: 'combat',
+						order: 2,
+						aiGenerate: true
+					},
+					{
+						key: 'total_power',
+						label: 'Total Power',
+						type: 'computed',
+						required: false,
+						order: 3,
+						computedConfig: {
+							formula: '{strength} + {intelligence}',
+							dependencies: ['strength', 'intelligence'],
+							outputType: 'number'
+						}
+					}
+				],
+				defaultRelationships: ['located_at', 'part_of']
+			};
+
+			const exported = exportEntityType(complexType);
+
+			expect(exported.data).toEqual(complexType);
+			expect(exported.data.fieldDefinitions).toHaveLength(3);
+			expect(exported.data.fieldDefinitions[2].computedConfig).toBeDefined();
+		});
+
+		it('should handle entity type with no field definitions', () => {
+			const emptyType: EntityTypeDefinition = {
+				type: 'simple',
+				label: 'Simple',
+				labelPlural: 'Simples',
+				icon: 'circle',
+				color: 'gray',
+				isBuiltIn: false,
+				fieldDefinitions: [],
+				defaultRelationships: []
+			};
+
+			const exported = exportEntityType(emptyType);
+
+			expect(exported.data.fieldDefinitions).toEqual([]);
+		});
+
+		it('should handle entity type with no default relationships', () => {
+			const type: EntityTypeDefinition = {
+				type: 'standalone',
+				label: 'Standalone',
+				labelPlural: 'Standalones',
+				icon: 'star',
+				color: 'yellow',
+				isBuiltIn: false,
+				fieldDefinitions: [],
+				defaultRelationships: []
+			};
+
+			const exported = exportEntityType(type);
+
+			expect(exported.data.defaultRelationships).toEqual([]);
+		});
+	});
+
+	describe('exportFieldTemplate', () => {
+		it('should export field template with correct structure', () => {
+			const template: FieldTemplate = {
+				id: 'template-1',
+				name: 'Combat Stats',
+				description: 'Standard combat statistics',
+				category: 'draw-steel',
+				fieldDefinitions: [
+					{
+						key: 'ac',
+						label: 'AC',
+						type: 'number',
+						required: false,
+						order: 1
+					},
+					{
+						key: 'hp',
+						label: 'HP',
+						type: 'number',
+						required: false,
+						order: 2
+					}
+				],
+				createdAt: new Date('2024-01-01'),
+				updatedAt: new Date('2024-01-15')
+			};
+
+			const exported = exportFieldTemplate(template);
+
+			expect(exported.version).toBe('1.0.0');
+			expect(exported.type).toBe('field-template');
+			expect(exported.data).toEqual(template);
+			expect(exported.exportedAt).toBeInstanceOf(Date);
+			expect(exported.generator.name).toBe('Director Assist');
+		});
+
+		it('should include metadata when provided', () => {
+			const template: FieldTemplate = {
+				id: 'template-1',
+				name: 'Social Stats',
+				category: 'user',
+				fieldDefinitions: [],
+				createdAt: new Date(),
+				updatedAt: new Date()
+			};
+
+			const metadata = {
+				author: 'Jane Smith',
+				sourceUrl: 'https://example.com/templates',
+				license: 'MIT'
+			};
+
+			const exported = exportFieldTemplate(template, metadata);
+
+			expect(exported.metadata).toEqual(metadata);
+		});
+
+		it('should handle template with complex field definitions', () => {
+			const template: FieldTemplate = {
+				id: 'template-1',
+				name: 'Complex Template',
+				category: 'user',
+				fieldDefinitions: [
+					{
+						key: 'skills',
+						label: 'Skills',
+						type: 'multi-select',
+						required: false,
+						options: ['Stealth', 'Combat', 'Magic'],
+						order: 1
+					},
+					{
+						key: 'allies',
+						label: 'Allies',
+						type: 'entity-refs',
+						required: false,
+						entityTypes: ['npc', 'character'],
+						order: 2
+					}
+				],
+				createdAt: new Date(),
+				updatedAt: new Date()
+			};
+
+			const exported = exportFieldTemplate(template);
+
+			expect(exported.data.fieldDefinitions).toHaveLength(2);
+			expect(exported.data.fieldDefinitions[0].options).toEqual(['Stealth', 'Combat', 'Magic']);
+			expect(exported.data.fieldDefinitions[1].entityTypes).toEqual(['npc', 'character']);
+		});
+	});
+
+	describe('validateImport', () => {
+		describe('Valid Import Data', () => {
+			it('should accept valid entity type export', () => {
+				const validExport: EntityTypeExport = {
+					version: '1.0.0',
+					exportedAt: new Date(),
+					generator: {
+						name: 'Director Assist',
+						version: '0.8.0'
+					},
+					type: 'entity-type',
+					data: {
+						type: 'custom',
+						label: 'Custom',
+						labelPlural: 'Customs',
+						icon: 'star',
+						color: 'blue',
+						isBuiltIn: false,
+						fieldDefinitions: [],
+						defaultRelationships: []
+					},
+					metadata: {}
+				};
+
+				const result = validateImport(validExport);
+
+				expect(result.valid).toBe(true);
+				expect(result.errors).toHaveLength(0);
+				expect(result.preview.name).toBe('Custom');
+				expect(result.preview.type).toBe('entity-type');
+				expect(result.preview.fieldCount).toBe(0);
+			});
+
+			it('should accept valid field template export', () => {
+				const validExport: EntityTypeExport = {
+					version: '1.0.0',
+					exportedAt: new Date(),
+					generator: {
+						name: 'Director Assist',
+						version: '0.8.0'
+					},
+					type: 'field-template',
+					data: {
+						id: 'template-1',
+						name: 'Test Template',
+						category: 'user',
+						fieldDefinitions: [
+							{
+								key: 'field1',
+								label: 'Field 1',
+								type: 'text',
+								required: false,
+								order: 1
+							}
+						],
+						createdAt: new Date(),
+						updatedAt: new Date()
+					},
+					metadata: {}
+				};
+
+				const result = validateImport(validExport);
+
+				expect(result.valid).toBe(true);
+				expect(result.errors).toHaveLength(0);
+				expect(result.preview.name).toBe('Test Template');
+				expect(result.preview.type).toBe('field-template');
+				expect(result.preview.fieldCount).toBe(1);
+			});
+
+			it('should include warnings for non-critical issues', () => {
+				const exportFromOldVersion: EntityTypeExport = {
+					version: '1.0.0',
+					exportedAt: new Date('2020-01-01'), // Old export
+					generator: {
+						name: 'Director Assist',
+						version: '0.1.0' // Very old version
+					},
+					type: 'entity-type',
+					data: {
+						type: 'old_custom',
+						label: 'Old Custom',
+						labelPlural: 'Old Customs',
+						icon: 'archive',
+						color: 'gray',
+						isBuiltIn: false,
+						fieldDefinitions: [],
+						defaultRelationships: []
+					},
+					metadata: {}
+				};
+
+				const result = validateImport(exportFromOldVersion);
+
+				expect(result.valid).toBe(true);
+				expect(result.warnings.length).toBeGreaterThan(0);
+				expect(result.warnings.some((w) => w.includes('old version'))).toBe(true);
+			});
+		});
+
+		describe('Invalid Version', () => {
+			it('should reject unsupported version', () => {
+				const invalidExport = {
+					version: '2.0.0', // Future version
+					exportedAt: new Date(),
+					generator: {
+						name: 'Director Assist',
+						version: '0.8.0'
+					},
+					type: 'entity-type',
+					data: {
+						type: 'test',
+						label: 'Test',
+						labelPlural: 'Tests',
+						icon: 'star',
+						color: 'blue',
+						isBuiltIn: false,
+						fieldDefinitions: [],
+						defaultRelationships: []
+					},
+					metadata: {}
+				};
+
+				const result = validateImport(invalidExport);
+
+				expect(result.valid).toBe(false);
+				expect(result.errors.some((e) => e.includes('version'))).toBe(true);
+			});
+
+			it('should reject missing version field', () => {
+				const invalidExport = {
+					// version field missing
+					exportedAt: new Date(),
+					generator: {
+						name: 'Director Assist',
+						version: '0.8.0'
+					},
+					type: 'entity-type',
+					data: {
+						type: 'test',
+						label: 'Test',
+						labelPlural: 'Tests',
+						icon: 'star',
+						color: 'blue',
+						isBuiltIn: false,
+						fieldDefinitions: [],
+						defaultRelationships: []
+					},
+					metadata: {}
+				};
+
+				const result = validateImport(invalidExport);
+
+				expect(result.valid).toBe(false);
+				expect(result.errors.some((e) => e.includes('version'))).toBe(true);
+			});
+		});
+
+		describe('Missing Required Fields', () => {
+			it('should reject export missing type field', () => {
+				const invalidExport = {
+					version: '1.0.0',
+					exportedAt: new Date(),
+					generator: {
+						name: 'Director Assist',
+						version: '0.8.0'
+					},
+					// type field missing
+					data: {
+						type: 'test',
+						label: 'Test',
+						labelPlural: 'Tests',
+						icon: 'star',
+						color: 'blue',
+						isBuiltIn: false,
+						fieldDefinitions: [],
+						defaultRelationships: []
+					},
+					metadata: {}
+				};
+
+				const result = validateImport(invalidExport);
+
+				expect(result.valid).toBe(false);
+				expect(result.errors.some((e) => e.includes('type'))).toBe(true);
+			});
+
+			it('should reject export missing data field', () => {
+				const invalidExport = {
+					version: '1.0.0',
+					exportedAt: new Date(),
+					generator: {
+						name: 'Director Assist',
+						version: '0.8.0'
+					},
+					type: 'entity-type',
+					// data field missing
+					metadata: {}
+				};
+
+				const result = validateImport(invalidExport);
+
+				expect(result.valid).toBe(false);
+				expect(result.errors.some((e) => e.includes('data'))).toBe(true);
+			});
+
+			it('should reject export missing exportedAt field', () => {
+				const invalidExport = {
+					version: '1.0.0',
+					// exportedAt missing
+					generator: {
+						name: 'Director Assist',
+						version: '0.8.0'
+					},
+					type: 'entity-type',
+					data: {
+						type: 'test',
+						label: 'Test',
+						labelPlural: 'Tests',
+						icon: 'star',
+						color: 'blue',
+						isBuiltIn: false,
+						fieldDefinitions: [],
+						defaultRelationships: []
+					},
+					metadata: {}
+				};
+
+				const result = validateImport(invalidExport);
+
+				expect(result.valid).toBe(false);
+				expect(result.errors.some((e) => e.includes('exportedAt'))).toBe(true);
+			});
+
+			it('should reject export missing generator field', () => {
+				const invalidExport = {
+					version: '1.0.0',
+					exportedAt: new Date(),
+					// generator missing
+					type: 'entity-type',
+					data: {
+						type: 'test',
+						label: 'Test',
+						labelPlural: 'Tests',
+						icon: 'star',
+						color: 'blue',
+						isBuiltIn: false,
+						fieldDefinitions: [],
+						defaultRelationships: []
+					},
+					metadata: {}
+				};
+
+				const result = validateImport(invalidExport);
+
+				expect(result.valid).toBe(false);
+				expect(result.errors.some((e) => e.includes('generator'))).toBe(true);
+			});
+		});
+
+		describe('Invalid Data Structure', () => {
+			it('should reject entity type with invalid structure', () => {
+				const invalidExport: EntityTypeExport = {
+					version: '1.0.0',
+					exportedAt: new Date(),
+					generator: {
+						name: 'Director Assist',
+						version: '0.8.0'
+					},
+					type: 'entity-type',
+					data: {
+						// Missing required fields like type, label, icon, etc.
+						type: 'test'
+					} as any,
+					metadata: {}
+				};
+
+				const result = validateImport(invalidExport);
+
+				expect(result.valid).toBe(false);
+				expect(result.errors.length).toBeGreaterThan(0);
+			});
+
+			it('should reject field template with invalid structure', () => {
+				const invalidExport: EntityTypeExport = {
+					version: '1.0.0',
+					exportedAt: new Date(),
+					generator: {
+						name: 'Director Assist',
+						version: '0.8.0'
+					},
+					type: 'field-template',
+					data: {
+						// Missing required fields like id, name, fieldDefinitions, etc.
+						name: 'Test'
+					} as any,
+					metadata: {}
+				};
+
+				const result = validateImport(invalidExport);
+
+				expect(result.valid).toBe(false);
+				expect(result.errors.length).toBeGreaterThan(0);
+			});
+
+			it('should reject entity type with invalid field definitions', () => {
+				const invalidExport: EntityTypeExport = {
+					version: '1.0.0',
+					exportedAt: new Date(),
+					generator: {
+						name: 'Director Assist',
+						version: '0.8.0'
+					},
+					type: 'entity-type',
+					data: {
+						type: 'test',
+						label: 'Test',
+						labelPlural: 'Tests',
+						icon: 'star',
+						color: 'blue',
+						isBuiltIn: false,
+						fieldDefinitions: [
+							{
+								// Missing required field properties
+								key: 'field1'
+							} as any
+						],
+						defaultRelationships: []
+					},
+					metadata: {}
+				};
+
+				const result = validateImport(invalidExport);
+
+				expect(result.valid).toBe(false);
+				expect(result.errors.some((e) => e.includes('field'))).toBe(true);
+			});
+		});
+
+		describe('Conflict Detection', () => {
+			it('should detect conflict with existing entity type', () => {
+				const exportData: EntityTypeExport = {
+					version: '1.0.0',
+					exportedAt: new Date(),
+					generator: {
+						name: 'Director Assist',
+						version: '0.8.0'
+					},
+					type: 'entity-type',
+					data: {
+						type: 'character', // Built-in type
+						label: 'Character',
+						labelPlural: 'Characters',
+						icon: 'user',
+						color: 'blue',
+						isBuiltIn: false,
+						fieldDefinitions: [],
+						defaultRelationships: []
+					},
+					metadata: {}
+				};
+
+				// Pass existing types to check for conflicts
+				const existingTypes = ['character', 'npc', 'location'];
+				const result = validateImport(exportData, existingTypes);
+
+				expect(result.preview.conflictsWithExisting).toBe(true);
+				expect(result.warnings.some((w) => w.includes('already exists'))).toBe(true);
+			});
+
+			it('should detect conflict with existing field template', () => {
+				const exportData: EntityTypeExport = {
+					version: '1.0.0',
+					exportedAt: new Date(),
+					generator: {
+						name: 'Director Assist',
+						version: '0.8.0'
+					},
+					type: 'field-template',
+					data: {
+						id: 'combat-stats', // Existing template ID
+						name: 'Combat Stats',
+						category: 'user',
+						fieldDefinitions: [],
+						createdAt: new Date(),
+						updatedAt: new Date()
+					},
+					metadata: {}
+				};
+
+				const existingTemplateIds = ['combat-stats', 'social-stats'];
+				const result = validateImport(exportData, [], existingTemplateIds);
+
+				expect(result.preview.conflictsWithExisting).toBe(true);
+				expect(result.warnings.some((w) => w.includes('already exists'))).toBe(true);
+			});
+
+			it('should not show conflict when no conflicts exist', () => {
+				const exportData: EntityTypeExport = {
+					version: '1.0.0',
+					exportedAt: new Date(),
+					generator: {
+						name: 'Director Assist',
+						version: '0.8.0'
+					},
+					type: 'entity-type',
+					data: {
+						type: 'unique_custom_type',
+						label: 'Unique Custom',
+						labelPlural: 'Unique Customs',
+						icon: 'star',
+						color: 'purple',
+						isBuiltIn: false,
+						fieldDefinitions: [],
+						defaultRelationships: []
+					},
+					metadata: {}
+				};
+
+				const existingTypes = ['character', 'npc', 'location'];
+				const result = validateImport(exportData, existingTypes);
+
+				expect(result.preview.conflictsWithExisting).toBe(false);
+			});
+		});
+
+		describe('Preview Information', () => {
+			it('should provide preview with entity type name', () => {
+				const exportData: EntityTypeExport = {
+					version: '1.0.0',
+					exportedAt: new Date(),
+					generator: {
+						name: 'Director Assist',
+						version: '0.8.0'
+					},
+					type: 'entity-type',
+					data: {
+						type: 'custom',
+						label: 'Custom Type',
+						labelPlural: 'Custom Types',
+						icon: 'star',
+						color: 'blue',
+						isBuiltIn: false,
+						fieldDefinitions: [],
+						defaultRelationships: []
+					},
+					metadata: {}
+				};
+
+				const result = validateImport(exportData);
+
+				expect(result.preview.name).toBe('Custom Type');
+			});
+
+			it('should provide preview with field template name', () => {
+				const exportData: EntityTypeExport = {
+					version: '1.0.0',
+					exportedAt: new Date(),
+					generator: {
+						name: 'Director Assist',
+						version: '0.8.0'
+					},
+					type: 'field-template',
+					data: {
+						id: 'template-1',
+						name: 'My Template',
+						category: 'user',
+						fieldDefinitions: [],
+						createdAt: new Date(),
+						updatedAt: new Date()
+					},
+					metadata: {}
+				};
+
+				const result = validateImport(exportData);
+
+				expect(result.preview.name).toBe('My Template');
+			});
+
+			it('should provide preview with correct field count', () => {
+				const exportData: EntityTypeExport = {
+					version: '1.0.0',
+					exportedAt: new Date(),
+					generator: {
+						name: 'Director Assist',
+						version: '0.8.0'
+					},
+					type: 'entity-type',
+					data: {
+						type: 'custom',
+						label: 'Custom',
+						labelPlural: 'Customs',
+						icon: 'star',
+						color: 'blue',
+						isBuiltIn: false,
+						fieldDefinitions: [
+							{
+								key: 'field1',
+								label: 'Field 1',
+								type: 'text',
+								required: false,
+								order: 1
+							},
+							{
+								key: 'field2',
+								label: 'Field 2',
+								type: 'number',
+								required: false,
+								order: 2
+							},
+							{
+								key: 'field3',
+								label: 'Field 3',
+								type: 'boolean',
+								required: false,
+								order: 3
+							}
+						],
+						defaultRelationships: []
+					},
+					metadata: {}
+				};
+
+				const result = validateImport(exportData);
+
+				expect(result.preview.fieldCount).toBe(3);
+			});
+
+			it('should provide preview with type information', () => {
+				const entityTypeExport: EntityTypeExport = {
+					version: '1.0.0',
+					exportedAt: new Date(),
+					generator: { name: 'Director Assist', version: '0.8.0' },
+					type: 'entity-type',
+					data: {
+						type: 'test',
+						label: 'Test',
+						labelPlural: 'Tests',
+						icon: 'star',
+						color: 'blue',
+						isBuiltIn: false,
+						fieldDefinitions: [],
+						defaultRelationships: []
+					},
+					metadata: {}
+				};
+
+				const templateExport: EntityTypeExport = {
+					version: '1.0.0',
+					exportedAt: new Date(),
+					generator: { name: 'Director Assist', version: '0.8.0' },
+					type: 'field-template',
+					data: {
+						id: 'template-1',
+						name: 'Template',
+						category: 'user',
+						fieldDefinitions: [],
+						createdAt: new Date(),
+						updatedAt: new Date()
+					},
+					metadata: {}
+				};
+
+				const entityResult = validateImport(entityTypeExport);
+				const templateResult = validateImport(templateExport);
+
+				expect(entityResult.preview.type).toBe('entity-type');
+				expect(templateResult.preview.type).toBe('field-template');
+			});
+		});
+
+		describe('Edge Cases', () => {
+			it('should handle null input', () => {
+				const result = validateImport(null as any);
+
+				expect(result.valid).toBe(false);
+				expect(result.errors.length).toBeGreaterThan(0);
+			});
+
+			it('should handle undefined input', () => {
+				const result = validateImport(undefined as any);
+
+				expect(result.valid).toBe(false);
+				expect(result.errors.length).toBeGreaterThan(0);
+			});
+
+			it('should handle empty object', () => {
+				const result = validateImport({} as any);
+
+				expect(result.valid).toBe(false);
+				expect(result.errors.length).toBeGreaterThan(0);
+			});
+
+			it('should handle malformed JSON data', () => {
+				const malformed = {
+					version: '1.0.0',
+					exportedAt: 'not-a-date',
+					generator: 'not-an-object',
+					type: 123,
+					data: 'not-an-object',
+					metadata: null
+				};
+
+				const result = validateImport(malformed as any);
+
+				expect(result.valid).toBe(false);
+			});
+		});
+	});
+
+	describe('Round-trip Import/Export', () => {
+		it('should preserve all entity type data through export/import cycle', () => {
+			const original: EntityTypeDefinition = {
+				type: 'quest',
+				label: 'Quest',
+				labelPlural: 'Quests',
+				description: 'Track quests and missions',
+				icon: 'scroll',
+				color: 'amber',
+				isBuiltIn: false,
+				fieldDefinitions: [
+					{
+						key: 'status',
+						label: 'Status',
+						type: 'select',
+						required: true,
+						options: ['active', 'completed', 'failed'],
+						defaultValue: 'active',
+						order: 1
+					},
+					{
+						key: 'reward',
+						label: 'Reward',
+						type: 'richtext',
+						required: false,
+						placeholder: 'Enter reward',
+						helpText: 'Description of quest reward',
+						order: 2
+					}
+				],
+				defaultRelationships: ['assigned_to', 'part_of']
+			};
+
+			// Export
+			const exported = exportEntityType(original);
+
+			// Validate (simulating import)
+			const validation = validateImport(exported);
+
+			// Should be valid
+			expect(validation.valid).toBe(true);
+
+			// Data should match original
+			expect(exported.data).toEqual(original);
+		});
+
+		it('should preserve all field template data through export/import cycle', () => {
+			const original: FieldTemplate = {
+				id: 'template-1',
+				name: 'Social Interaction',
+				description: 'Fields for social encounters',
+				category: 'draw-steel',
+				fieldDefinitions: [
+					{
+						key: 'attitude',
+						label: 'Attitude',
+						type: 'select',
+						required: false,
+						options: ['hostile', 'unfriendly', 'neutral', 'friendly', 'helpful'],
+						order: 1
+					},
+					{
+						key: 'goals',
+						label: 'Goals',
+						type: 'tags',
+						required: false,
+						order: 2
+					}
+				],
+				createdAt: new Date('2024-01-01'),
+				updatedAt: new Date('2024-01-15')
+			};
+
+			// Export
+			const exported = exportFieldTemplate(original);
+
+			// Validate (simulating import)
+			const validation = validateImport(exported);
+
+			// Should be valid
+			expect(validation.valid).toBe(true);
+
+			// Data should match original
+			expect(exported.data).toEqual(original);
+		});
+
+		it('should preserve metadata through round-trip', () => {
+			const entityType: EntityTypeDefinition = {
+				type: 'test',
+				label: 'Test',
+				labelPlural: 'Tests',
+				icon: 'test-tube',
+				color: 'gray',
+				isBuiltIn: false,
+				fieldDefinitions: [],
+				defaultRelationships: []
+			};
+
+			const metadata = {
+				author: 'Test Author',
+				sourceUrl: 'https://test.com',
+				license: 'MIT'
+			};
+
+			const exported = exportEntityType(entityType, metadata);
+			const validation = validateImport(exported);
+
+			expect(validation.valid).toBe(true);
+			expect(exported.metadata).toEqual(metadata);
+		});
+	});
+
+	describe('EXPORT_VERSION constant', () => {
+		it('should be defined and be a string', () => {
+			expect(EXPORT_VERSION).toBeDefined();
+			expect(typeof EXPORT_VERSION).toBe('string');
+		});
+
+		it('should be in semver format', () => {
+			expect(EXPORT_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+		});
+
+		it('should match version used in exports', () => {
+			const entityType: EntityTypeDefinition = {
+				type: 'test',
+				label: 'Test',
+				labelPlural: 'Tests',
+				icon: 'test-tube',
+				color: 'gray',
+				isBuiltIn: false,
+				fieldDefinitions: [],
+				defaultRelationships: []
+			};
+
+			const exported = exportEntityType(entityType);
+
+			expect(exported.version).toBe(EXPORT_VERSION);
+		});
+	});
+});

--- a/src/lib/services/entityTypeExportService.ts
+++ b/src/lib/services/entityTypeExportService.ts
@@ -1,0 +1,348 @@
+/**
+ * Entity Type Export/Import Service (GitHub Issue #210)
+ *
+ * Provides functionality to export and import custom entity types and field templates
+ * as JSON files. This enables sharing of custom configurations between campaigns and users.
+ *
+ * Export Format (Version 1.0.0):
+ * - Standardized JSON structure with version tracking
+ * - Includes metadata (author, license, source URL)
+ * - Generator information for compatibility tracking
+ * - Supports both entity types and field templates
+ *
+ * Import Validation:
+ * - Version compatibility checking
+ * - Data structure validation
+ * - Conflict detection with existing types
+ * - Preview information before import
+ */
+
+import type {
+	EntityTypeDefinition,
+	FieldTemplate,
+	EntityTypeExport,
+	ImportValidationResult
+} from '$lib/types';
+
+/**
+ * Export format version
+ * Follow semver: increment major for breaking changes
+ */
+export const EXPORT_VERSION = '1.0.0' as const;
+
+/**
+ * Application version - used in generator field
+ * Read from package.json or use fallback
+ */
+const APP_VERSION = '0.9.0'; // This should match package.json version
+
+/**
+ * Export an entity type definition to JSON format
+ *
+ * @param definition - The entity type definition to export
+ * @param metadata - Optional metadata about the export (author, license, source URL)
+ * @returns Export object ready to be serialized to JSON
+ *
+ * @example
+ * ```ts
+ * const monsterType = getEntityType('custom_monster');
+ * const exported = exportEntityType(monsterType, {
+ *   author: 'John Doe',
+ *   license: 'CC-BY-4.0'
+ * });
+ * const json = JSON.stringify(exported, null, 2);
+ * // Save to file or share
+ * ```
+ */
+export function exportEntityType(
+	definition: EntityTypeDefinition,
+	metadata?: { author?: string; sourceUrl?: string; license?: string }
+): EntityTypeExport {
+	return {
+		version: EXPORT_VERSION,
+		exportedAt: new Date(),
+		generator: {
+			name: 'Director Assist',
+			version: APP_VERSION
+		},
+		type: 'entity-type',
+		data: definition,
+		metadata: metadata ?? {}
+	};
+}
+
+/**
+ * Export a field template to JSON format
+ *
+ * @param template - The field template to export
+ * @param metadata - Optional metadata about the export (author, license, source URL)
+ * @returns Export object ready to be serialized to JSON
+ *
+ * @example
+ * ```ts
+ * const template = campaignStore.getFieldTemplate('combat-stats');
+ * const exported = exportFieldTemplate(template, {
+ *   author: 'Jane Smith',
+ *   license: 'MIT'
+ * });
+ * const json = JSON.stringify(exported, null, 2);
+ * ```
+ */
+export function exportFieldTemplate(
+	template: FieldTemplate,
+	metadata?: { author?: string; sourceUrl?: string; license?: string }
+): EntityTypeExport {
+	return {
+		version: EXPORT_VERSION,
+		exportedAt: new Date(),
+		generator: {
+			name: 'Director Assist',
+			version: APP_VERSION
+		},
+		type: 'field-template',
+		data: template,
+		metadata: metadata ?? {}
+	};
+}
+
+/**
+ * Validate import data and provide preview information
+ *
+ * Checks for:
+ * - Valid version (currently only 1.0.0 supported)
+ * - Required fields (version, type, data, exportedAt, generator)
+ * - Data structure validity (entity type or field template)
+ * - Conflicts with existing types/templates
+ *
+ * @param data - The import data to validate (from JSON.parse)
+ * @param existingTypes - Array of existing entity type keys to check for conflicts
+ * @param existingTemplateIds - Array of existing template IDs to check for conflicts
+ * @returns Validation result with errors, warnings, and preview information
+ *
+ * @example
+ * ```ts
+ * const jsonData = JSON.parse(fileContents);
+ * const existingTypes = ['character', 'npc', 'custom_monster'];
+ * const result = validateImport(jsonData, existingTypes);
+ * if (!result.valid) {
+ *   console.error('Import failed:', result.errors);
+ * } else {
+ *   console.log('Preview:', result.preview);
+ * }
+ * ```
+ */
+export function validateImport(
+	data: unknown,
+	existingTypes?: string[],
+	existingTemplateIds?: string[]
+): ImportValidationResult {
+	const errors: string[] = [];
+	const warnings: string[] = [];
+	let preview = {
+		name: '',
+		type: 'entity-type' as 'entity-type' | 'field-template',
+		fieldCount: 0,
+		conflictsWithExisting: false
+	};
+
+	// Handle null/undefined
+	if (data === null || data === undefined) {
+		errors.push('Import data is null or undefined');
+		return { valid: false, errors, warnings, preview };
+	}
+
+	// Must be an object
+	if (typeof data !== 'object') {
+		errors.push('Import data must be an object');
+		return { valid: false, errors, warnings, preview };
+	}
+
+	const exportData = data as Record<string, unknown>;
+
+	// Validate version
+	if (!exportData.version) {
+		errors.push('Missing required field: version');
+	} else if (exportData.version !== '1.0.0') {
+		errors.push(`Unsupported version: ${exportData.version}. Only version 1.0.0 is supported.`);
+	}
+
+	// Validate required fields
+	if (!exportData.type) {
+		errors.push('Missing required field: type');
+	}
+	if (!exportData.data) {
+		errors.push('Missing required field: data');
+	}
+	if (!exportData.exportedAt) {
+		errors.push('Missing required field: exportedAt');
+	}
+	if (!exportData.generator) {
+		errors.push('Missing required field: generator');
+	}
+
+	// If basic validation failed, return early
+	if (errors.length > 0) {
+		return { valid: false, errors, warnings, preview };
+	}
+
+	// Validate type field
+	const type = exportData.type as string;
+	if (type !== 'entity-type' && type !== 'field-template') {
+		errors.push(`Invalid type: ${type}. Must be 'entity-type' or 'field-template'.`);
+		return { valid: false, errors, warnings, preview };
+	}
+
+	preview.type = type as 'entity-type' | 'field-template';
+
+	// Validate data structure based on type
+	const exportedData = exportData.data as Record<string, unknown>;
+	if (!exportedData || typeof exportedData !== 'object') {
+		errors.push('Data field must be an object');
+		return { valid: false, errors, warnings, preview };
+	}
+
+	if (type === 'entity-type') {
+		// Validate EntityTypeDefinition structure
+		const entityType = exportedData as Partial<EntityTypeDefinition>;
+
+		if (!entityType.type || typeof entityType.type !== 'string') {
+			errors.push('Entity type data missing or invalid: type');
+		}
+		if (!entityType.label || typeof entityType.label !== 'string') {
+			errors.push('Entity type data missing or invalid: label');
+		}
+		if (!entityType.icon || typeof entityType.icon !== 'string') {
+			errors.push('Entity type data missing or invalid: icon');
+		}
+		if (!entityType.color || typeof entityType.color !== 'string') {
+			errors.push('Entity type data missing or invalid: color');
+		}
+		if (entityType.isBuiltIn === undefined || typeof entityType.isBuiltIn !== 'boolean') {
+			errors.push('Entity type data missing or invalid: isBuiltIn');
+		}
+		if (!Array.isArray(entityType.fieldDefinitions)) {
+			errors.push('Entity type data missing or invalid: fieldDefinitions');
+		} else {
+			// Validate field definitions
+			entityType.fieldDefinitions.forEach((field, index) => {
+				if (!field.key || typeof field.key !== 'string') {
+					errors.push(`Entity type field definition ${index} missing or invalid: key`);
+				}
+				if (!field.label || typeof field.label !== 'string') {
+					errors.push(`Entity type field definition ${index} missing or invalid: label`);
+				}
+				if (!field.type || typeof field.type !== 'string') {
+					errors.push(`Entity type field definition ${index} missing or invalid: type`);
+				}
+				if (field.required === undefined || typeof field.required !== 'boolean') {
+					errors.push(`Entity type field definition ${index} missing or invalid: required`);
+				}
+				if (field.order === undefined || typeof field.order !== 'number') {
+					errors.push(`Entity type field definition ${index} missing or invalid: order`);
+				}
+			});
+
+			preview.fieldCount = entityType.fieldDefinitions.length;
+		}
+		if (!Array.isArray(entityType.defaultRelationships)) {
+			errors.push('Entity type data missing or invalid: defaultRelationships');
+		}
+
+		if (entityType.label) {
+			preview.name = entityType.label;
+		}
+
+		// Check for conflicts
+		if (existingTypes && entityType.type && existingTypes.includes(entityType.type)) {
+			preview.conflictsWithExisting = true;
+			warnings.push(
+				`An entity type with key "${entityType.type}" already exists. Importing will require choosing a different key.`
+			);
+		}
+	} else if (type === 'field-template') {
+		// Validate FieldTemplate structure
+		const template = exportedData as Partial<FieldTemplate>;
+
+		if (!template.id || typeof template.id !== 'string') {
+			errors.push('Field template data missing or invalid: id');
+		}
+		if (!template.name || typeof template.name !== 'string') {
+			errors.push('Field template data missing or invalid: name');
+		}
+		if (!template.category || typeof template.category !== 'string') {
+			errors.push('Field template data missing or invalid: category');
+		}
+		if (!Array.isArray(template.fieldDefinitions)) {
+			errors.push('Field template data missing or invalid: fieldDefinitions');
+		} else {
+			// Validate field definitions (same as entity type)
+			template.fieldDefinitions.forEach((field, index) => {
+				if (!field.key || typeof field.key !== 'string') {
+					errors.push(`Template field definition ${index} missing or invalid: key`);
+				}
+				if (!field.label || typeof field.label !== 'string') {
+					errors.push(`Template field definition ${index} missing or invalid: label`);
+				}
+				if (!field.type || typeof field.type !== 'string') {
+					errors.push(`Template field definition ${index} missing or invalid: type`);
+				}
+				if (field.required === undefined || typeof field.required !== 'boolean') {
+					errors.push(`Template field definition ${index} missing or invalid: required`);
+				}
+				if (field.order === undefined || typeof field.order !== 'number') {
+					errors.push(`Template field definition ${index} missing or invalid: order`);
+				}
+			});
+
+			preview.fieldCount = template.fieldDefinitions.length;
+		}
+		if (!template.createdAt) {
+			errors.push('Field template data missing or invalid: createdAt');
+		}
+		if (!template.updatedAt) {
+			errors.push('Field template data missing or invalid: updatedAt');
+		}
+
+		if (template.name) {
+			preview.name = template.name;
+		}
+
+		// Check for conflicts
+		if (existingTemplateIds && template.id && existingTemplateIds.includes(template.id)) {
+			preview.conflictsWithExisting = true;
+			warnings.push(
+				`A field template with ID "${template.id}" already exists. Importing will replace the existing template.`
+			);
+		}
+	}
+
+	// Check for old version warning
+	const generator = exportData.generator as Record<string, unknown>;
+	if (generator?.version && typeof generator.version === 'string') {
+		const exportVersion = generator.version;
+		// Simple version comparison - just check if it's very old
+		const [major] = exportVersion.split('.').map(Number);
+		if (major === 0 && exportVersion !== APP_VERSION) {
+			warnings.push(
+				`This export was created with an old version of Director Assist (${exportVersion}). Some features may not be fully compatible.`
+			);
+		}
+	}
+
+	// Check for old export date warning
+	if (exportData.exportedAt) {
+		const exportDate = new Date(exportData.exportedAt as string);
+		const now = new Date();
+		const yearAgo = new Date(now.getFullYear() - 1, now.getMonth(), now.getDate());
+		if (exportDate < yearAgo) {
+			warnings.push('This export is over a year old and may not include newer features.');
+		}
+	}
+
+	return {
+		valid: errors.length === 0,
+		errors,
+		warnings,
+		preview
+	};
+}

--- a/src/lib/types/campaign.ts
+++ b/src/lib/types/campaign.ts
@@ -1,4 +1,10 @@
-import type { EntityId, EntityTypeDefinition, EntityTypeOverride, BaseEntity } from './entities';
+import type {
+	EntityId,
+	EntityTypeDefinition,
+	EntityTypeOverride,
+	BaseEntity,
+	FieldDefinition
+} from './entities';
 import type { ChatMessage } from './ai';
 
 // Campaign model
@@ -28,6 +34,23 @@ export interface CampaignSettings {
 }
 
 /**
+ * Field Template Interface (GitHub Issue #210)
+ *
+ * Represents a reusable collection of field definitions that can be applied
+ * to custom entity types. Field templates allow users to save and share
+ * common field configurations.
+ */
+export interface FieldTemplate {
+	id: string; // Unique identifier
+	name: string; // Display name
+	description?: string; // Usage description
+	category: string; // Organization category (e.g., 'draw-steel', 'user')
+	fieldDefinitions: FieldDefinition[]; // Field definitions in this template
+	createdAt: Date; // When template was created
+	updatedAt: Date; // When template was last updated
+}
+
+/**
  * Campaign-specific metadata stored in the entity's metadata field.
  * This is used when Campaign is stored as a BaseEntity.
  */
@@ -35,6 +58,7 @@ export interface CampaignMetadata {
 	systemId?: string; // Game system identifier (e.g., 'draw-steel', 'system-agnostic')
 	customEntityTypes: EntityTypeDefinition[];
 	entityTypeOverrides: EntityTypeOverride[];
+	fieldTemplates?: FieldTemplate[]; // User-created field templates (Issue #210)
 	settings: CampaignSettings;
 }
 

--- a/src/lib/types/entityTypeExport.ts
+++ b/src/lib/types/entityTypeExport.ts
@@ -1,0 +1,48 @@
+/**
+ * Entity Type Export/Import Types (GitHub Issue #210)
+ *
+ * Type definitions for exporting and importing custom entity types and field templates.
+ * Enables sharing of custom entity configurations as JSON files.
+ */
+
+import type { EntityTypeDefinition } from './entities';
+import type { FieldTemplate } from './campaign';
+
+/**
+ * Export format for entity types and field templates
+ * Version 1.0.0 structure
+ */
+export interface EntityTypeExport {
+	version: '1.0.0'; // Export format version
+	exportedAt: Date; // Timestamp of export
+	generator: {
+		name: 'Director Assist'; // Application name
+		version: string; // Application version (e.g., "0.8.0")
+	};
+	type: 'entity-type' | 'field-template'; // Type of export
+	data: EntityTypeDefinition | FieldTemplate; // The exported data
+	metadata: {
+		// Optional metadata about the export
+		author?: string; // Creator of the entity type/template
+		sourceUrl?: string; // URL to original source
+		license?: string; // License information (e.g., "CC-BY-4.0", "MIT")
+		[key: string]: unknown; // Allow additional custom metadata
+	};
+}
+
+/**
+ * Result of import validation
+ * Provides validation status, errors, warnings, and preview information
+ */
+export interface ImportValidationResult {
+	valid: boolean; // Whether the import data is valid
+	errors: string[]; // Critical errors that prevent import
+	warnings: string[]; // Non-critical warnings (e.g., old version, potential conflicts)
+	preview: {
+		// Preview information for user before importing
+		name: string; // Name of the entity type or template
+		type: 'entity-type' | 'field-template'; // Type being imported
+		fieldCount: number; // Number of field definitions
+		conflictsWithExisting: boolean; // Whether this conflicts with existing data
+	};
+}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -6,3 +6,4 @@ export * from './cache';
 export * from './systems';
 export * from './combat';
 export * from './playerExport';
+export * from './entityTypeExport';

--- a/src/lib/utils/cloneEntityType.test.ts
+++ b/src/lib/utils/cloneEntityType.test.ts
@@ -1,0 +1,756 @@
+/**
+ * Tests for Clone Entity Type Utility (TDD RED Phase)
+ * GitHub Issue #210: Add clone and template library for custom entities
+ *
+ * Tests the cloneEntityType utility function that creates deep copies of
+ * EntityTypeDefinition objects for cloning existing entity types.
+ *
+ * RED Phase: These tests SHOULD FAIL until implementation is complete.
+ *
+ * Covers:
+ * - Cloning built-in entity types
+ * - Cloning custom entity types
+ * - Type key reset to empty string
+ * - Label suffix "(Copy)" addition
+ * - isBuiltIn forced to false
+ * - Deep copying of fieldDefinitions and defaultRelationships
+ * - Immutability (modifications don't affect original)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { cloneEntityType } from './cloneEntityType';
+import type { EntityTypeDefinition, FieldDefinition } from '$lib/types';
+
+describe('cloneEntityType', () => {
+	describe('Basic Cloning Behavior', () => {
+		it('should clone a built-in entity type', () => {
+			const original: EntityTypeDefinition = {
+				type: 'character',
+				label: 'Character',
+				labelPlural: 'Characters',
+				description: 'Player characters',
+				icon: 'user',
+				color: 'blue',
+				isBuiltIn: true,
+				fieldDefinitions: [
+					{
+						key: 'class',
+						label: 'Class',
+						type: 'text',
+						required: false,
+						order: 1
+					}
+				],
+				defaultRelationships: ['member_of', 'knows']
+			};
+
+			const cloned = cloneEntityType(original);
+
+			expect(cloned).toBeDefined();
+			expect(cloned.type).toBe('');
+			expect(cloned.label).toBe('Character (Copy)');
+			expect(cloned.labelPlural).toBe('Characters (Copy)');
+			expect(cloned.isBuiltIn).toBe(false);
+			expect(cloned.icon).toBe('user');
+			expect(cloned.color).toBe('blue');
+			expect(cloned.description).toBe('Player characters');
+		});
+
+		it('should clone a custom entity type', () => {
+			const original: EntityTypeDefinition = {
+				type: 'custom_monster',
+				label: 'Custom Monster',
+				labelPlural: 'Custom Monsters',
+				icon: 'skull',
+				color: 'red',
+				isBuiltIn: false,
+				fieldDefinitions: [
+					{
+						key: 'threat_level',
+						label: 'Threat Level',
+						type: 'select',
+						required: false,
+						options: ['low', 'medium', 'high'],
+						order: 1
+					}
+				],
+				defaultRelationships: ['located_at']
+			};
+
+			const cloned = cloneEntityType(original);
+
+			expect(cloned).toBeDefined();
+			expect(cloned.type).toBe('');
+			expect(cloned.label).toBe('Custom Monster (Copy)');
+			expect(cloned.labelPlural).toBe('Custom Monsters (Copy)');
+			expect(cloned.isBuiltIn).toBe(false);
+		});
+
+		it('should set type to empty string', () => {
+			const original: EntityTypeDefinition = {
+				type: 'npc',
+				label: 'NPC',
+				labelPlural: 'NPCs',
+				icon: 'users',
+				color: 'green',
+				isBuiltIn: true,
+				fieldDefinitions: [],
+				defaultRelationships: []
+			};
+
+			const cloned = cloneEntityType(original);
+
+			expect(cloned.type).toBe('');
+		});
+
+		it('should always set isBuiltIn to false regardless of original', () => {
+			const builtIn: EntityTypeDefinition = {
+				type: 'location',
+				label: 'Location',
+				labelPlural: 'Locations',
+				icon: 'map-pin',
+				color: 'purple',
+				isBuiltIn: true,
+				fieldDefinitions: [],
+				defaultRelationships: []
+			};
+
+			const custom: EntityTypeDefinition = {
+				type: 'custom_type',
+				label: 'Custom Type',
+				labelPlural: 'Custom Types',
+				icon: 'star',
+				color: 'yellow',
+				isBuiltIn: false,
+				fieldDefinitions: [],
+				defaultRelationships: []
+			};
+
+			const clonedBuiltIn = cloneEntityType(builtIn);
+			const clonedCustom = cloneEntityType(custom);
+
+			expect(clonedBuiltIn.isBuiltIn).toBe(false);
+			expect(clonedCustom.isBuiltIn).toBe(false);
+		});
+	});
+
+	describe('Label Suffix Behavior', () => {
+		it('should append "(Copy)" to label', () => {
+			const original: EntityTypeDefinition = {
+				type: 'item',
+				label: 'Item',
+				labelPlural: 'Items',
+				icon: 'package',
+				color: 'orange',
+				isBuiltIn: true,
+				fieldDefinitions: [],
+				defaultRelationships: []
+			};
+
+			const cloned = cloneEntityType(original);
+
+			expect(cloned.label).toBe('Item (Copy)');
+		});
+
+		it('should append "(Copy)" to labelPlural', () => {
+			const original: EntityTypeDefinition = {
+				type: 'faction',
+				label: 'Faction',
+				labelPlural: 'Factions',
+				icon: 'flag',
+				color: 'indigo',
+				isBuiltIn: true,
+				fieldDefinitions: [],
+				defaultRelationships: []
+			};
+
+			const cloned = cloneEntityType(original);
+
+			expect(cloned.labelPlural).toBe('Factions (Copy)');
+		});
+
+		it('should handle labels with existing parentheses', () => {
+			const original: EntityTypeDefinition = {
+				type: 'test',
+				label: 'Test (Beta)',
+				labelPlural: 'Tests (Beta)',
+				icon: 'test-tube',
+				color: 'gray',
+				isBuiltIn: false,
+				fieldDefinitions: [],
+				defaultRelationships: []
+			};
+
+			const cloned = cloneEntityType(original);
+
+			expect(cloned.label).toBe('Test (Beta) (Copy)');
+			expect(cloned.labelPlural).toBe('Tests (Beta) (Copy)');
+		});
+
+		it('should handle labels with multiple words', () => {
+			const original: EntityTypeDefinition = {
+				type: 'timeline_event',
+				label: 'Timeline Event',
+				labelPlural: 'Timeline Events',
+				icon: 'calendar',
+				color: 'blue',
+				isBuiltIn: true,
+				fieldDefinitions: [],
+				defaultRelationships: []
+			};
+
+			const cloned = cloneEntityType(original);
+
+			expect(cloned.label).toBe('Timeline Event (Copy)');
+			expect(cloned.labelPlural).toBe('Timeline Events (Copy)');
+		});
+
+		it('should handle labels that already end with "(Copy)"', () => {
+			const original: EntityTypeDefinition = {
+				type: 'test',
+				label: 'Test (Copy)',
+				labelPlural: 'Tests (Copy)',
+				icon: 'copy',
+				color: 'gray',
+				isBuiltIn: false,
+				fieldDefinitions: [],
+				defaultRelationships: []
+			};
+
+			const cloned = cloneEntityType(original);
+
+			// Should append another (Copy) - user can edit if needed
+			expect(cloned.label).toBe('Test (Copy) (Copy)');
+			expect(cloned.labelPlural).toBe('Tests (Copy) (Copy)');
+		});
+	});
+
+	describe('Field Definitions Deep Copy', () => {
+		it('should deep copy fieldDefinitions array', () => {
+			const original: EntityTypeDefinition = {
+				type: 'character',
+				label: 'Character',
+				labelPlural: 'Characters',
+				icon: 'user',
+				color: 'blue',
+				isBuiltIn: true,
+				fieldDefinitions: [
+					{
+						key: 'level',
+						label: 'Level',
+						type: 'number',
+						required: true,
+						defaultValue: 1,
+						order: 1
+					},
+					{
+						key: 'class',
+						label: 'Class',
+						type: 'select',
+						required: true,
+						options: ['Warrior', 'Mage', 'Rogue'],
+						order: 2
+					}
+				],
+				defaultRelationships: []
+			};
+
+			const cloned = cloneEntityType(original);
+
+			expect(cloned.fieldDefinitions).toEqual(original.fieldDefinitions);
+			expect(cloned.fieldDefinitions).not.toBe(original.fieldDefinitions);
+			expect(cloned.fieldDefinitions[0]).not.toBe(original.fieldDefinitions[0]);
+			expect(cloned.fieldDefinitions[1]).not.toBe(original.fieldDefinitions[1]);
+		});
+
+		it('should preserve all field properties in deep copy', () => {
+			const original: EntityTypeDefinition = {
+				type: 'monster',
+				label: 'Monster',
+				labelPlural: 'Monsters',
+				icon: 'skull',
+				color: 'red',
+				isBuiltIn: false,
+				fieldDefinitions: [
+					{
+						key: 'abilities',
+						label: 'Abilities',
+						type: 'richtext',
+						required: false,
+						placeholder: 'Enter abilities',
+						helpText: 'List special abilities',
+						section: 'combat',
+						order: 1,
+						aiGenerate: true
+					}
+				],
+				defaultRelationships: []
+			};
+
+			const cloned = cloneEntityType(original);
+
+			const clonedField = cloned.fieldDefinitions[0];
+			expect(clonedField.key).toBe('abilities');
+			expect(clonedField.label).toBe('Abilities');
+			expect(clonedField.type).toBe('richtext');
+			expect(clonedField.required).toBe(false);
+			expect(clonedField.placeholder).toBe('Enter abilities');
+			expect(clonedField.helpText).toBe('List special abilities');
+			expect(clonedField.section).toBe('combat');
+			expect(clonedField.order).toBe(1);
+			expect(clonedField.aiGenerate).toBe(true);
+		});
+
+		it('should deep copy field options array', () => {
+			const original: EntityTypeDefinition = {
+				type: 'test',
+				label: 'Test',
+				labelPlural: 'Tests',
+				icon: 'test-tube',
+				color: 'gray',
+				isBuiltIn: false,
+				fieldDefinitions: [
+					{
+						key: 'skills',
+						label: 'Skills',
+						type: 'multi-select',
+						required: false,
+						options: ['Stealth', 'Combat', 'Magic'],
+						order: 1
+					}
+				],
+				defaultRelationships: []
+			};
+
+			const cloned = cloneEntityType(original);
+
+			expect(cloned.fieldDefinitions[0].options).toEqual(['Stealth', 'Combat', 'Magic']);
+			expect(cloned.fieldDefinitions[0].options).not.toBe(original.fieldDefinitions[0].options);
+		});
+
+		it('should deep copy entity types array in field definitions', () => {
+			const original: EntityTypeDefinition = {
+				type: 'quest',
+				label: 'Quest',
+				labelPlural: 'Quests',
+				icon: 'scroll',
+				color: 'amber',
+				isBuiltIn: false,
+				fieldDefinitions: [
+					{
+						key: 'npcs',
+						label: 'Related NPCs',
+						type: 'entity-refs',
+						required: false,
+						entityTypes: ['npc', 'character'],
+						order: 1
+					}
+				],
+				defaultRelationships: []
+			};
+
+			const cloned = cloneEntityType(original);
+
+			expect(cloned.fieldDefinitions[0].entityTypes).toEqual(['npc', 'character']);
+			expect(cloned.fieldDefinitions[0].entityTypes).not.toBe(
+				original.fieldDefinitions[0].entityTypes
+			);
+		});
+
+		it('should handle computed field config deep copy', () => {
+			const original: EntityTypeDefinition = {
+				type: 'stat_block',
+				label: 'Stat Block',
+				labelPlural: 'Stat Blocks',
+				icon: 'calculator',
+				color: 'cyan',
+				isBuiltIn: false,
+				fieldDefinitions: [
+					{
+						key: 'total_power',
+						label: 'Total Power',
+						type: 'computed',
+						required: false,
+						order: 1,
+						computedConfig: {
+							formula: '{strength} + {intelligence}',
+							dependencies: ['strength', 'intelligence'],
+							outputType: 'number'
+						}
+					}
+				],
+				defaultRelationships: []
+			};
+
+			const cloned = cloneEntityType(original);
+
+			expect(cloned.fieldDefinitions[0].computedConfig).toEqual({
+				formula: '{strength} + {intelligence}',
+				dependencies: ['strength', 'intelligence'],
+				outputType: 'number'
+			});
+			expect(cloned.fieldDefinitions[0].computedConfig).not.toBe(
+				original.fieldDefinitions[0].computedConfig
+			);
+			expect(cloned.fieldDefinitions[0].computedConfig?.dependencies).not.toBe(
+				original.fieldDefinitions[0].computedConfig?.dependencies
+			);
+		});
+
+		it('should handle empty fieldDefinitions array', () => {
+			const original: EntityTypeDefinition = {
+				type: 'simple',
+				label: 'Simple',
+				labelPlural: 'Simples',
+				icon: 'circle',
+				color: 'gray',
+				isBuiltIn: false,
+				fieldDefinitions: [],
+				defaultRelationships: []
+			};
+
+			const cloned = cloneEntityType(original);
+
+			expect(cloned.fieldDefinitions).toEqual([]);
+			expect(cloned.fieldDefinitions).not.toBe(original.fieldDefinitions);
+		});
+	});
+
+	describe('Default Relationships Deep Copy', () => {
+		it('should deep copy defaultRelationships array', () => {
+			const original: EntityTypeDefinition = {
+				type: 'character',
+				label: 'Character',
+				labelPlural: 'Characters',
+				icon: 'user',
+				color: 'blue',
+				isBuiltIn: true,
+				fieldDefinitions: [],
+				defaultRelationships: ['member_of', 'knows', 'located_at']
+			};
+
+			const cloned = cloneEntityType(original);
+
+			expect(cloned.defaultRelationships).toEqual(['member_of', 'knows', 'located_at']);
+			expect(cloned.defaultRelationships).not.toBe(original.defaultRelationships);
+		});
+
+		it('should handle empty defaultRelationships array', () => {
+			const original: EntityTypeDefinition = {
+				type: 'test',
+				label: 'Test',
+				labelPlural: 'Tests',
+				icon: 'test-tube',
+				color: 'gray',
+				isBuiltIn: false,
+				fieldDefinitions: [],
+				defaultRelationships: []
+			};
+
+			const cloned = cloneEntityType(original);
+
+			expect(cloned.defaultRelationships).toEqual([]);
+			expect(cloned.defaultRelationships).not.toBe(original.defaultRelationships);
+		});
+
+		it('should handle single relationship in array', () => {
+			const original: EntityTypeDefinition = {
+				type: 'item',
+				label: 'Item',
+				labelPlural: 'Items',
+				icon: 'package',
+				color: 'orange',
+				isBuiltIn: true,
+				fieldDefinitions: [],
+				defaultRelationships: ['owned_by']
+			};
+
+			const cloned = cloneEntityType(original);
+
+			expect(cloned.defaultRelationships).toEqual(['owned_by']);
+			expect(cloned.defaultRelationships).not.toBe(original.defaultRelationships);
+		});
+	});
+
+	describe('Immutability - Modifying Clone Should Not Affect Original', () => {
+		it('should not affect original when modifying cloned basic properties', () => {
+			const original: EntityTypeDefinition = {
+				type: 'character',
+				label: 'Character',
+				labelPlural: 'Characters',
+				icon: 'user',
+				color: 'blue',
+				isBuiltIn: true,
+				fieldDefinitions: [],
+				defaultRelationships: []
+			};
+
+			const cloned = cloneEntityType(original);
+
+			// Modify clone
+			cloned.type = 'new_type';
+			cloned.label = 'New Label';
+			cloned.icon = 'new-icon';
+			cloned.color = 'red';
+
+			// Original should be unchanged
+			expect(original.type).toBe('character');
+			expect(original.label).toBe('Character');
+			expect(original.icon).toBe('user');
+			expect(original.color).toBe('blue');
+		});
+
+		it('should not affect original when modifying cloned fieldDefinitions', () => {
+			const original: EntityTypeDefinition = {
+				type: 'character',
+				label: 'Character',
+				labelPlural: 'Characters',
+				icon: 'user',
+				color: 'blue',
+				isBuiltIn: true,
+				fieldDefinitions: [
+					{
+						key: 'level',
+						label: 'Level',
+						type: 'number',
+						required: false,
+						order: 1
+					}
+				],
+				defaultRelationships: []
+			};
+
+			const cloned = cloneEntityType(original);
+
+			// Modify cloned fieldDefinitions
+			cloned.fieldDefinitions[0].label = 'Modified Level';
+			cloned.fieldDefinitions.push({
+				key: 'new_field',
+				label: 'New Field',
+				type: 'text',
+				required: false,
+				order: 2
+			});
+
+			// Original should be unchanged
+			expect(original.fieldDefinitions).toHaveLength(1);
+			expect(original.fieldDefinitions[0].label).toBe('Level');
+		});
+
+		it('should not affect original when modifying field options', () => {
+			const original: EntityTypeDefinition = {
+				type: 'test',
+				label: 'Test',
+				labelPlural: 'Tests',
+				icon: 'test-tube',
+				color: 'gray',
+				isBuiltIn: false,
+				fieldDefinitions: [
+					{
+						key: 'class',
+						label: 'Class',
+						type: 'select',
+						required: false,
+						options: ['Warrior', 'Mage'],
+						order: 1
+					}
+				],
+				defaultRelationships: []
+			};
+
+			const cloned = cloneEntityType(original);
+
+			// Modify cloned options
+			cloned.fieldDefinitions[0].options?.push('Rogue');
+
+			// Original should be unchanged
+			expect(original.fieldDefinitions[0].options).toEqual(['Warrior', 'Mage']);
+		});
+
+		it('should not affect original when modifying defaultRelationships', () => {
+			const original: EntityTypeDefinition = {
+				type: 'character',
+				label: 'Character',
+				labelPlural: 'Characters',
+				icon: 'user',
+				color: 'blue',
+				isBuiltIn: true,
+				fieldDefinitions: [],
+				defaultRelationships: ['member_of']
+			};
+
+			const cloned = cloneEntityType(original);
+
+			// Modify cloned relationships
+			cloned.defaultRelationships.push('knows');
+			cloned.defaultRelationships.push('located_at');
+
+			// Original should be unchanged
+			expect(original.defaultRelationships).toEqual(['member_of']);
+		});
+
+		it('should not affect original when modifying computed config', () => {
+			const original: EntityTypeDefinition = {
+				type: 'stat_block',
+				label: 'Stat Block',
+				labelPlural: 'Stat Blocks',
+				icon: 'calculator',
+				color: 'cyan',
+				isBuiltIn: false,
+				fieldDefinitions: [
+					{
+						key: 'total',
+						label: 'Total',
+						type: 'computed',
+						required: false,
+						order: 1,
+						computedConfig: {
+							formula: '{a} + {b}',
+							dependencies: ['a', 'b'],
+							outputType: 'number'
+						}
+					}
+				],
+				defaultRelationships: []
+			};
+
+			const cloned = cloneEntityType(original);
+
+			// Modify cloned computed config
+			cloned.fieldDefinitions[0].computedConfig!.formula = '{a} + {b} + {c}';
+			cloned.fieldDefinitions[0].computedConfig!.dependencies.push('c');
+
+			// Original should be unchanged
+			expect(original.fieldDefinitions[0].computedConfig?.formula).toBe('{a} + {b}');
+			expect(original.fieldDefinitions[0].computedConfig?.dependencies).toEqual(['a', 'b']);
+		});
+	});
+
+	describe('Optional Description Field', () => {
+		it('should preserve description when present', () => {
+			const original: EntityTypeDefinition = {
+				type: 'character',
+				label: 'Character',
+				labelPlural: 'Characters',
+				description: 'A player character in the game',
+				icon: 'user',
+				color: 'blue',
+				isBuiltIn: true,
+				fieldDefinitions: [],
+				defaultRelationships: []
+			};
+
+			const cloned = cloneEntityType(original);
+
+			expect(cloned.description).toBe('A player character in the game');
+		});
+
+		it('should handle undefined description', () => {
+			const original: EntityTypeDefinition = {
+				type: 'character',
+				label: 'Character',
+				labelPlural: 'Characters',
+				icon: 'user',
+				color: 'blue',
+				isBuiltIn: true,
+				fieldDefinitions: [],
+				defaultRelationships: []
+			};
+
+			const cloned = cloneEntityType(original);
+
+			expect(cloned.description).toBeUndefined();
+		});
+
+		it('should not affect original when modifying description', () => {
+			const original: EntityTypeDefinition = {
+				type: 'character',
+				label: 'Character',
+				labelPlural: 'Characters',
+				description: 'Original description',
+				icon: 'user',
+				color: 'blue',
+				isBuiltIn: true,
+				fieldDefinitions: [],
+				defaultRelationships: []
+			};
+
+			const cloned = cloneEntityType(original);
+			cloned.description = 'Modified description';
+
+			expect(original.description).toBe('Original description');
+		});
+	});
+
+	describe('Complex Entity Type Cloning', () => {
+		it('should clone a complex entity type with all features', () => {
+			const original: EntityTypeDefinition = {
+				type: 'ds-monster-threat',
+				label: 'Monster/Threat',
+				labelPlural: 'Monsters/Threats',
+				description: 'Track enemies and creatures for encounters',
+				icon: 'skull',
+				color: 'red',
+				isBuiltIn: false,
+				fieldDefinitions: [
+					{
+						key: 'threat_level',
+						label: 'Threat Level',
+						type: 'select',
+						required: false,
+						options: ['minion', 'standard', 'boss'],
+						order: 1
+					},
+					{
+						key: 'role',
+						label: 'Role',
+						type: 'select',
+						required: false,
+						options: ['ambusher', 'brute', 'defender'],
+						order: 2
+					},
+					{
+						key: 'ac',
+						label: 'AC',
+						type: 'number',
+						required: false,
+						order: 3
+					},
+					{
+						key: 'hp',
+						label: 'HP',
+						type: 'number',
+						required: false,
+						order: 4
+					},
+					{
+						key: 'abilities',
+						label: 'Abilities',
+						type: 'richtext',
+						required: false,
+						order: 5,
+						aiGenerate: true
+					}
+				],
+				defaultRelationships: ['located_at', 'part_of']
+			};
+
+			const cloned = cloneEntityType(original);
+
+			// Verify all aspects were cloned correctly
+			expect(cloned.type).toBe('');
+			expect(cloned.label).toBe('Monster/Threat (Copy)');
+			expect(cloned.labelPlural).toBe('Monsters/Threats (Copy)');
+			expect(cloned.description).toBe('Track enemies and creatures for encounters');
+			expect(cloned.icon).toBe('skull');
+			expect(cloned.color).toBe('red');
+			expect(cloned.isBuiltIn).toBe(false);
+			expect(cloned.fieldDefinitions).toHaveLength(5);
+			expect(cloned.defaultRelationships).toEqual(['located_at', 'part_of']);
+
+			// Verify deep copy
+			expect(cloned.fieldDefinitions).not.toBe(original.fieldDefinitions);
+			expect(cloned.defaultRelationships).not.toBe(original.defaultRelationships);
+		});
+	});
+});

--- a/src/lib/utils/cloneEntityType.ts
+++ b/src/lib/utils/cloneEntityType.ts
@@ -1,0 +1,57 @@
+/**
+ * Clone Entity Type Utility (GitHub Issue #210)
+ *
+ * Provides deep cloning functionality for EntityTypeDefinition objects.
+ * Used when users want to clone existing entity types as a starting point for new custom types.
+ *
+ * Key behaviors:
+ * - Deep clones all properties (fieldDefinitions, defaultRelationships, etc.)
+ * - Resets type to empty string (user must provide new unique key)
+ * - Forces isBuiltIn to false (clones are always custom types)
+ * - Appends "(Copy)" to labels for clarity
+ * - Ensures immutability (modifications to clone don't affect original)
+ */
+
+import type { EntityTypeDefinition } from '$lib/types';
+
+/**
+ * Creates a deep clone of an entity type definition suitable for creating a new custom type.
+ *
+ * The cloned entity type will have:
+ * - `type` set to empty string (user must provide new unique key)
+ * - `isBuiltIn` set to false (all clones are custom types)
+ * - Labels suffixed with "(Copy)" to indicate it's a clone
+ * - All nested objects/arrays deep cloned for immutability
+ *
+ * @param original - The entity type definition to clone
+ * @returns A new entity type definition ready to be customized
+ *
+ * @example
+ * ```ts
+ * const characterType = getEntityType('character');
+ * const cloned = cloneEntityType(characterType);
+ * cloned.type = 'hero'; // User provides new key
+ * cloned.label = 'Hero'; // User can customize
+ * ```
+ */
+export function cloneEntityType(original: EntityTypeDefinition): EntityTypeDefinition {
+	// Deep clone using structuredClone (modern browser API)
+	// This handles nested objects, arrays, dates, etc. properly
+	const cloned = structuredClone(original);
+
+	// Reset type to empty string - user must provide new unique key
+	cloned.type = '';
+
+	// Always set isBuiltIn to false - clones are custom types
+	cloned.isBuiltIn = false;
+
+	// Append "(Copy)" to label
+	cloned.label = `${original.label} (Copy)`;
+
+	// Append "(Copy)" to labelPlural if it exists
+	if (original.labelPlural) {
+		cloned.labelPlural = `${original.labelPlural} (Copy)`;
+	}
+
+	return cloned;
+}


### PR DESCRIPTION
## Summary

Phase 3 of Custom Entity UX Improvements - implements the backend/service layer for:

- **Clone Entity Type Utility** - Deep clone EntityTypeDefinition objects with proper key/label handling
- **Field Template Library** - CRUD operations for reusable field definition patterns stored in campaign metadata
- **Export/Import Service** - Community sharing with comprehensive validation (format v1.0.0)

## Changes

### New Files
- `src/lib/utils/cloneEntityType.ts` - Clone utility
- `src/lib/services/entityTypeExportService.ts` - Export/import with validation
- `src/lib/types/entityTypeExport.ts` - Export format types

### Modified Files
- `src/lib/types/campaign.ts` - Added `FieldTemplate` interface
- `src/lib/stores/campaign.svelte.ts` - Added field template CRUD methods
- Documentation (CHANGELOG, USER_GUIDE, API, ARCHITECTURE)

## Test Plan

- [x] 27 tests for clone utility (deep copy, immutability, label handling)
- [x] 24 tests for field template CRUD operations
- [x] 40 tests for export/import service (validation, round-trip, conflicts)
- [x] All 111 tests passing
- [x] Build succeeds (`npm run build`)

Closes #210

🤖 Generated with [Claude Code](https://claude.ai/code)