### PR TITLE
fix(#231): remove invalid content property reference in EntityContext

### DIFF
--- a/src/lib/services/chatService.ts
+++ b/src/lib/services/chatService.ts
@@ -110,7 +110,7 @@ export async function sendChatMessage(
 				id: e.id,
 				type: e.type,
 				name: e.name,
-				summaryLength: (e.content || e.summary || '').length
+				summaryLength: (e.summary || '').length
 			})),
 			totalCharacters: context.totalCharacters,
 			truncated: context.truncated || false,


### PR DESCRIPTION
## Summary
- Fixes TypeScript compile error in `chatService.ts:113` where `e.content` was referenced but doesn't exist on `EntityContext` type
- Removes the invalid property access, using only `e.summary` which is the correct property
- Unblocks the v1.0.0 release

## Changes
```typescript
// Before:
summaryLength: (e.content || e.summary || '').length

// After:
summaryLength: (e.summary || '').length
```

## Test plan
- [x] `npm run check` passes (no TypeScript errors for chatService.ts)
- [x] `npm run build` completes successfully

Fixes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)