### PR TITLE
feat(#236): add full-width edit mode with preview toggle to markdown editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+**Markdown Editor UX Improvement (Issue #236)**
+- Markdown editor now defaults to full-width edit mode instead of split view
+- Added Preview/Edit toggle button to toolbar for switching between editing and preview modes
+- Provides more editing space while maintaining easy access to markdown preview
+- Split view mode still available programmatically for components that need it
+
 ## [1.0.0] - 2026-01-21
 
 ### Added

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -172,7 +172,7 @@ Single-line inputs for short information like role, occupation, or title.
 Multi-line inputs for longer content like personality descriptions or notes.
 
 **Rich Text Fields**
-Full markdown editor with a formatting toolbar for creating rich formatted text. The editor offers three modes: edit-only, preview-only, or split view showing both side-by-side. Use the toolbar buttons to add bold, italic, headings, code blocks, links, and lists. Keyboard shortcuts available: Ctrl+B for bold, Ctrl+I for italic. Great for backgrounds, histories, or detailed descriptions that need formatting.
+Full markdown editor with a formatting toolbar for creating rich formatted text. The editor defaults to full-width edit mode, giving you maximum space for writing. Click the Preview button in the toolbar to see your formatted text, then click Edit to return to editing. Use the toolbar buttons to add bold, italic, headings, code blocks, links, and lists. Keyboard shortcuts available: Ctrl+B for bold, Ctrl+I for italic. Great for backgrounds, histories, or detailed descriptions that need formatting.
 
 **Select Fields**
 Dropdown menus for predefined choices like status (active, inactive, deceased) or importance (critical, major, minor).
@@ -2522,8 +2522,9 @@ Create a Session entity after each game session with:
 
 **Rich Text**: Use the markdown editor toolbar for easy formatting:
 - Click the toolbar buttons or use keyboard shortcuts (Ctrl+B for bold, Ctrl+I for italic)
-- Switch between edit, preview, and split modes using the mode buttons
-- Preview your formatted text in real-time
+- Click the Preview button (eye icon) to see your formatted markdown
+- Click the Edit button (pencil icon) to return to editing
+- Full-width editing gives you maximum space for longer content
 - Headings: `## Heading`
 - Bold: `**bold text**` or Ctrl+B
 - Italic: `*italic text*` or Ctrl+I


### PR DESCRIPTION
## Summary

- Changes markdown editor default from split view to full-width edit mode
- Adds Preview/Edit toggle button to toolbar (Eye/Pencil icons)
- Gives users more screen real estate for editing while maintaining easy preview access

## Changes

- **Modified**: `MarkdownEditor.svelte` - toggle implementation with internal state management
- **Modified**: `MarkdownEditor.test.ts` - 12 new tests (87 total passing)
- **Docs**: Updated CHANGELOG.md and USER_GUIDE.md

## Test plan

- [x] 87 component tests passing
- [ ] Manual test: Open entity with markdown field, verify edit mode is default
- [ ] Manual test: Click Eye icon to preview, verify rendered markdown shown
- [ ] Manual test: Click Pencil icon to return to edit mode
- [ ] Manual test: Verify content preserved when toggling

Closes #236

🤖 Generated with [Claude Code](https://claude.ai/code)