### PR TITLE
fix(#245): apply default values in entity parser

### DIFF
--- a/src/lib/services/entityParserService.ts
+++ b/src/lib/services/entityParserService.ts
@@ -317,6 +317,17 @@ export function extractFields(
 		}
 	}
 
+	// Apply default values for fields that weren't found in text
+	// This ensures entities with required fields that have defaults can be saved
+	for (const fieldDef of typeDef.fieldDefinitions) {
+		if (
+			fieldDef.defaultValue !== undefined &&
+			fields[fieldDef.key] === undefined
+		) {
+			fields[fieldDef.key] = fieldDef.defaultValue;
+		}
+	}
+
 	// Also check for common fields that might not be in type definition
 	// e.g., "inhabitants" for locations, "leadership" for factions, "tags" for all
 	if (entityType === 'location') {


### PR DESCRIPTION
## Summary

- Fixes entity parser not applying default values from field definitions
- Entities with required fields that have defaults (e.g., NPC `status`) can now be saved immediately after detection
- Updates tests to reflect correct behavior with defaults

Closes #245

## Test plan

- [x] Unit tests pass for default value application
- [x] Existing entity parser tests updated and passing
- [x] Entity save service tests passing
- [x] Chat message and detection indicator tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)