### PR TITLE
feat(#48): add forced campaign linking option for entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+**Forced Campaign Linking Option (Issue #48)**
+- New "Enforce Campaign Linking" setting automatically links all new entities to campaigns
+- When enabled, creates 'belongs_to_campaign' relationship on entity creation
+- Bulk linking modal offers to link existing unlinked entities when first enabled
+- Shows entity count and allows campaign selection for bulk operations
+- Handles multiple scenarios: single campaign (auto-link), multiple campaigns (select default), no campaigns (disabled)
+- Default campaign selector appears when multiple campaigns exist
+- Info banner on entity creation forms indicates when auto-linking is active
+- CampaignLinkingSettings component provides settings UI with toggle and dropdown
+- BulkCampaignLinkingModal component handles bulk linking workflow
+- New campaign store methods: setEnforceCampaignLinking(), setDefaultCampaignId()
+- New entity repository method: getEntitiesWithoutCampaignLink() for identifying unlinked entities
+- Settings stored in campaign metadata: enforceCampaignLinking, defaultCampaignId
+
 ## [0.9.0] - 2026-01-21
 
 ### Added

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1230,6 +1230,7 @@ Each campaign has its own settings stored separately:
 - **Entity Type Overrides**: Customize built-in entity types for this campaign
 - **Custom Relationships**: Define custom relationship types
 - **Enabled Entity Types**: Control which entity types appear in the UI
+- **Campaign Linking**: Automatically link new entities to campaigns (see Settings → Campaign Linking for details)
 
 Access campaign-specific settings:
 1. View the campaign details
@@ -1371,6 +1372,88 @@ When generating content with AI, Director Assist can include information about r
 - You can override the default on a per-entity basis when editing
 - Settings persist across browser sessions
 - Not included in backups (local preference only)
+
+### Campaign Linking
+
+The Campaign Linking feature automatically creates relationships between entities and campaigns, helping you organize which entities belong to which campaign.
+
+**What It Does:**
+
+When enabled, Director Assist automatically:
+- Links all newly created entities to campaigns using the 'belongs_to_campaign' relationship
+- Offers to bulk-link existing unlinked entities when you first enable the setting
+- Maintains campaign organization without manual relationship creation
+
+**How to Enable:**
+
+1. Open Settings (gear icon in header or `/settings` command)
+2. Scroll to the "Campaign Linking" section
+3. Check "Enforce Campaign Linking"
+4. If you have existing unlinked entities, a modal appears with options to link them
+
+**Bulk Linking Modal:**
+
+When you enable campaign linking for the first time with existing entities:
+
+1. Modal shows count of unlinked entities
+2. Choose a campaign to link them to (if multiple campaigns exist)
+3. Three options:
+   - **Link All**: Links all existing unlinked entities to the selected campaign
+   - **Skip**: Enables the setting without linking existing entities (only new entities will be linked)
+   - **Cancel**: Cancels enabling the feature
+
+**Default Campaign Selection:**
+
+When you have multiple campaigns:
+
+- A "Default Campaign" dropdown appears in the Campaign Linking settings
+- Select which campaign new entities should automatically link to
+- Only visible when multiple campaigns exist
+- Can be changed at any time
+
+**Behavior by Scenario:**
+
+**Single Campaign:**
+- New entities automatically link to your campaign
+- No campaign selection needed
+
+**Multiple Campaigns:**
+- New entities link to the selected default campaign
+- Change the default campaign anytime in Settings
+- Default campaign dropdown appears below the toggle
+
+**No Campaigns:**
+- Setting is disabled (grayed out)
+- Create a campaign first to enable this feature
+- Message appears: "Please create a campaign first to enable this feature"
+
+**When Auto-Linking is Active:**
+
+On entity creation forms, an info banner appears:
+- Indicates the entity will be automatically linked to a campaign
+- Shows which campaign it will link to
+- No action required from you
+
+**Benefits:**
+
+- Maintains clear campaign organization automatically
+- Eliminates manual relationship creation for campaign membership
+- Makes it easier to filter entities by campaign
+- Useful when managing multiple campaigns simultaneously
+
+**Disabling the Feature:**
+
+1. Open Settings
+2. Uncheck "Enforce Campaign Linking"
+3. New entities will no longer be automatically linked
+4. Existing relationships remain unchanged
+
+**Important Notes:**
+
+- Disabling the setting doesn't remove existing campaign links
+- Only affects new entity creation, not existing entities
+- Setting is stored per-campaign in campaign metadata
+- Works seamlessly with the relationship system
 
 ## AI Features
 

--- a/src/lib/components/settings/BulkCampaignLinkingModal.svelte
+++ b/src/lib/components/settings/BulkCampaignLinkingModal.svelte
@@ -1,0 +1,411 @@
+<script lang="ts">
+	import { entityRepository } from '$lib/db/repositories';
+	import type { BaseEntity } from '$lib/types';
+
+	interface Props {
+		open: boolean;
+		unlinkedEntities: BaseEntity[];
+		campaigns: BaseEntity[];
+		defaultCampaignId?: string;
+		onConfirm: (linkedCount: number) => void;
+		onSkip: () => void;
+		onCancel: () => void;
+	}
+
+	let {
+		open = false,
+		unlinkedEntities,
+		campaigns,
+		defaultCampaignId,
+		onConfirm,
+		onSkip,
+		onCancel
+	}: Props = $props();
+
+	// State
+	let selectedCampaignId = $state('');
+	let isLinking = $state(false);
+	let errorMessage = $state('');
+	let successMessage = $state('');
+
+	// Derived values
+	const hasSingleCampaign = $derived(campaigns.length === 1);
+	const selectedCampaign = $derived(
+		campaigns.find((c) => c.id === selectedCampaignId)
+	);
+
+	// Initialize selected campaign
+	$effect(() => {
+		if (open) {
+			if (defaultCampaignId) {
+				selectedCampaignId = defaultCampaignId;
+			} else if (campaigns.length > 0) {
+				selectedCampaignId = campaigns[0].id;
+			}
+			// Reset messages
+			errorMessage = '';
+			successMessage = '';
+		}
+	});
+
+	function handleCampaignChange(event: Event) {
+		const target = event.target as HTMLSelectElement;
+		selectedCampaignId = target.value;
+	}
+
+	async function handleLinkAll() {
+		if (!selectedCampaignId || isLinking) return;
+
+		isLinking = true;
+		errorMessage = '';
+		successMessage = '';
+
+		try {
+			const entityIds = unlinkedEntities.map((e) => e.id);
+			const linkedCount = await entityRepository.bulkLinkToCampaign(
+				entityIds,
+				selectedCampaignId
+			);
+
+			successMessage = `Successfully linked ${linkedCount} entities`;
+
+			// Wait a moment to show success message
+			setTimeout(() => {
+				onConfirm(linkedCount);
+			}, 500);
+		} catch (error) {
+			console.error('Failed to link entities:', error);
+			errorMessage = 'Failed to link entities. Please try again.';
+			isLinking = false;
+		}
+	}
+
+	function handleSkip() {
+		if (isLinking) return;
+		onSkip();
+	}
+
+	function handleCancel() {
+		if (isLinking) return;
+		onCancel();
+	}
+
+	function handleBackdropClick(event: MouseEvent) {
+		if (event.target === event.currentTarget) {
+			handleCancel();
+		}
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape' && !isLinking) {
+			handleCancel();
+		}
+	}
+
+	// Focus management
+	let linkAllButton = $state<HTMLButtonElement | null>(null);
+	$effect(() => {
+		if (open && linkAllButton) {
+			linkAllButton.focus();
+		}
+	});
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+{#if open}
+	<div
+		class="modal-backdrop"
+		onclick={handleBackdropClick}
+		role="presentation"
+	>
+		<div
+			class="modal-content"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="modal-title"
+		>
+			<div class="modal-header">
+				<h2 id="modal-title" class="text-xl font-semibold">
+					Link Existing Entities
+				</h2>
+			</div>
+
+			<div class="modal-body">
+				{#if unlinkedEntities.length === 0}
+					<!-- Empty state: all entities are already linked (Issue #48) -->
+					<div class="text-center py-8">
+						<p class="text-lg font-medium text-green-600 dark:text-green-400 mb-2">
+							All entities are already linked to campaigns!
+						</p>
+						<p class="text-sm text-slate-600 dark:text-slate-400">
+							No action needed - you're all set.
+						</p>
+					</div>
+				{:else}
+					<p class="mb-4">
+						Found {unlinkedEntities.length} {unlinkedEntities.length === 1 ? 'entity' : 'entities'} that are not linked to any campaign.
+						Would you like to link them now?
+					</p>
+
+					{#if hasSingleCampaign}
+						<p class="mb-4 text-sm">
+							All entities will be linked to <strong>{campaigns[0].name}</strong>.
+						</p>
+					{:else}
+						<div class="mb-4">
+							<label for="campaign-select" class="label">Select Campaign</label>
+							<select
+								id="campaign-select"
+								class="input w-full"
+								value={selectedCampaignId}
+								onchange={handleCampaignChange}
+								disabled={isLinking}
+								aria-label="Select Campaign"
+							>
+								{#each campaigns as campaign}
+									<option value={campaign.id}>{campaign.name}</option>
+								{/each}
+							</select>
+						</div>
+					{/if}
+
+					<!-- Entity List -->
+					<div class="entity-list" data-testid="entity-list" role="list">
+						{#each unlinkedEntities as entity}
+							<div class="entity-item" role="listitem">
+								<span class="entity-name">{entity.name}</span>
+								<span class="entity-type">{entity.type}</span>
+							</div>
+						{/each}
+					</div>
+				{/if}
+
+				{#if isLinking}
+					<p class="text-sm text-blue-600 dark:text-blue-400 mt-4">
+						Linking entities...
+					</p>
+				{/if}
+
+				{#if successMessage}
+					<p class="text-sm text-green-600 dark:text-green-400 mt-4">
+						{successMessage}
+					</p>
+				{/if}
+
+				{#if errorMessage}
+					<p class="text-sm text-red-600 dark:text-red-400 mt-4">
+						{errorMessage}
+					</p>
+				{/if}
+			</div>
+
+			<div class="modal-footer">
+				{#if unlinkedEntities.length === 0}
+					<!-- Only show close button for empty state -->
+					<button
+						class="btn btn-primary"
+						onclick={handleCancel}
+						aria-label="Close"
+					>
+						Close
+					</button>
+				{:else}
+					<button
+						bind:this={linkAllButton}
+						class="btn btn-primary"
+						onclick={handleLinkAll}
+						disabled={isLinking}
+						aria-label="Link All"
+					>
+						Link All
+					</button>
+					<button
+						class="btn btn-secondary"
+						onclick={handleSkip}
+						disabled={isLinking}
+						aria-label="Skip"
+					>
+						Skip
+					</button>
+					<button
+						class="btn btn-ghost"
+						onclick={handleCancel}
+						disabled={isLinking}
+						aria-label="Cancel"
+					>
+						Cancel
+					</button>
+				{/if}
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.modal-backdrop {
+		position: fixed;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		background-color: rgba(0, 0, 0, 0.5);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 1000;
+	}
+
+	.modal-content {
+		background-color: white;
+		border-radius: 0.5rem;
+		max-width: 600px;
+		width: 90%;
+		max-height: 80vh;
+		display: flex;
+		flex-direction: column;
+		box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
+	}
+
+	:global(.dark) .modal-content {
+		background-color: #1e293b;
+	}
+
+	.modal-header {
+		padding: 1.5rem;
+		border-bottom: 1px solid #e2e8f0;
+	}
+
+	:global(.dark) .modal-header {
+		border-bottom-color: #475569;
+	}
+
+	.modal-body {
+		padding: 1.5rem;
+		overflow-y: auto;
+		flex: 1;
+	}
+
+	.modal-footer {
+		padding: 1.5rem;
+		border-top: 1px solid #e2e8f0;
+		display: flex;
+		gap: 0.75rem;
+		justify-content: flex-end;
+	}
+
+	:global(.dark) .modal-footer {
+		border-top-color: #475569;
+	}
+
+	.label {
+		display: block;
+		font-size: 0.875rem;
+		font-weight: 500;
+		margin-bottom: 0.5rem;
+	}
+
+	.input {
+		padding: 0.5rem;
+		border: 1px solid #cbd5e1;
+		border-radius: 0.375rem;
+		background-color: white;
+	}
+
+	:global(.dark) .input {
+		background-color: #1e293b;
+		border-color: #475569;
+		color: white;
+	}
+
+	.entity-list {
+		max-height: 300px;
+		overflow-y: auto;
+		border: 1px solid #e2e8f0;
+		border-radius: 0.375rem;
+		padding: 0.5rem;
+	}
+
+	:global(.dark) .entity-list {
+		border-color: #475569;
+	}
+
+	.entity-item {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 0.5rem;
+		border-bottom: 1px solid #f1f5f9;
+	}
+
+	:global(.dark) .entity-item {
+		border-bottom-color: #334155;
+	}
+
+	.entity-item:last-child {
+		border-bottom: none;
+	}
+
+	.entity-name {
+		font-weight: 500;
+	}
+
+	.entity-type {
+		font-size: 0.875rem;
+		color: #64748b;
+		text-transform: capitalize;
+	}
+
+	:global(.dark) .entity-type {
+		color: #94a3b8;
+	}
+
+	.btn {
+		padding: 0.5rem 1rem;
+		border-radius: 0.375rem;
+		font-weight: 500;
+		cursor: pointer;
+		border: none;
+		transition: all 0.2s;
+	}
+
+	.btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.btn-primary {
+		background-color: #3b82f6;
+		color: white;
+	}
+
+	.btn-primary:hover:not(:disabled) {
+		background-color: #2563eb;
+	}
+
+	.btn-secondary {
+		background-color: #64748b;
+		color: white;
+	}
+
+	.btn-secondary:hover:not(:disabled) {
+		background-color: #475569;
+	}
+
+	.btn-ghost {
+		background-color: transparent;
+		color: #64748b;
+	}
+
+	.btn-ghost:hover:not(:disabled) {
+		background-color: #f1f5f9;
+	}
+
+	:global(.dark) .btn-ghost {
+		color: #94a3b8;
+	}
+
+	:global(.dark) .btn-ghost:hover:not(:disabled) {
+		background-color: #334155;
+	}
+</style>

--- a/src/lib/components/settings/BulkCampaignLinkingModal.test.ts
+++ b/src/lib/components/settings/BulkCampaignLinkingModal.test.ts
@@ -1,0 +1,581 @@
+/**
+ * Tests for BulkCampaignLinkingModal Component - Issue #48
+ *
+ * RED Phase (TDD): These tests define expected behavior before implementation.
+ * Tests should FAIL until the component is implemented.
+ *
+ * This modal appears when enabling "Enforce Campaign Linking" and there are
+ * unlinked entities. It should:
+ * - Display the count of unlinked entities
+ * - Allow campaign selection (when multiple campaigns exist)
+ * - Provide "Link All", "Skip", and "Cancel" actions
+ * - Call bulkLinkToCampaign repository method on confirm
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import BulkCampaignLinkingModal from './BulkCampaignLinkingModal.svelte';
+import type { BaseEntity } from '$lib/types';
+
+// Use vi.hoisted to make mockBulkLinkToCampaign available to hoisted vi.mock call
+const { mockBulkLinkToCampaign } = vi.hoisted(() => ({
+	mockBulkLinkToCampaign: vi.fn()
+}));
+
+// Mock the entity repository
+vi.mock('$lib/db/repositories', () => ({
+	entityRepository: {
+		bulkLinkToCampaign: mockBulkLinkToCampaign
+	}
+}));
+
+describe('BulkCampaignLinkingModal Component', () => {
+	let unlinkedEntities: BaseEntity[];
+	let campaigns: BaseEntity[];
+	let defaultProps: any;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		unlinkedEntities = [
+			{
+				id: 'char-1',
+				type: 'character',
+				name: 'Hero',
+				description: 'A brave hero',
+				tags: [],
+				fields: {},
+				links: [],
+				notes: '',
+				createdAt: new Date(),
+				updatedAt: new Date()
+			},
+			{
+				id: 'char-2',
+				type: 'character',
+				name: 'Sidekick',
+				description: 'A loyal sidekick',
+				tags: [],
+				fields: {},
+				links: [],
+				notes: '',
+				createdAt: new Date(),
+				updatedAt: new Date()
+			},
+			{
+				id: 'npc-1',
+				type: 'npc',
+				name: 'Villain',
+				description: 'A dastardly villain',
+				tags: [],
+				fields: {},
+				links: [],
+				notes: '',
+				createdAt: new Date(),
+				updatedAt: new Date()
+			}
+		];
+
+		campaigns = [
+			{
+				id: 'campaign-1',
+				type: 'campaign',
+				name: 'Test Campaign',
+				description: 'Test campaign',
+				tags: [],
+				fields: {},
+				links: [],
+				notes: '',
+				createdAt: new Date(),
+				updatedAt: new Date()
+			}
+		];
+
+		defaultProps = {
+			open: true,
+			unlinkedEntities,
+			campaigns,
+			defaultCampaignId: 'campaign-1',
+			onConfirm: vi.fn(),
+			onSkip: vi.fn(),
+			onCancel: vi.fn()
+		};
+
+		mockBulkLinkToCampaign.mockResolvedValue(3);
+	});
+
+	describe('Modal Rendering', () => {
+		it('should render as a dialog when open', () => {
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const dialog = screen.getByRole('dialog');
+			expect(dialog).toBeInTheDocument();
+		});
+
+		it('should not render when open is false', () => {
+			render(BulkCampaignLinkingModal, { props: { ...defaultProps, open: false } });
+
+			const dialog = screen.queryByRole('dialog');
+			expect(dialog).not.toBeInTheDocument();
+		});
+
+		it('should display modal title', () => {
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			expect(screen.getByText(/link existing entities/i)).toBeInTheDocument();
+		});
+
+		it('should show count of unlinked entities', () => {
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			expect(screen.getByText(/3 entities/i)).toBeInTheDocument();
+		});
+
+		it('should display explanatory text', () => {
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			expect(
+				screen.getByText(/found \d+ entities? that are not linked to any campaign/i)
+			).toBeInTheDocument();
+		});
+	});
+
+	describe('Single Campaign Scenario', () => {
+		it('should not show campaign selector for single campaign', () => {
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const selector = screen.queryByLabelText(/select campaign/i);
+			expect(selector).not.toBeInTheDocument();
+		});
+
+		it('should display the campaign name that will be linked', () => {
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			expect(screen.getByText(/test campaign/i)).toBeInTheDocument();
+		});
+
+		it('should call bulkLinkToCampaign with the single campaign ID on confirm', async () => {
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const linkAllButton = screen.getByRole('button', { name: /link all/i });
+			await fireEvent.click(linkAllButton);
+
+			expect(mockBulkLinkToCampaign).toHaveBeenCalledWith(
+				['char-1', 'char-2', 'npc-1'],
+				'campaign-1'
+			);
+		});
+	});
+
+	describe('Multiple Campaigns Scenario', () => {
+		beforeEach(() => {
+			const campaign2: BaseEntity = {
+				id: 'campaign-2',
+				type: 'campaign',
+				name: 'Another Campaign',
+				description: 'Another test campaign',
+				tags: [],
+				fields: {},
+				links: [],
+				notes: '',
+				createdAt: new Date(),
+				updatedAt: new Date()
+			};
+
+			defaultProps.campaigns = [campaigns[0], campaign2];
+		});
+
+		it('should show campaign selector when multiple campaigns exist', () => {
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const selector = screen.getByLabelText(/select campaign/i);
+			expect(selector).toBeInTheDocument();
+		});
+
+		it('should populate selector with all campaigns', () => {
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const selector = screen.getByLabelText(/select campaign/i) as HTMLSelectElement;
+			const options = Array.from(selector.options).map((opt) => opt.textContent);
+
+			expect(options).toContain('Test Campaign');
+			expect(options).toContain('Another Campaign');
+		});
+
+		it('should pre-select defaultCampaignId', () => {
+			defaultProps.defaultCampaignId = 'campaign-2';
+
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const selector = screen.getByLabelText(/select campaign/i) as HTMLSelectElement;
+			expect(selector.value).toBe('campaign-2');
+		});
+
+		it('should select first campaign if no defaultCampaignId provided', () => {
+			defaultProps.defaultCampaignId = undefined;
+
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const selector = screen.getByLabelText(/select campaign/i) as HTMLSelectElement;
+			expect(selector.value).toBe('campaign-1');
+		});
+
+		it('should allow changing campaign selection', async () => {
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const selector = screen.getByLabelText(/select campaign/i) as HTMLSelectElement;
+			await fireEvent.change(selector, { target: { value: 'campaign-2' } });
+
+			expect(selector.value).toBe('campaign-2');
+		});
+
+		it('should call bulkLinkToCampaign with selected campaign on confirm', async () => {
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const selector = screen.getByLabelText(/select campaign/i) as HTMLSelectElement;
+			await fireEvent.change(selector, { target: { value: 'campaign-2' } });
+
+			const linkAllButton = screen.getByRole('button', { name: /link all/i });
+			await fireEvent.click(linkAllButton);
+
+			expect(mockBulkLinkToCampaign).toHaveBeenCalledWith(
+				['char-1', 'char-2', 'npc-1'],
+				'campaign-2'
+			);
+		});
+	});
+
+	describe('Action Buttons', () => {
+		it('should render "Link All" button', () => {
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const button = screen.getByRole('button', { name: /link all/i });
+			expect(button).toBeInTheDocument();
+		});
+
+		it('should render "Skip" button', () => {
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const button = screen.getByRole('button', { name: /skip/i });
+			expect(button).toBeInTheDocument();
+		});
+
+		it('should render "Cancel" button', () => {
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const button = screen.getByRole('button', { name: /cancel/i });
+			expect(button).toBeInTheDocument();
+		});
+
+		it('should call onConfirm when "Link All" is clicked', async () => {
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const button = screen.getByRole('button', { name: /link all/i });
+			await fireEvent.click(button);
+
+			// Wait for async operation (modal has 500ms delay before calling onConfirm)
+			await new Promise((resolve) => setTimeout(resolve, 700));
+
+			expect(defaultProps.onConfirm).toHaveBeenCalled();
+		});
+
+		it('should call onSkip when "Skip" is clicked', async () => {
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const button = screen.getByRole('button', { name: /skip/i });
+			await fireEvent.click(button);
+
+			expect(defaultProps.onSkip).toHaveBeenCalled();
+		});
+
+		it('should call onCancel when "Cancel" is clicked', async () => {
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const button = screen.getByRole('button', { name: /cancel/i });
+			await fireEvent.click(button);
+
+			expect(defaultProps.onCancel).toHaveBeenCalled();
+		});
+
+		it('should close modal on backdrop click', async () => {
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const backdrop = screen.getByRole('dialog').parentElement;
+			if (backdrop) {
+				await fireEvent.click(backdrop);
+			}
+
+			expect(defaultProps.onCancel).toHaveBeenCalled();
+		});
+
+		it('should support ESC key to close modal', async () => {
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const dialog = screen.getByRole('dialog');
+			await fireEvent.keyDown(dialog, { key: 'Escape' });
+
+			expect(defaultProps.onCancel).toHaveBeenCalled();
+		});
+	});
+
+	describe('Bulk Linking Execution', () => {
+		it('should disable buttons while linking is in progress', async () => {
+			mockBulkLinkToCampaign.mockImplementation(
+				() => new Promise((resolve) => setTimeout(() => resolve(3), 1000))
+			);
+
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const linkAllButton = screen.getByRole('button', { name: /link all/i });
+			await fireEvent.click(linkAllButton);
+
+			// Buttons should be disabled during operation
+			expect(linkAllButton).toBeDisabled();
+			expect(screen.getByRole('button', { name: /skip/i })).toBeDisabled();
+			expect(screen.getByRole('button', { name: /cancel/i })).toBeDisabled();
+		});
+
+		it('should show loading indicator while linking', async () => {
+			mockBulkLinkToCampaign.mockImplementation(
+				() => new Promise((resolve) => setTimeout(() => resolve(3), 1000))
+			);
+
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const linkAllButton = screen.getByRole('button', { name: /link all/i });
+			await fireEvent.click(linkAllButton);
+
+			expect(screen.getByText(/linking/i)).toBeInTheDocument();
+		});
+
+		it('should call bulkLinkToCampaign with correct entity IDs', async () => {
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const linkAllButton = screen.getByRole('button', { name: /link all/i });
+			await fireEvent.click(linkAllButton);
+
+			expect(mockBulkLinkToCampaign).toHaveBeenCalledWith(
+				expect.arrayContaining(['char-1', 'char-2', 'npc-1']),
+				'campaign-1'
+			);
+		});
+
+		it('should call onConfirm with link count after successful linking', async () => {
+			mockBulkLinkToCampaign.mockResolvedValue(3);
+
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const linkAllButton = screen.getByRole('button', { name: /link all/i });
+			await fireEvent.click(linkAllButton);
+
+			// Wait for async operation (modal has 500ms delay before calling onConfirm)
+			await new Promise((resolve) => setTimeout(resolve, 700));
+
+			expect(defaultProps.onConfirm).toHaveBeenCalledWith(3);
+		});
+
+		it('should show success message after linking', async () => {
+			mockBulkLinkToCampaign.mockResolvedValue(3);
+
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const linkAllButton = screen.getByRole('button', { name: /link all/i });
+			await fireEvent.click(linkAllButton);
+
+			// Wait for async operation
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			expect(screen.getByText(/successfully linked 3 entities/i)).toBeInTheDocument();
+		});
+
+		it('should handle partial linking (some entities already linked)', async () => {
+			mockBulkLinkToCampaign.mockResolvedValue(2); // Only 2 out of 3 were linked
+
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const linkAllButton = screen.getByRole('button', { name: /link all/i });
+			await fireEvent.click(linkAllButton);
+
+			// Wait for async operation (modal has 500ms delay before calling onConfirm)
+			await new Promise((resolve) => setTimeout(resolve, 700));
+
+			expect(defaultProps.onConfirm).toHaveBeenCalledWith(2);
+		});
+	});
+
+	describe('Error Handling', () => {
+		it('should show error message if bulkLinkToCampaign fails', async () => {
+			mockBulkLinkToCampaign.mockRejectedValue(new Error('Database error'));
+
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const linkAllButton = screen.getByRole('button', { name: /link all/i });
+			await fireEvent.click(linkAllButton);
+
+			// Wait for error handling
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			expect(screen.getByText(/failed to link entities/i)).toBeInTheDocument();
+		});
+
+		it('should re-enable buttons after error', async () => {
+			mockBulkLinkToCampaign.mockRejectedValue(new Error('Database error'));
+
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const linkAllButton = screen.getByRole('button', { name: /link all/i });
+			await fireEvent.click(linkAllButton);
+
+			// Wait for error handling
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			expect(linkAllButton).not.toBeDisabled();
+			expect(screen.getByRole('button', { name: /skip/i })).not.toBeDisabled();
+			expect(screen.getByRole('button', { name: /cancel/i })).not.toBeDisabled();
+		});
+
+		it('should not call onConfirm if linking fails', async () => {
+			mockBulkLinkToCampaign.mockRejectedValue(new Error('Database error'));
+
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const linkAllButton = screen.getByRole('button', { name: /link all/i });
+			await fireEvent.click(linkAllButton);
+
+			// Wait for error handling
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			expect(defaultProps.onConfirm).not.toHaveBeenCalled();
+		});
+
+		it('should allow retrying after error', async () => {
+			mockBulkLinkToCampaign
+				.mockRejectedValueOnce(new Error('Database error'))
+				.mockResolvedValueOnce(3);
+
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const linkAllButton = screen.getByRole('button', { name: /link all/i });
+
+			// First attempt - fails
+			await fireEvent.click(linkAllButton);
+			await new Promise((resolve) => setTimeout(resolve, 150));
+
+			// Second attempt - succeeds (needs 700ms for the confirm callback due to 500ms delay)
+			await fireEvent.click(linkAllButton);
+			await new Promise((resolve) => setTimeout(resolve, 700));
+
+			expect(mockBulkLinkToCampaign).toHaveBeenCalledTimes(2);
+			expect(defaultProps.onConfirm).toHaveBeenCalledWith(3);
+		});
+	});
+
+	describe('Entity List Display', () => {
+		it('should show list of unlinked entities', () => {
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			expect(screen.getByText('Hero')).toBeInTheDocument();
+			expect(screen.getByText('Sidekick')).toBeInTheDocument();
+			expect(screen.getByText('Villain')).toBeInTheDocument();
+		});
+
+		it('should show entity types', () => {
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const characterLabels = screen.getAllByText(/character/i);
+			expect(characterLabels.length).toBeGreaterThan(0);
+
+			const npcLabel = screen.getByText(/npc/i);
+			expect(npcLabel).toBeInTheDocument();
+		});
+
+		it('should handle long list of entities with scrolling', () => {
+			const manyEntities = Array.from({ length: 50 }, (_, i) => ({
+				id: `entity-${i}`,
+				type: 'character',
+				name: `Entity ${i}`,
+				description: '',
+				tags: [],
+				fields: {},
+				links: [],
+				notes: '',
+				createdAt: new Date(),
+				updatedAt: new Date()
+			}));
+
+			render(BulkCampaignLinkingModal, {
+				props: { ...defaultProps, unlinkedEntities: manyEntities }
+			});
+
+			expect(screen.getByText(/50 entities/i)).toBeInTheDocument();
+
+			// List container should exist and have the entity-list class (which has overflow-y: auto in CSS)
+			const listContainer = screen.getByTestId('entity-list');
+			expect(listContainer).toBeInTheDocument();
+			expect(listContainer).toHaveClass('entity-list');
+		});
+	});
+
+	describe('Accessibility', () => {
+		it('should have proper ARIA role for modal', () => {
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const dialog = screen.getByRole('dialog');
+			expect(dialog).toHaveAttribute('aria-modal', 'true');
+		});
+
+		it('should have accessible label for modal', () => {
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const dialog = screen.getByRole('dialog');
+			expect(dialog).toHaveAttribute('aria-labelledby');
+		});
+
+		it('should have accessible label for campaign selector', () => {
+			const campaign2: BaseEntity = {
+				id: 'campaign-2',
+				type: 'campaign',
+				name: 'Another Campaign',
+				description: '',
+				tags: [],
+				fields: {},
+				links: [],
+				notes: '',
+				createdAt: new Date(),
+				updatedAt: new Date()
+			};
+
+			defaultProps.campaigns = [campaigns[0], campaign2];
+
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const selector = screen.getByLabelText(/select campaign/i);
+			expect(selector).toHaveAccessibleName();
+		});
+
+		it('should focus "Link All" button on modal open', () => {
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const linkAllButton = screen.getByRole('button', { name: /link all/i });
+			expect(document.activeElement).toBe(linkAllButton);
+		});
+
+		it('should keep focus within modal buttons', async () => {
+			render(BulkCampaignLinkingModal, { props: defaultProps });
+
+			const linkAllButton = screen.getByRole('button', { name: /link all/i });
+			const skipButton = screen.getByRole('button', { name: /skip/i });
+			const cancelButton = screen.getByRole('button', { name: /cancel/i });
+
+			// Verify all buttons are focusable and exist in the modal
+			expect(linkAllButton).toBeInTheDocument();
+			expect(skipButton).toBeInTheDocument();
+			expect(cancelButton).toBeInTheDocument();
+
+			// Verify buttons are not disabled by default
+			expect(linkAllButton).not.toBeDisabled();
+			expect(skipButton).not.toBeDisabled();
+			expect(cancelButton).not.toBeDisabled();
+		});
+	});
+});

--- a/src/lib/components/settings/CampaignLinkingSettings.svelte
+++ b/src/lib/components/settings/CampaignLinkingSettings.svelte
@@ -1,0 +1,187 @@
+<script lang="ts">
+	import { campaignStore } from '$lib/stores';
+	import { entityRepository } from '$lib/db/repositories';
+	import { notificationStore } from '$lib/stores';
+	import BulkCampaignLinkingModal from './BulkCampaignLinkingModal.svelte';
+	import type { BaseEntity } from '$lib/types';
+
+	// Reactive state
+	let enabled = $state(false);
+	let selectedDefaultCampaign = $state('');
+	let showBulkModal = $state(false);
+	let unlinkedEntities = $state<BaseEntity[]>([]);
+	let isLoading = $state(false);
+
+	// Derived values
+	const campaign = $derived(campaignStore.campaign);
+	const allCampaigns = $derived(campaignStore.allCampaigns);
+	const hasNoCampaigns = $derived(allCampaigns.length === 0);
+	const hasMultipleCampaigns = $derived(allCampaigns.length > 1);
+
+	// Initialize values from store
+	$effect(() => {
+		if (campaign) {
+			enabled = campaignStore.enforceCampaignLinking ?? false;
+			selectedDefaultCampaign =
+				campaignStore.defaultCampaignId || campaign.id;
+		}
+	});
+
+	async function handleToggle() {
+		if (isLoading) return;
+
+		try {
+			const newValue = !enabled;
+
+			if (newValue) {
+				// Enabling - check for unlinked entities
+				isLoading = true;
+				unlinkedEntities = await entityRepository.getEntitiesWithoutCampaignLink();
+
+				if (unlinkedEntities.length > 0) {
+					// Show modal
+					showBulkModal = true;
+					// Don't update the toggle yet - wait for user decision
+					return;
+				}
+
+				// No unlinked entities - just enable
+				const targetCampaignId = hasMultipleCampaigns
+					? selectedDefaultCampaign
+					: campaign?.id;
+				await campaignStore.setEnforceCampaignLinking(true, targetCampaignId);
+				enabled = true;
+			} else {
+				// Disabling - just update
+				await campaignStore.setEnforceCampaignLinking(false);
+				enabled = false;
+			}
+		} catch (error) {
+			console.error('Failed to toggle campaign linking:', error);
+			notificationStore.error('Failed to update campaign linking setting');
+		} finally {
+			isLoading = false;
+		}
+	}
+
+	async function handleDefaultCampaignChange(event: Event) {
+		const target = event.target as HTMLSelectElement;
+		const newValue = target.value;
+		selectedDefaultCampaign = newValue;
+
+		try {
+			await campaignStore.setDefaultCampaignId(newValue);
+		} catch (error) {
+			console.error('Failed to update default campaign:', error);
+			notificationStore.error('Failed to update default campaign');
+		}
+	}
+
+	function handleModalConfirm(linkedCount: number) {
+		// User confirmed and entities were linked
+		enabled = true;
+		showBulkModal = false;
+		notificationStore.success(`Successfully linked ${linkedCount} entities to campaign`);
+	}
+
+	function handleModalSkip() {
+		// User wants to enable without linking existing entities
+		enabled = true;
+		showBulkModal = false;
+	}
+
+	function handleModalCancel() {
+		// User cancelled - don't enable the setting
+		enabled = false;
+		showBulkModal = false;
+	}
+</script>
+
+<div class="space-y-4">
+	<div>
+		<h3 class="text-lg font-semibold mb-2">Campaign Linking</h3>
+		<p class="text-sm text-slate-600 dark:text-slate-400 mb-4">
+			Automatically link all new entities to campaigns when this setting is enabled.
+		</p>
+	</div>
+
+	<div class="flex items-center gap-3">
+		<input
+			type="checkbox"
+			id="enforce-campaign-linking"
+			class="checkbox"
+			checked={enabled}
+			disabled={hasNoCampaigns || isLoading}
+			onclick={(e) => { e.preventDefault(); handleToggle(); }}
+			aria-label="Enforce Campaign Linking"
+			aria-disabled={hasNoCampaigns ? 'true' : 'false'}
+		/>
+		<label for="enforce-campaign-linking" class="text-sm font-medium">
+			Enforce Campaign Linking
+		</label>
+	</div>
+
+	{#if hasNoCampaigns}
+		<p class="text-sm text-slate-500 dark:text-slate-400 italic">
+			Please create a campaign first to enable this feature.
+		</p>
+	{/if}
+
+	{#if hasMultipleCampaigns && !hasNoCampaigns}
+		<div class="space-y-2">
+			<label for="default-campaign" class="text-sm font-medium">Default Campaign</label>
+			<select
+				id="default-campaign"
+				class="input w-full"
+				value={selectedDefaultCampaign}
+				onchange={handleDefaultCampaignChange}
+				aria-label="Default Campaign"
+			>
+				{#each allCampaigns as camp}
+					<option value={camp.id}>{camp.name}</option>
+				{/each}
+			</select>
+			<p class="text-xs text-slate-500 dark:text-slate-400">
+				New entities will be automatically linked to this campaign.
+			</p>
+		</div>
+	{/if}
+</div>
+
+{#if showBulkModal}
+	<BulkCampaignLinkingModal
+		open={showBulkModal}
+		{unlinkedEntities}
+		campaigns={allCampaigns}
+		defaultCampaignId={selectedDefaultCampaign}
+		onConfirm={handleModalConfirm}
+		onSkip={handleModalSkip}
+		onCancel={handleModalCancel}
+	/>
+{/if}
+
+<style>
+	.checkbox {
+		width: 1.25rem;
+		height: 1.25rem;
+		cursor: pointer;
+	}
+
+	.checkbox:disabled {
+		cursor: not-allowed;
+		opacity: 0.5;
+	}
+
+	.input {
+		padding: 0.5rem;
+		border: 1px solid #cbd5e1;
+		border-radius: 0.375rem;
+		background-color: white;
+	}
+
+	:global(.dark) .input {
+		background-color: #1e293b;
+		border-color: #475569;
+		color: white;
+	}
+</style>

--- a/src/lib/components/settings/CampaignLinkingSettings.test.ts
+++ b/src/lib/components/settings/CampaignLinkingSettings.test.ts
@@ -1,0 +1,464 @@
+/**
+ * Tests for CampaignLinkingSettings Component - Issue #48
+ *
+ * RED Phase (TDD): These tests define expected behavior before implementation.
+ * Tests should FAIL until the component is implemented.
+ *
+ * This component provides UI for the "Enforce Campaign Linking" setting.
+ * It should:
+ * - Display a toggle for enabling/disabling the setting
+ * - Be disabled when no campaigns exist
+ * - Show a dropdown for default campaign selection when multiple campaigns exist
+ * - Trigger bulk linking modal when enabling with unlinked entities
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import CampaignLinkingSettings from './CampaignLinkingSettings.svelte';
+import {
+	createMockCampaignStore,
+	createMockEntitiesStore,
+	createMockNotificationStore
+} from '../../../tests/mocks/stores';
+
+// Use vi.hoisted to make variables available to hoisted vi.mock calls
+const { mockCampaignStore, mockEntitiesStore, mockNotificationStore, mockGetEntitiesWithoutCampaignLink, mockBulkLinkToCampaign } = vi.hoisted(() => {
+	return {
+		mockCampaignStore: { current: null as ReturnType<typeof createMockCampaignStore> | null },
+		mockEntitiesStore: { current: null as ReturnType<typeof createMockEntitiesStore> | null },
+		mockNotificationStore: { current: null as ReturnType<typeof createMockNotificationStore> | null },
+		mockGetEntitiesWithoutCampaignLink: vi.fn(),
+		mockBulkLinkToCampaign: vi.fn()
+	};
+});
+
+// Mock the stores
+vi.mock('$lib/stores', () => {
+	return {
+		get campaignStore() {
+			return mockCampaignStore.current;
+		},
+		get entitiesStore() {
+			return mockEntitiesStore.current;
+		},
+		get notificationStore() {
+			return mockNotificationStore.current;
+		}
+	};
+});
+
+// Mock the entity repository
+vi.mock('$lib/db/repositories', () => ({
+	entityRepository: {
+		getEntitiesWithoutCampaignLink: mockGetEntitiesWithoutCampaignLink,
+		bulkLinkToCampaign: mockBulkLinkToCampaign
+	}
+}));
+
+describe('CampaignLinkingSettings Component', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		mockCampaignStore.current = createMockCampaignStore();
+		mockEntitiesStore.current = createMockEntitiesStore();
+		mockNotificationStore.current = createMockNotificationStore();
+
+		// Default: 1 campaign, setting disabled
+		mockCampaignStore.current.campaign.metadata = {
+			customEntityTypes: [],
+			entityTypeOverrides: [],
+			settings: {
+				customRelationships: [],
+				enabledEntityTypes: [],
+				enforceCampaignLinking: false
+			}
+		};
+
+		mockGetEntitiesWithoutCampaignLink.mockResolvedValue([]);
+	});
+
+	describe('Component Rendering', () => {
+		it('should render the settings section', () => {
+			render(CampaignLinkingSettings);
+
+			// Check for the section header specifically
+			expect(screen.getByRole('heading', { name: /campaign linking/i })).toBeInTheDocument();
+		});
+
+		it('should render a toggle for enforce campaign linking', () => {
+			render(CampaignLinkingSettings);
+
+			const toggle = screen.getByRole('checkbox', { name: /enforce campaign linking/i });
+			expect(toggle).toBeInTheDocument();
+		});
+
+		it('should show help text explaining the feature', () => {
+			render(CampaignLinkingSettings);
+
+			expect(
+				screen.getByText(/automatically link all new entities to campaigns/i)
+			).toBeInTheDocument();
+		});
+
+		it('should display the toggle in unchecked state by default', () => {
+			render(CampaignLinkingSettings);
+
+			const toggle = screen.getByRole('checkbox', { name: /enforce campaign linking/i });
+			expect(toggle).not.toBeChecked();
+		});
+
+		it('should display the toggle in checked state when setting is enabled', () => {
+			mockCampaignStore.current!.campaign.metadata.settings.enforceCampaignLinking = true;
+
+			render(CampaignLinkingSettings);
+
+			const toggle = screen.getByRole('checkbox', { name: /enforce campaign linking/i });
+			expect(toggle).toBeChecked();
+		});
+	});
+
+	describe('No Campaigns Scenario', () => {
+		it('should disable the toggle when no campaigns exist', () => {
+			mockCampaignStore.current!.allCampaigns = [];
+			mockCampaignStore.current!.campaign = null;
+
+			render(CampaignLinkingSettings);
+
+			const toggle = screen.getByRole('checkbox', { name: /enforce campaign linking/i });
+			expect(toggle).toBeDisabled();
+		});
+
+		it('should show explanatory text when no campaigns exist', () => {
+			mockCampaignStore.current!.allCampaigns = [];
+			mockCampaignStore.current!.campaign = null;
+
+			render(CampaignLinkingSettings);
+
+			expect(screen.getByText(/create a campaign first/i)).toBeInTheDocument();
+		});
+	});
+
+	describe('Single Campaign Scenario', () => {
+		it('should enable the toggle when one campaign exists', () => {
+			render(CampaignLinkingSettings);
+
+			const toggle = screen.getByRole('checkbox', { name: /enforce campaign linking/i });
+			expect(toggle).not.toBeDisabled();
+		});
+
+		it('should not show default campaign selector for single campaign', () => {
+			render(CampaignLinkingSettings);
+
+			const selector = screen.queryByLabelText(/default campaign/i);
+			expect(selector).not.toBeInTheDocument();
+		});
+
+		it('should call setEnforceCampaignLinking when toggled on', async () => {
+			const setEnforceCampaignLinking = vi.fn();
+			mockCampaignStore.current!.setEnforceCampaignLinking = setEnforceCampaignLinking;
+
+			render(CampaignLinkingSettings);
+
+			const toggle = screen.getByRole('checkbox', { name: /enforce campaign linking/i });
+			await fireEvent.click(toggle);
+
+			expect(setEnforceCampaignLinking).toHaveBeenCalledWith(
+				true,
+				mockCampaignStore.current!.campaign.id
+			);
+		});
+
+		it('should call setEnforceCampaignLinking when toggled off', async () => {
+			mockCampaignStore.current!.campaign.metadata.settings.enforceCampaignLinking = true;
+			const setEnforceCampaignLinking = vi.fn();
+			mockCampaignStore.current!.setEnforceCampaignLinking = setEnforceCampaignLinking;
+
+			render(CampaignLinkingSettings);
+
+			const toggle = screen.getByRole('checkbox', { name: /enforce campaign linking/i });
+			await fireEvent.click(toggle);
+
+			expect(setEnforceCampaignLinking).toHaveBeenCalledWith(false);
+		});
+	});
+
+	describe('Multiple Campaigns Scenario', () => {
+		beforeEach(() => {
+			const campaign2 = {
+				...mockCampaignStore.current!.campaign,
+				id: 'campaign-2',
+				name: 'Another Campaign'
+			};
+
+			mockCampaignStore.current!.allCampaigns = [mockCampaignStore.current!.campaign, campaign2];
+		});
+
+		it('should show default campaign selector when multiple campaigns exist', () => {
+			render(CampaignLinkingSettings);
+
+			const selector = screen.getByLabelText(/default campaign/i);
+			expect(selector).toBeInTheDocument();
+		});
+
+		it('should populate selector with all campaigns', () => {
+			render(CampaignLinkingSettings);
+
+			const selector = screen.getByLabelText(/default campaign/i) as HTMLSelectElement;
+			const options = Array.from(selector.options).map((opt) => opt.textContent);
+
+			expect(options).toContain('Test Campaign');
+			expect(options).toContain('Another Campaign');
+		});
+
+		it('should select active campaign by default', () => {
+			mockCampaignStore.current!.campaign.metadata.settings.defaultCampaignId = 'campaign-2';
+
+			render(CampaignLinkingSettings);
+
+			const selector = screen.getByLabelText(/default campaign/i) as HTMLSelectElement;
+			expect(selector.value).toBe('campaign-2');
+		});
+
+		it('should call setDefaultCampaignId when changing selection', async () => {
+			const setDefaultCampaignId = vi.fn();
+			mockCampaignStore.current!.setDefaultCampaignId = setDefaultCampaignId;
+
+			render(CampaignLinkingSettings);
+
+			const selector = screen.getByLabelText(/default campaign/i) as HTMLSelectElement;
+			await fireEvent.change(selector, { target: { value: 'campaign-2' } });
+
+			expect(setDefaultCampaignId).toHaveBeenCalledWith('campaign-2');
+		});
+
+		it('should call setEnforceCampaignLinking with selected default campaign', async () => {
+			const setEnforceCampaignLinking = vi.fn();
+			mockCampaignStore.current!.setEnforceCampaignLinking = setEnforceCampaignLinking;
+			mockCampaignStore.current!.campaign.metadata.settings.defaultCampaignId = 'campaign-2';
+
+			render(CampaignLinkingSettings);
+
+			const toggle = screen.getByRole('checkbox', { name: /enforce campaign linking/i });
+			await fireEvent.click(toggle);
+
+			expect(setEnforceCampaignLinking).toHaveBeenCalledWith(true, 'campaign-2');
+		});
+	});
+
+	describe('Bulk Linking on Enable', () => {
+		it('should NOT show modal when toggling on with no unlinked entities', async () => {
+			mockGetEntitiesWithoutCampaignLink.mockResolvedValue([]);
+
+			render(CampaignLinkingSettings);
+
+			const toggle = screen.getByRole('checkbox', { name: /enforce campaign linking/i });
+			await fireEvent.click(toggle);
+
+			// Wait for async operations
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			const modal = screen.queryByRole('dialog');
+			expect(modal).not.toBeInTheDocument();
+		});
+
+		it('should show bulk linking modal when toggling on with unlinked entities', async () => {
+			const unlinkedEntities = [
+				{
+					id: 'char-1',
+					type: 'character',
+					name: 'Hero',
+					description: '',
+					tags: [],
+					fields: {},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date()
+				},
+				{
+					id: 'npc-1',
+					type: 'npc',
+					name: 'Villain',
+					description: '',
+					tags: [],
+					fields: {},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date()
+				}
+			];
+
+			mockGetEntitiesWithoutCampaignLink.mockResolvedValue(unlinkedEntities);
+
+			render(CampaignLinkingSettings);
+
+			const toggle = screen.getByRole('checkbox', { name: /enforce campaign linking/i });
+			await fireEvent.click(toggle);
+
+			// Wait for async operations
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			expect(screen.getByRole('dialog')).toBeInTheDocument();
+			expect(screen.getByText(/2 entities/i)).toBeInTheDocument();
+		});
+
+		it('should revert toggle if user cancels bulk linking modal', async () => {
+			const unlinkedEntities = [
+				{
+					id: 'char-1',
+					type: 'character',
+					name: 'Hero',
+					description: '',
+					tags: [],
+					fields: {},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date()
+				}
+			];
+
+			mockGetEntitiesWithoutCampaignLink.mockResolvedValue(unlinkedEntities);
+
+			render(CampaignLinkingSettings);
+
+			const toggle = screen.getByRole('checkbox', { name: /enforce campaign linking/i });
+			await fireEvent.click(toggle);
+
+			// Wait for modal to appear
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			const cancelButton = screen.getByRole('button', { name: /cancel/i });
+			await fireEvent.click(cancelButton);
+
+			// Toggle should be reverted to unchecked
+			expect(toggle).not.toBeChecked();
+		});
+
+		it('should keep toggle enabled after user confirms bulk linking', async () => {
+			const unlinkedEntities = [
+				{
+					id: 'char-1',
+					type: 'character',
+					name: 'Hero',
+					description: '',
+					tags: [],
+					fields: {},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date()
+				}
+			];
+
+			mockGetEntitiesWithoutCampaignLink.mockResolvedValue(unlinkedEntities);
+			mockBulkLinkToCampaign.mockResolvedValue(1);
+
+			render(CampaignLinkingSettings);
+
+			const toggle = screen.getByRole('checkbox', { name: /enforce campaign linking/i });
+			await fireEvent.click(toggle);
+
+			// Wait for modal to appear
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			const linkAllButton = screen.getByRole('button', { name: /link all/i });
+			await fireEvent.click(linkAllButton);
+
+			// Wait for operation to complete (modal has 500ms delay before calling onConfirm)
+			await new Promise((resolve) => setTimeout(resolve, 700));
+
+			// Toggle should remain checked
+			expect(toggle).toBeChecked();
+		});
+	});
+
+	describe('Error Handling', () => {
+		it('should show error notification if setEnforceCampaignLinking fails', async () => {
+			const setEnforceCampaignLinking = vi.fn().mockRejectedValue(new Error('Failed to update'));
+			mockCampaignStore.current!.setEnforceCampaignLinking = setEnforceCampaignLinking;
+
+			render(CampaignLinkingSettings);
+
+			const toggle = screen.getByRole('checkbox', { name: /enforce campaign linking/i });
+			await fireEvent.click(toggle);
+
+			// Wait for error handling
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			expect(mockNotificationStore.current!.error).toHaveBeenCalled();
+		});
+
+		it('should show error message in modal if bulk linking fails', async () => {
+			const unlinkedEntities = [
+				{
+					id: 'char-1',
+					type: 'character',
+					name: 'Hero',
+					description: '',
+					tags: [],
+					fields: {},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date()
+				}
+			];
+
+			mockGetEntitiesWithoutCampaignLink.mockResolvedValue(unlinkedEntities);
+			mockBulkLinkToCampaign.mockRejectedValue(new Error('Bulk link failed'));
+
+			render(CampaignLinkingSettings);
+
+			const toggle = screen.getByRole('checkbox', { name: /enforce campaign linking/i });
+			await fireEvent.click(toggle);
+
+			// Wait for modal
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			const linkAllButton = screen.getByRole('button', { name: /link all/i });
+			await fireEvent.click(linkAllButton);
+
+			// Wait for error handling
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			// Modal shows inline error message instead of using notification store
+			expect(screen.getByText(/failed to link entities/i)).toBeInTheDocument();
+		});
+	});
+
+	describe('Accessibility', () => {
+		it('should have proper label for toggle', () => {
+			render(CampaignLinkingSettings);
+
+			const toggle = screen.getByRole('checkbox', { name: /enforce campaign linking/i });
+			expect(toggle).toHaveAccessibleName();
+		});
+
+		it('should have proper label for default campaign selector', () => {
+			const campaign2 = {
+				...mockCampaignStore.current!.campaign,
+				id: 'campaign-2',
+				name: 'Another Campaign'
+			};
+
+			mockCampaignStore.current!.allCampaigns = [mockCampaignStore.current!.campaign, campaign2];
+
+			render(CampaignLinkingSettings);
+
+			const selector = screen.getByLabelText(/default campaign/i);
+			expect(selector).toHaveAccessibleName();
+		});
+
+		it('should have descriptive aria-label for disabled state', () => {
+			mockCampaignStore.current!.allCampaigns = [];
+			mockCampaignStore.current!.campaign = null;
+
+			render(CampaignLinkingSettings);
+
+			const toggle = screen.getByRole('checkbox', { name: /enforce campaign linking/i });
+			expect(toggle).toHaveAttribute('aria-disabled', 'true');
+		});
+	});
+});

--- a/src/lib/components/settings/index.ts
+++ b/src/lib/components/settings/index.ts
@@ -5,3 +5,5 @@ export { default as ColorPicker } from './ColorPicker.svelte';
 export { default as SystemSelector } from './SystemSelector.svelte';
 export { default as EntityTypeTemplateGallery } from './EntityTypeTemplateGallery.svelte';
 export { default as DrawSteelTipsPanel } from './DrawSteelTipsPanel.svelte';
+export { default as CampaignLinkingSettings } from './CampaignLinkingSettings.svelte';
+export { default as BulkCampaignLinkingModal } from './BulkCampaignLinkingModal.svelte';

--- a/src/lib/types/campaign.ts
+++ b/src/lib/types/campaign.ts
@@ -25,6 +25,8 @@ export interface CampaignSettings {
 	customRelationships: string[]; // Custom relationship types beyond defaults
 	enabledEntityTypes: string[]; // Which entity types to show in UI
 	theme?: 'light' | 'dark' | 'system';
+	enforceCampaignLinking?: boolean; // Issue #48: Automatically link all new entities to campaigns
+	defaultCampaignId?: string; // Issue #48: Default campaign for auto-linking (when multiple campaigns exist)
 }
 
 /**

--- a/src/routes/entities/[type]/new/+page.svelte
+++ b/src/routes/entities/[type]/new/+page.svelte
@@ -9,6 +9,7 @@
 	import { validateEntity, formatContextSummary } from '$lib/utils';
 	import { getSystemAwareEntityType } from '$lib/utils/entityFormUtils';
 	import { deserializePrefillParams } from '$lib/utils/entityPrefillUtils';
+	import { nanoid } from 'nanoid';
 	import PrefillBanner from '$lib/components/ui/PrefillBanner.svelte';
 	import { ArrowLeft, Save, Sparkles, Loader2, ExternalLink, ImagePlus, X as XIcon, Upload, Search, ChevronDown, Eye, EyeOff, Plus, ChevronRight } from 'lucide-svelte';
 	import FieldGenerateButton from '$lib/components/entity/FieldGenerateButton.svelte';
@@ -49,6 +50,25 @@
 	let pendingRelationships = $state<PendingRelationship[]>([]);
 	let showRelateCommand = $state(false);
 	let relationshipsExpanded = $state(false);
+
+	// Auto-linking for Issue #48
+	const shouldAutoLink = $derived(
+		campaignStore.enforceCampaignLinking &&
+		entityType !== 'campaign'  // Don't link campaigns to themselves
+	);
+
+	const autoLinkCampaignId = $derived(() => {
+		if (!shouldAutoLink) return null;
+		// If single campaign, use it; otherwise use defaultCampaignId
+		const campaigns = campaignStore.allCampaigns;
+		if (campaigns.length === 1) return campaigns[0].id;
+		return campaignStore.defaultCampaignId ?? null;
+	});
+
+	function getCampaignName(campaignId: string): string {
+		const camp = campaignStore.allCampaigns.find(c => c.id === campaignId);
+		return camp?.name ?? 'Unknown Campaign';
+	}
 
 	// Prefill state (from chat entity detection)
 	const prefillParam = $derived($page.url.searchParams.get('prefill'));
@@ -115,6 +135,28 @@
 		isSaving = true;
 
 		try {
+			// Auto-link to campaign if enabled (Issue #48)
+			let relationshipsToCreate = [...pendingRelationships];
+			const targetCampaignId = autoLinkCampaignId();
+			if (targetCampaignId) {
+				// Check if a campaign link already exists
+				const hasCampaignLink = relationshipsToCreate.some(
+					r => r.relationship === 'belongs_to_campaign' ||
+					(r.targetType === 'campaign' && r.targetId === targetCampaignId)
+				);
+
+				if (!hasCampaignLink) {
+					const campaignLink: PendingRelationship = {
+						tempId: nanoid(),
+						targetId: targetCampaignId,
+						targetType: 'campaign',
+						relationship: 'belongs_to_campaign',
+						bidirectional: false
+					};
+					relationshipsToCreate = [...relationshipsToCreate, campaignLink];
+				}
+			}
+
 			const newEntity = createEntity(entityType, name.trim(), {
 				description: description.trim(),
 				summary: summary.trim() || undefined,
@@ -128,9 +170,9 @@
 			});
 
 			let created;
-			if (pendingRelationships.length > 0) {
+			if (relationshipsToCreate.length > 0) {
 				// Use createWithRelationships when there are pending relationships
-				created = await entitiesStore.createWithRelationships(newEntity, pendingRelationships);
+				created = await entitiesStore.createWithRelationships(newEntity, relationshipsToCreate);
 			} else {
 				// Use standard create when no relationships
 				created = await entitiesStore.create(newEntity);
@@ -413,6 +455,18 @@
 			sourceMessageId={prefillData.sourceMessageId}
 			onDismiss={dismissPrefillBanner}
 		/>
+	{/if}
+
+	{#if shouldAutoLink}
+		{@const campaignId = autoLinkCampaignId()}
+		{#if campaignId}
+			<div class="mb-4 p-3 rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800">
+				<p class="text-sm text-blue-700 dark:text-blue-300">
+					This entity will be automatically linked to campaign:
+					<strong>{getCampaignName(campaignId)}</strong>
+				</p>
+			</div>
+		{/if}
 	{/if}
 
 	<form onsubmit={handleSubmit} class="space-y-6">

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -22,7 +22,7 @@
 	import { Download, Upload, Moon, Sun, Monitor, Trash2, Key, RefreshCw, Layers, ChevronRight, Users } from 'lucide-svelte';
 	import PlayerExportModal from '$lib/components/settings/PlayerExportModal.svelte';
 	import LoadingButton from '$lib/components/ui/LoadingButton.svelte';
-	import { SystemSelector } from '$lib/components/settings';
+	import { SystemSelector, CampaignLinkingSettings } from '$lib/components/settings';
 	import { page } from '$app/stores';
 
 	// Form state
@@ -392,6 +392,11 @@
 				Create or select a campaign to change the game system.
 			</p>
 		{/if}
+	</section>
+
+	<!-- Campaign Linking -->
+	<section class="mb-8">
+		<CampaignLinkingSettings />
 	</section>
 
 	<!-- Theme -->

--- a/src/tests/mocks/stores.ts
+++ b/src/tests/mocks/stores.ts
@@ -95,18 +95,41 @@ export function createMockCampaignStore() {
 		notes: '',
 		createdAt: new Date(),
 		updatedAt: new Date(),
-		metadata: {} as Record<string, unknown>
+		metadata: {
+			customEntityTypes: [],
+			entityTypeOverrides: [],
+			settings: {
+				customRelationships: [],
+				enabledEntityTypes: [],
+				enforceCampaignLinking: false,
+				defaultCampaignId: undefined
+			}
+		} as Record<string, unknown>
 	};
 
-	return {
+	const store = {
 		campaign,
 		customEntityTypes: [] as Array<unknown>,
 		entityTypeOverrides: [] as Array<unknown>,
 		allCampaigns: [campaign] as typeof campaign[],
 		activeCampaignId: 'test-campaign',
 		load: vi.fn(),
-		setActiveCampaign: vi.fn()
+		setActiveCampaign: vi.fn(),
+		// Campaign linking getters (Issue #48)
+		get enforceCampaignLinking(): boolean {
+			const settings = (store.campaign?.metadata as any)?.settings;
+			return settings?.enforceCampaignLinking ?? false;
+		},
+		get defaultCampaignId(): string | undefined {
+			const settings = (store.campaign?.metadata as any)?.settings;
+			return settings?.defaultCampaignId;
+		},
+		// Campaign linking methods (Issue #48)
+		setEnforceCampaignLinking: vi.fn(),
+		setDefaultCampaignId: vi.fn()
 	};
+
+	return store;
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements an optional "Enforce Campaign Linking" setting that automatically links all entities to campaigns, reducing manual organization work.

- **New Setting**: "Enforce Campaign Linking" toggle in Settings page
- **Auto-linking**: New entities automatically linked to campaigns when enabled
- **Bulk linking**: Modal to link existing unlinked entities when enabling the setting
- **Multi-campaign support**: Default campaign selector when multiple campaigns exist

## Changes

### New Components
- `CampaignLinkingSettings.svelte` - Settings UI with toggle and campaign selector
- `BulkCampaignLinkingModal.svelte` - Modal for bulk linking existing entities

### Modified Files
- `campaign.svelte.ts` - Added getters/setters for `enforceCampaignLinking` and `defaultCampaignId`
- `entityRepository.ts` - Added `getEntitiesWithoutCampaignLink()` and `bulkLinkToCampaign()` methods
- `entities/[type]/new/+page.svelte` - Auto-linking logic on entity creation
- `settings/+page.svelte` - Added Campaign Linking section

### Documentation
- Updated `CHANGELOG.md` with feature entry
- Added comprehensive section to `USER_GUIDE.md`

## Test Plan

- [x] All 104 campaign linking tests pass
- [x] TypeScript check passes
- [x] Build succeeds
- [ ] Manual test: Enable setting with single campaign
- [ ] Manual test: Enable setting with multiple campaigns
- [ ] Manual test: Create new entity and verify auto-link
- [ ] Manual test: Bulk link existing entities via modal

Closes #48

🤖 Generated with [Claude Code](https://claude.ai/code)