### PR TITLE
feat(#233): simplify combat tracker with quick-add combatants and optional maxHp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "director-assist",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "director-assist",
-      "version": "0.9.0",
+      "version": "1.0.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.15",
         "@ai-sdk/google": "^3.0.10",

--- a/src/lib/components/combat/AddCombatantModal.svelte
+++ b/src/lib/components/combat/AddCombatantModal.svelte
@@ -11,6 +11,7 @@
 
 	let { open = false, onAdd, onClose }: Props = $props();
 
+	let addMode = $state<'quick' | 'entity'>('entity');
 	let combatantType = $state<'hero' | 'creature'>('hero');
 	let selectedEntity = $state<BaseEntity | null>(null);
 	let searchQuery = $state('');
@@ -18,6 +19,11 @@
 	let maxHp = $state('');
 	let ac = $state('');
 	let initiative = $state('');
+
+	// Quick-add fields
+	let quickName = $state('');
+	let quickHp = $state('');
+	let quickType = $state<'hero' | 'creature'>('creature');
 
 	// Hero-specific fields
 	let resourceName = $state('');
@@ -46,15 +52,18 @@
 	});
 
 	const canSubmit = $derived.by(() => {
+		if (addMode === 'quick') {
+			return quickName.trim() !== '' && quickHp !== '' && parseInt(quickHp, 10) > 0;
+		}
+		// Entity mode - only require hp, not maxHp
 		if (!selectedEntity) return false;
-		if (!hp || !maxHp) return false;
-		if (combatantType === 'hero' && !resourceName) return false;
+		if (!hp) return false;
 		return Object.keys(errors).length === 0;
 	});
 
-	// Reset form when type changes
+	// Reset form when type or mode changes
 	$effect(() => {
-		if (combatantType) {
+		if (combatantType || addMode) {
 			selectedEntity = null;
 			clearForm();
 		}
@@ -63,6 +72,7 @@
 	// Reset form when modal closes
 	$effect(() => {
 		if (!open) {
+			addMode = 'entity';
 			combatantType = 'hero';
 			selectedEntity = null;
 			clearForm();
@@ -84,7 +94,8 @@
 			newErrors.maxHp = 'Max HP must be greater than 0';
 		}
 
-		if (hp && maxHp && hpNum > maxHpNum) {
+		// Only validate HP <= maxHp if both are provided
+		if (hp && maxHp && maxHpNum > 0 && hpNum > maxHpNum) {
 			newErrors.hp = 'HP cannot exceed Max HP';
 		}
 
@@ -110,6 +121,8 @@
 		resourceCurrent = '';
 		resourceMax = '';
 		threat = '1';
+		quickName = '';
+		quickHp = '';
 		errors = {};
 	}
 
@@ -118,13 +131,26 @@
 	}
 
 	function handleSubmit() {
-		if (!canSubmit || !selectedEntity) return;
+		if (!canSubmit) return;
+
+		if (addMode === 'quick') {
+			onAdd?.({
+				type: quickType,
+				name: quickName.trim(),
+				hp: parseInt(quickHp, 10),
+				isAdHoc: true
+			});
+			onClose?.();
+			return;
+		}
+
+		if (!selectedEntity) return;
 
 		const baseData = {
 			name: selectedEntity.name,
 			entityId: selectedEntity.id,
 			hp: parseInt(hp, 10),
-			maxHp: parseInt(maxHp, 10),
+			maxHp: maxHp ? parseInt(maxHp, 10) : undefined,
 			ac: ac ? parseInt(ac, 10) : undefined
 		};
 
@@ -132,11 +158,11 @@
 			onAdd?.({
 				...baseData,
 				type: 'hero',
-				heroicResource: {
+				heroicResource: resourceName ? {
 					name: resourceName,
 					current: resourceCurrent ? parseInt(resourceCurrent, 10) : 0,
 					max: resourceMax ? parseInt(resourceMax, 10) : 0
-				}
+				} : undefined
 			});
 		} else {
 			onAdd?.({
@@ -196,211 +222,310 @@
 
 			<!-- Content -->
 			<div class="p-6 space-y-6">
-				<!-- Type Toggle -->
+				<!-- Add Method Toggle -->
 				<div>
-					<label class="label">Type</label>
+					<label class="label">Add Method</label>
 					<div class="flex gap-2">
 						<button
 							class={`flex-1 px-4 py-2 rounded-lg border transition-colors ${
-								combatantType === 'hero'
-									? 'bg-blue-100 dark:bg-blue-900 border-blue-500 text-blue-700 dark:text-blue-300 active selected'
+								addMode === 'quick'
+									? 'bg-purple-100 dark:bg-purple-900 border-purple-500 text-purple-700 dark:text-purple-300 active selected'
 									: 'border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700'
 							}`}
-							onclick={() => (combatantType = 'hero')}
+							onclick={() => (addMode = 'quick')}
 							role="button"
-							aria-pressed={combatantType === 'hero'}
+							aria-pressed={addMode === 'quick'}
 						>
-							<User class="inline-block w-4 h-4 mr-2" />
-							Hero
+							Quick Add
 						</button>
 						<button
 							class={`flex-1 px-4 py-2 rounded-lg border transition-colors ${
-								combatantType === 'creature'
-									? 'bg-red-100 dark:bg-red-900 border-red-500 text-red-700 dark:text-red-300 active selected'
+								addMode === 'entity'
+									? 'bg-purple-100 dark:bg-purple-900 border-purple-500 text-purple-700 dark:text-purple-300 active selected'
 									: 'border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700'
 							}`}
-							onclick={() => (combatantType = 'creature')}
+							onclick={() => (addMode = 'entity')}
 							role="button"
-							aria-pressed={combatantType === 'creature'}
+							aria-pressed={addMode === 'entity'}
 						>
-							<Skull class="inline-block w-4 h-4 mr-2" />
-							Creature
+							From Entity
 						</button>
 					</div>
 				</div>
 
-				<!-- Entity Search -->
-				<div>
-					<label for="entity-search" class="label">Search Entity</label>
-					<input
-						id="entity-search"
-						type="text"
-						class="input"
-						bind:value={searchQuery}
-						bind:this={searchInputRef}
-						placeholder={`Search ${combatantType === 'hero' ? 'characters' : 'NPCs'}...`}
-						aria-label="Search entity"
-					/>
-				</div>
-
-				<!-- Entity List -->
-				<div>
-					{#if availableEntities.length === 0}
-						<p class="text-sm text-slate-500 dark:text-slate-400 text-center py-4">
-							No {combatantType === 'hero' ? 'characters' : 'NPCs'} {searchQuery ? 'found' : 'available'}
-						</p>
-					{:else}
-						<div class="space-y-2 max-h-48 overflow-y-auto">
-							{#each availableEntities as entity (entity.id)}
+				{#if addMode === 'quick'}
+					<!-- Quick-Add Form -->
+					<div class="space-y-4 p-4 bg-slate-50 dark:bg-slate-700/50 rounded-lg">
+						<!-- Quick Type Toggle -->
+						<div>
+							<label class="label">Type</label>
+							<div class="flex gap-2">
 								<button
-									class={`w-full text-left px-4 py-2 rounded-lg border transition-colors ${
-										selectedEntity?.id === entity.id
-											? 'bg-blue-50 dark:bg-blue-900/20 border-blue-500 selected active'
+									class={`flex-1 px-4 py-2 rounded-lg border transition-colors ${
+										quickType === 'hero'
+											? 'bg-blue-100 dark:bg-blue-900 border-blue-500 text-blue-700 dark:text-blue-300 active selected'
 											: 'border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700'
 									}`}
-									onclick={() => handleEntitySelect(entity)}
+									onclick={() => (quickType = 'hero')}
+									role="button"
+									aria-pressed={quickType === 'hero'}
 								>
-									{entity.name}
+									<User class="inline-block w-4 h-4 mr-2" />
+									Hero
 								</button>
-							{/each}
-						</div>
-					{/if}
-				</div>
-
-				<!-- Stats -->
-				{#if selectedEntity}
-					<div class="space-y-4 pt-4 border-t border-slate-200 dark:border-slate-700">
-						<!-- HP -->
-						<div class="grid grid-cols-2 gap-4">
-							<div>
-								<label for="hp" class="label">HP</label>
-								<input
-									id="hp"
-									type="number"
-									class="input"
-									bind:value={hp}
-									min="0"
-									step="1"
-									aria-label="HP"
-								/>
-								{#if errors.hp}
-									<p class="text-xs text-red-600 dark:text-red-400 mt-1">{errors.hp}</p>
-								{/if}
-							</div>
-							<div>
-								<label for="max-hp" class="label">Max HP</label>
-								<input
-									id="max-hp"
-									type="number"
-									class="input"
-									bind:value={maxHp}
-									min="1"
-									step="1"
-									aria-label="Max HP"
-								/>
-								{#if errors.maxHp}
-									<p class="text-xs text-red-600 dark:text-red-400 mt-1">{errors.maxHp}</p>
-								{/if}
+								<button
+									class={`flex-1 px-4 py-2 rounded-lg border transition-colors ${
+										quickType === 'creature'
+											? 'bg-red-100 dark:bg-red-900 border-red-500 text-red-700 dark:text-red-300 active selected'
+											: 'border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700'
+									}`}
+									onclick={() => (quickType = 'creature')}
+									role="button"
+									aria-pressed={quickType === 'creature'}
+								>
+									<Skull class="inline-block w-4 h-4 mr-2" />
+									Creature
+								</button>
 							</div>
 						</div>
 
-						<!-- AC and Initiative -->
-						<div class="grid grid-cols-2 gap-4">
-							<div>
-								<label for="ac" class="label">AC (Armor Class)</label>
-								<input
-									id="ac"
-									type="number"
-									class="input"
-									bind:value={ac}
-									min="0"
-									step="1"
-									aria-label="AC"
-								/>
-							</div>
-							<div>
-								<label for="initiative" class="label">Initiative</label>
-								<input
-									id="initiative"
-									type="number"
-									class="input"
-									bind:value={initiative}
-									step="1"
-									aria-label="Initiative"
-								/>
-							</div>
+						<!-- Quick Name -->
+						<div>
+							<label for="quick-name" class="label">Name</label>
+							<input
+								id="quick-name"
+								type="text"
+								class="input"
+								bind:value={quickName}
+								placeholder="e.g., Goblin, Guard, Dragon"
+								aria-label="Combatant name"
+							/>
 						</div>
 
-						<!-- Hero-specific: Heroic Resource -->
-						{#if combatantType === 'hero'}
-							<div class="space-y-4 p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
-								<h3 class="font-medium text-blue-900 dark:text-blue-100">Heroic Resource</h3>
+						<!-- Quick HP -->
+						<div>
+							<label for="quick-hp" class="label">HP</label>
+							<input
+								id="quick-hp"
+								type="number"
+								class="input"
+								bind:value={quickHp}
+								min="1"
+								step="1"
+								placeholder="Current HP"
+								aria-label="HP"
+							/>
+						</div>
+					</div>
+				{:else}
+					<!-- Entity Mode -->
+					<!-- Type Toggle -->
+					<div>
+						<label class="label">Type</label>
+						<div class="flex gap-2">
+							<button
+								class={`flex-1 px-4 py-2 rounded-lg border transition-colors ${
+									combatantType === 'hero'
+										? 'bg-blue-100 dark:bg-blue-900 border-blue-500 text-blue-700 dark:text-blue-300 active selected'
+										: 'border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700'
+								}`}
+								onclick={() => (combatantType = 'hero')}
+								role="button"
+								aria-pressed={combatantType === 'hero'}
+							>
+								<User class="inline-block w-4 h-4 mr-2" />
+								Hero
+							</button>
+							<button
+								class={`flex-1 px-4 py-2 rounded-lg border transition-colors ${
+									combatantType === 'creature'
+										? 'bg-red-100 dark:bg-red-900 border-red-500 text-red-700 dark:text-red-300 active selected'
+										: 'border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700'
+								}`}
+								onclick={() => (combatantType = 'creature')}
+								role="button"
+								aria-pressed={combatantType === 'creature'}
+							>
+								<Skull class="inline-block w-4 h-4 mr-2" />
+								Creature
+							</button>
+						</div>
+					</div>
 
-								<div>
-									<label for="resource-name" class="label">Resource Name</label>
-									<input
-										id="resource-name"
-										type="text"
-										class="input"
-										bind:value={resourceName}
-										placeholder="e.g., Victories, Focus"
-										aria-label="Resource name"
-										list="resource-suggestions"
-									/>
-									<datalist id="resource-suggestions">
-										<option value="Victories"></option>
-										<option value="Focus"></option>
-										<option value="Fury"></option>
-										<option value="Resolve"></option>
-									</datalist>
-								</div>
+					<!-- Entity Search -->
+					<div>
+						<label for="entity-search" class="label">Search Entity</label>
+						<input
+							id="entity-search"
+							type="text"
+							class="input"
+							bind:value={searchQuery}
+							bind:this={searchInputRef}
+							placeholder={`Search ${combatantType === 'hero' ? 'characters' : 'NPCs'}...`}
+							aria-label="Search entity"
+						/>
+					</div>
 
-								<div class="grid grid-cols-2 gap-4">
-									<div>
-										<label for="resource-current" class="label">Current</label>
-										<input
-											id="resource-current"
-											type="number"
-											class="input"
-											bind:value={resourceCurrent}
-											min="0"
-											step="1"
-											aria-label="Current"
-										/>
-										{#if errors.resourceCurrent}
-											<p class="text-xs text-red-600 dark:text-red-400 mt-1">
-												{errors.resourceCurrent}
-											</p>
-										{/if}
-									</div>
-									<div>
-										<label for="resource-max" class="label">Max</label>
-										<input
-											id="resource-max"
-											type="number"
-											class="input"
-											bind:value={resourceMax}
-											min="0"
-											step="1"
-											aria-label="Max"
-										/>
-									</div>
-								</div>
-							</div>
-						{/if}
-
-						<!-- Creature-specific: Threat Level -->
-						{#if combatantType === 'creature'}
-							<div>
-								<label for="threat-level" class="label">Threat Level</label>
-								<select id="threat-level" class="input" bind:value={threat} aria-label="Threat level">
-									<option value="1">1 - Standard</option>
-									<option value="2">2 - Elite</option>
-									<option value="3">3 - Boss</option>
-								</select>
+					<!-- Entity List -->
+					<div>
+						{#if availableEntities.length === 0}
+							<p class="text-sm text-slate-500 dark:text-slate-400 text-center py-4">
+								No {combatantType === 'hero' ? 'characters' : 'NPCs'} {searchQuery ? 'found' : 'available'}
+							</p>
+						{:else}
+							<div class="space-y-2 max-h-48 overflow-y-auto">
+								{#each availableEntities as entity (entity.id)}
+									<button
+										class={`w-full text-left px-4 py-2 rounded-lg border transition-colors ${
+											selectedEntity?.id === entity.id
+												? 'bg-blue-50 dark:bg-blue-900/20 border-blue-500 selected active'
+												: 'border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700'
+										}`}
+										onclick={() => handleEntitySelect(entity)}
+									>
+										{entity.name}
+									</button>
+								{/each}
 							</div>
 						{/if}
 					</div>
+
+					<!-- Stats -->
+					{#if selectedEntity}
+						<div class="space-y-4 pt-4 border-t border-slate-200 dark:border-slate-700">
+							<!-- HP -->
+							<div class="grid grid-cols-2 gap-4">
+								<div>
+									<label for="hp" class="label">HP</label>
+									<input
+										id="hp"
+										type="number"
+										class="input"
+										bind:value={hp}
+										min="0"
+										step="1"
+										aria-label="HP"
+									/>
+									{#if errors.hp}
+										<p class="text-xs text-red-600 dark:text-red-400 mt-1">{errors.hp}</p>
+									{/if}
+								</div>
+								<div>
+									<label for="max-hp" class="label">Max HP (optional)</label>
+									<input
+										id="max-hp"
+										type="number"
+										class="input"
+										bind:value={maxHp}
+										min="1"
+										step="1"
+										placeholder="Optional"
+										aria-label="Max HP"
+									/>
+									{#if errors.maxHp}
+										<p class="text-xs text-red-600 dark:text-red-400 mt-1">{errors.maxHp}</p>
+									{/if}
+								</div>
+							</div>
+
+							<!-- AC and Initiative -->
+							<div class="grid grid-cols-2 gap-4">
+								<div>
+									<label for="ac" class="label">AC (Armor Class)</label>
+									<input
+										id="ac"
+										type="number"
+										class="input"
+										bind:value={ac}
+										min="0"
+										step="1"
+										aria-label="AC"
+									/>
+								</div>
+								<div>
+									<label for="initiative" class="label">Initiative</label>
+									<input
+										id="initiative"
+										type="number"
+										class="input"
+										bind:value={initiative}
+										step="1"
+										aria-label="Initiative"
+									/>
+								</div>
+							</div>
+
+							<!-- Hero-specific: Heroic Resource -->
+							{#if combatantType === 'hero'}
+								<div class="space-y-4 p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
+									<h3 class="font-medium text-blue-900 dark:text-blue-100">Heroic Resource (optional)</h3>
+
+									<div>
+										<label for="resource-name" class="label">Resource Name</label>
+										<input
+											id="resource-name"
+											type="text"
+											class="input"
+											bind:value={resourceName}
+											placeholder="e.g., Victories, Focus"
+											aria-label="Resource name"
+											list="resource-suggestions"
+										/>
+										<datalist id="resource-suggestions">
+											<option value="Victories"></option>
+											<option value="Focus"></option>
+											<option value="Fury"></option>
+											<option value="Resolve"></option>
+										</datalist>
+									</div>
+
+									<div class="grid grid-cols-2 gap-4">
+										<div>
+											<label for="resource-current" class="label">Current</label>
+											<input
+												id="resource-current"
+												type="number"
+												class="input"
+												bind:value={resourceCurrent}
+												min="0"
+												step="1"
+												aria-label="Current"
+											/>
+											{#if errors.resourceCurrent}
+												<p class="text-xs text-red-600 dark:text-red-400 mt-1">
+													{errors.resourceCurrent}
+												</p>
+											{/if}
+										</div>
+										<div>
+											<label for="resource-max" class="label">Max</label>
+											<input
+												id="resource-max"
+												type="number"
+												class="input"
+												bind:value={resourceMax}
+												min="0"
+												step="1"
+												aria-label="Max"
+											/>
+										</div>
+									</div>
+								</div>
+							{/if}
+
+							<!-- Creature-specific: Threat Level -->
+							{#if combatantType === 'creature'}
+								<div>
+									<label for="threat-level" class="label">Threat Level</label>
+									<select id="threat-level" class="input" bind:value={threat} aria-label="Threat level">
+										<option value="1">1 - Standard</option>
+										<option value="2">2 - Elite</option>
+										<option value="3">3 - Boss</option>
+									</select>
+								</div>
+							{/if}
+						</div>
+					{/if}
 				{/if}
 			</div>
 

--- a/src/lib/components/combat/CombatantCard.svelte
+++ b/src/lib/components/combat/CombatantCard.svelte
@@ -15,11 +15,11 @@
 
 	const isHero = $derived(isHeroCombatant(combatant));
 	const isCreature = $derived(isCreatureCombatant(combatant));
-	const isBloodied = $derived(combatant.hp <= combatant.maxHp / 2);
+	const isBloodied = $derived(combatant.maxHp ? combatant.hp <= combatant.maxHp / 2 : false);
 	const isDefeated = $derived(combatant.hp <= 0);
-	const isCritical = $derived(combatant.hp <= combatant.maxHp * 0.25);
+	const isCritical = $derived(combatant.maxHp ? combatant.hp <= combatant.maxHp * 0.25 : false);
 	const hpPercentage = $derived(
-		combatant.maxHp > 0 ? (Math.max(0, combatant.hp) / combatant.maxHp) * 100 : 0
+		combatant.maxHp && combatant.maxHp > 0 ? (Math.max(0, combatant.hp) / combatant.maxHp) * 100 : 0
 	);
 	const isClickable = $derived(onClick !== undefined);
 

--- a/src/lib/components/combat/InitiativeTracker.test.ts
+++ b/src/lib/components/combat/InitiativeTracker.test.ts
@@ -197,7 +197,7 @@ describe('InitiativeTracker Component - Combatant Display', () => {
 	it('should show bloodied status when HP <= 50%', () => {
 		const combat = createActiveCombatSession();
 		const combatant = combat.combatants[0];
-		combatant.hp = Math.floor(combatant.maxHp / 2);
+		combatant.hp = Math.floor(combatant.maxHp! / 2);
 
 		render(InitiativeTracker, {
 			props: { combat }

--- a/src/lib/stores/combat.svelte.ts
+++ b/src/lib/stores/combat.svelte.ts
@@ -18,6 +18,7 @@ import type {
 	UpdateCombatInput,
 	AddHeroCombatantInput,
 	AddCreatureCombatantInput,
+	AddQuickCombatantInput,
 	UpdateCombatantInput,
 	Combatant,
 	AddConditionInput,
@@ -261,6 +262,31 @@ function createCombatStore() {
 		try {
 			error = null;
 			const updated = await combatRepository.addCreatureCombatant(combatId, input);
+			updateActiveCombatIfMatch(updated);
+			return updated;
+		} catch (err: any) {
+			error = err.message;
+			throw err;
+		}
+	}
+
+	/**
+	 * Add quick combatant with minimal information (Issue #233).
+	 *
+	 * Simplified entry requiring only name and HP.
+	 * Auto-numbers duplicates and sets isAdHoc flag.
+	 *
+	 * @param combatId - Combat session ID
+	 * @param input - Quick combatant data (name, type, hp required)
+	 * @returns Updated combat session
+	 */
+	async function addQuickCombatant(
+		combatId: string,
+		input: AddQuickCombatantInput
+	): Promise<CombatSession> {
+		try {
+			error = null;
+			const updated = await combatRepository.addQuickCombatant(combatId, input);
 			updateActiveCombatIfMatch(updated);
 			return updated;
 		} catch (err: any) {
@@ -611,6 +637,7 @@ function createCombatStore() {
 		// Combatants
 		addHero,
 		addCreature,
+		addQuickCombatant,
 		updateCombatant,
 		removeCombatant,
 		rollInitiative,

--- a/src/lib/types/combat.ts
+++ b/src/lib/types/combat.ts
@@ -67,14 +67,15 @@ interface BaseCombatant {
 	id: string;
 	type: CombatantType;
 	name: string;
-	entityId: string; // Reference to entity in entities table
+	entityId?: string; // Reference to entity in entities table (optional for ad-hoc combatants)
 	initiative: number;
 	initiativeRoll: [number, number]; // Draw Steel uses 2d10
 	hp: number;
-	maxHp: number;
+	maxHp?: number; // Optional for ad-hoc combatants and uncapped healing
 	tempHp: number;
 	ac?: number;
 	conditions: CombatCondition[];
+	isAdHoc?: boolean; // Flag for ad-hoc combatants added without entity template
 }
 
 /**
@@ -82,7 +83,7 @@ interface BaseCombatant {
  */
 export interface HeroCombatant extends BaseCombatant {
 	type: 'hero';
-	heroicResource: HeroicResource;
+	heroicResource?: HeroicResource; // Optional for ad-hoc heroes
 }
 
 /**
@@ -212,10 +213,11 @@ export interface UpdateCombatInput {
  */
 export interface AddHeroCombatantInput {
 	name: string;
-	entityId: string;
-	maxHp: number;
+	entityId?: string; // Optional for ad-hoc combatants
+	hp?: number; // Starting HP (defaults to maxHp if not provided)
+	maxHp?: number; // Optional for ad-hoc combatants and uncapped healing
 	ac?: number;
-	heroicResource: HeroicResource;
+	heroicResource?: HeroicResource; // Optional for simplified heroes
 }
 
 /**
@@ -223,10 +225,23 @@ export interface AddHeroCombatantInput {
  */
 export interface AddCreatureCombatantInput {
 	name: string;
-	entityId: string;
-	maxHp: number;
+	entityId?: string; // Optional for ad-hoc combatants
+	hp?: number; // Starting HP (defaults to maxHp if not provided)
+	maxHp?: number; // Optional for ad-hoc combatants
 	ac?: number;
-	threat: number;
+	threat?: number; // Optional for ad-hoc combatants (defaults to 1)
+}
+
+/**
+ * Input for quick-adding an ad-hoc combatant (Issue #233).
+ * Simplified interface requiring only name, HP, and type.
+ */
+export interface AddQuickCombatantInput {
+	name: string;
+	hp: number;
+	type: CombatantType;
+	ac?: number;
+	threat?: number; // For creatures, defaults to 1
 }
 
 /**

--- a/src/routes/combat/[id]/+page.svelte
+++ b/src/routes/combat/[id]/+page.svelte
@@ -130,10 +130,18 @@
 	async function handleAddCombatant(data: any) {
 		if (!combat) return;
 
-		if (data.type === 'hero') {
+		// Handle quick-add (ad-hoc) combatants
+		if (data.isAdHoc) {
+			await combatStore.addQuickCombatant(combat.id, {
+				name: data.name,
+				hp: data.hp,
+				type: data.type
+			});
+		} else if (data.type === 'hero') {
 			await combatStore.addHero(combat.id, {
 				name: data.name,
 				entityId: data.entityId,
+				hp: data.hp,
 				maxHp: data.maxHp,
 				ac: data.ac,
 				heroicResource: data.heroicResource
@@ -142,6 +150,7 @@
 			await combatStore.addCreature(combat.id, {
 				name: data.name,
 				entityId: data.entityId,
+				hp: data.hp,
 				maxHp: data.maxHp,
 				ac: data.ac,
 				threat: data.threat

--- a/src/routes/combat/[id]/page.test.ts
+++ b/src/routes/combat/[id]/page.test.ts
@@ -257,7 +257,7 @@ describe('Combat Runner Page - HP Tracker', () => {
 
 		await waitFor(() => {
 			const hpTracker = screen.getByTestId('hp-tracker');
-			expect(within(hpTracker).getByText(new RegExp(combatant.maxHp.toString()))).toBeInTheDocument();
+			expect(within(hpTracker).getByText(new RegExp(combatant.maxHp!.toString()))).toBeInTheDocument();
 		});
 	});
 

--- a/src/tests/utils/combatTestUtils.ts
+++ b/src/tests/utils/combatTestUtils.ts
@@ -235,7 +235,7 @@ export function getCurrentCombatant(combat: CombatSession): Combatant | undefine
  * Helper to check if a combatant is bloodied (HP <= 50% of max)
  */
 export function isBloodied(combatant: Combatant): boolean {
-	return combatant.hp <= combatant.maxHp / 2;
+	return combatant.maxHp ? combatant.hp <= combatant.maxHp / 2 : false;
 }
 
 /**


### PR DESCRIPTION
## Summary

Simplifies the combat tracker to be a lightweight tool focused on turn order, HP, and conditions. Closes #233.

- **Quick-add generic combatants** - Add with just name + HP, no entity required. Auto-numbers duplicates (Goblin, Goblin 1, Goblin 2)
- **Simplified hero/PC entry** - Only requires entity selection + current HP. maxHp and heroicResource now optional
- **Optional max HP** - Track current HP without a cap. Healing unlimited when maxHp is undefined

## Changes

| File | Description |
|------|-------------|
| `src/lib/types/combat.ts` | Made `entityId`, `maxHp` optional, added `isAdHoc` flag |
| `src/lib/db/repositories/combatRepository.ts` | Added `addQuickCombatant()`, updated healing logic |
| `src/lib/stores/combat.svelte.ts` | Exported `addQuickCombatant` |
| `src/lib/components/combat/AddCombatantModal.svelte` | Added quick-add mode UI |
| `src/lib/components/combat/HpTracker.svelte` | Handles optional maxHp display |
| `src/lib/components/combat/CombatantCard.svelte` | Handles optional maxHp |
| `docs/COMBAT_SYSTEM.md` | Updated documentation |

## Test plan

- [x] 235 combat-related tests pass (combatRepository, HpTracker, combat store)
- [x] Quick-add creates combatants with `isAdHoc: true`
- [x] Duplicate names auto-numbered correctly
- [x] Healing uncapped when maxHp undefined
- [x] Existing combat sessions work (backwards compatible)
- [x] Build succeeds

## Follow-up issues

- #240 - Add threat selector to quick-add form
- #241 - Uncapped healing edge case
- #242 - Bloodied condition for ad-hoc combatants

🤖 Generated with [Claude Code](https://claude.com/claude-code)