### PR TITLE
feat(#238): implement Forge Steel character import functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+**Forge Steel Character Import (Issue #238)**
+- Import character data from Forge Steel character builder into Director Assist
+- ForgeSteelImportModal component accessible from Settings page
+- Accepts .json or .ds-hero files exported from Forge Steel
+- File validation with detailed error messages and warnings
+- Preview imported character before saving
+- Automatic field mapping: name, concept (ancestry + class), background (notes), status (defeated state)
+- Duplicate name detection to prevent conflicts with existing characters
+- Creates character entity with "forge-steel-import" tag for easy filtering
+- Real-time validation feedback during file selection
+- Accessibility features: ARIA labels, keyboard navigation, backdrop click to close
+
 **Debug Console for AI Request/Response Inspection (Issue #118)**
 - Advanced debug console for inspecting all AI request and response data
 - Settings toggle in Advanced section to enable/disable debug console

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Director Assist features a **system-aware architecture** with first-class suppor
 - **System-Aware**: First-class support for Draw Steel and System Agnostic modes with game-specific fields and terminology
 - **AI-Powered Content Generation**: Generate content using Claude AI with campaign context awareness
 - **Conversation Management**: Organize AI chats into separate conversations—create, switch, rename, and delete as needed
+- **Forge Steel Integration**: Import character data directly from Forge Steel character builder
 - **Responsive Loading States**: Polished loading feedback with skeleton screens, spinners, and loading buttons
 
 ## Quick Start

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -2348,6 +2348,64 @@ This means you can safely share backups with other Directors or store them in cl
 
 After importing, you'll need to re-enter your API key in Settings if you want to use AI features. Your AI provider and model preferences will be restored automatically from the backup.
 
+### Importing from Forge Steel
+
+Director Assist can import character data directly from Forge Steel, the official Draw Steel character builder. This allows you to bring player characters or NPCs created in Forge Steel into your Director Assist campaign.
+
+**What Gets Imported**:
+- Character name
+- Ancestry and Class (combined into the "concept" field)
+- Character notes (imported as "background")
+- Defeated status (becomes "active" or "deceased")
+
+**How to Import**:
+
+1. Export your character from Forge Steel as a `.ds-hero` or `.json` file
+2. Open Settings in Director Assist (gear icon)
+3. Scroll to the "Import from Forge Steel" section
+4. Click "Import Character"
+5. Select your `.ds-hero` or `.json` file
+6. Review the import preview:
+   - Character name
+   - Concept (Ancestry + Class)
+   - Background (notes)
+   - Status (active or deceased)
+7. Click "Import Character" to save
+
+**Validation and Warnings**:
+
+Director Assist validates the file before importing and shows:
+- **Errors** (red): Issues that prevent import
+  - Invalid file format or structure
+  - Missing required fields (name, id, state)
+  - Duplicate character name (a character with this name already exists)
+- **Warnings** (yellow): Non-critical issues that won't block import
+  - Missing ancestry (concept field will be incomplete)
+  - Missing class (concept field will be incomplete)
+
+**What Happens After Import**:
+
+When you import a character from Forge Steel:
+- A new character entity is created in Director Assist
+- The entity is automatically tagged with "forge-steel-import" for easy filtering
+- A success notification confirms the import
+- The character appears in your Characters list
+
+**Limitations**:
+
+- Only character data from Forge Steel can be imported (not monsters, items, or other content)
+- Full character sheet details (stats, abilities, equipment) are not imported—only the basic narrative information
+- You'll need to manually add any additional details or relationships after import
+- The character must have a unique name (no duplicates with existing characters)
+
+**Tips**:
+
+- Use the import feature to quickly add player characters to your campaign
+- Import recurring NPCs you've built in Forge Steel
+- After importing, you can add relationships, notes, and other Director Assist-specific data
+- Filter your character list by the "forge-steel-import" tag to see all imported characters
+- Edit the imported character to add more detail beyond what Forge Steel provides
+
 ### Backup Best Practices
 
 **How Often to Backup**:

--- a/src/lib/components/settings/ForgeSteelImportModal.svelte
+++ b/src/lib/components/settings/ForgeSteelImportModal.svelte
@@ -1,0 +1,323 @@
+<script lang="ts">
+	import { X, Upload, AlertTriangle, CheckCircle } from 'lucide-svelte';
+	import { entitiesStore } from '$lib/stores/entities.svelte';
+	import { notificationStore } from '$lib/stores/notifications.svelte';
+	import { validateForgeSteelImport, mapForgeSteelHeroToEntity } from '$lib/services/forgeSteelImportService';
+	import type { ForgeSteelHero } from '$lib/types/forgeSteel';
+	import type { ImportValidationResult } from '$lib/services/forgeSteelImportService';
+
+	interface Props {
+		open: boolean;
+		onimport?: () => void;
+		oncancel?: () => void;
+	}
+
+	let { open = false, onimport, oncancel }: Props = $props();
+
+	let dialogElement: HTMLDialogElement | null = $state(null);
+	let fileInput: HTMLInputElement | null = $state(null);
+	let selectedFile: File | null = $state(null);
+	let validationResult: ImportValidationResult | null = $state(null);
+	let importData: ForgeSteelHero | null = $state(null);
+	let isImporting = $state(false);
+
+	// Derived states
+	const hasFile = $derived(!!selectedFile);
+	const hasValidation = $derived(!!validationResult);
+	const isValid = $derived(validationResult?.valid || false);
+	const hasErrors = $derived((validationResult?.errors.length || 0) > 0);
+	const hasWarnings = $derived((validationResult?.warnings.length || 0) > 0);
+	const canImport = $derived(isValid && !isImporting);
+
+	// Handle modal open/close
+	$effect(() => {
+		if (open && dialogElement && !dialogElement.open) {
+			dialogElement.showModal();
+		} else if (!open && dialogElement?.open) {
+			dialogElement.close();
+			// Reset state when closing
+			resetState();
+		}
+	});
+
+	function resetState() {
+		selectedFile = null;
+		validationResult = null;
+		importData = null;
+		isImporting = false;
+		if (fileInput) {
+			fileInput.value = '';
+		}
+	}
+
+	// Handle backdrop click
+	function handleBackdropClick(e: MouseEvent) {
+		const rect = dialogElement?.getBoundingClientRect();
+		if (
+			rect &&
+			(e.clientX < rect.left ||
+				e.clientX > rect.right ||
+				e.clientY < rect.top ||
+				e.clientY > rect.bottom)
+		) {
+			handleCancel();
+		}
+	}
+
+	// Handle Escape key
+	function handleKeyDown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			e.preventDefault();
+			handleCancel();
+		}
+	}
+
+	function handleCancel() {
+		if (!isImporting) {
+			oncancel?.();
+		}
+	}
+
+	async function handleFileChange(e: Event) {
+		const target = e.target as HTMLInputElement;
+		const file = target.files?.[0];
+
+		if (!file) {
+			resetState();
+			return;
+		}
+
+		selectedFile = file;
+
+		try {
+			// Read file
+			const text = await file.text();
+
+			// Parse JSON
+			try {
+				const data = JSON.parse(text);
+				importData = data;
+
+				// Get existing character names for conflict detection
+				const existingCharacterNames = entitiesStore.entities
+					.filter((e) => e.type === 'character')
+					.map((e) => e.name);
+
+				// Validate
+				validationResult = validateForgeSteelImport(data, existingCharacterNames);
+			} catch (parseError) {
+				validationResult = {
+					valid: false,
+					errors: ['Invalid JSON format: ' + (parseError as Error).message],
+					warnings: []
+				};
+				importData = null;
+			}
+		} catch (readError) {
+			validationResult = {
+				valid: false,
+				errors: ['Failed to read file: ' + (readError as Error).message],
+				warnings: []
+			};
+			importData = null;
+		}
+	}
+
+	async function handleImport() {
+		if (!canImport || !importData) return;
+
+		isImporting = true;
+
+		try {
+			// Map to NewEntity
+			const newEntity = mapForgeSteelHeroToEntity(importData);
+
+			// Create entity
+			await entitiesStore.create(newEntity);
+
+			// Success notification
+			notificationStore.success(`Character "${newEntity.name}" imported successfully`);
+
+			// Call onimport callback
+			onimport?.();
+		} catch (error) {
+			console.error('Import failed:', error);
+			notificationStore.error(
+				'Failed to import character: ' + (error instanceof Error ? error.message : 'Unknown error')
+			);
+		} finally {
+			isImporting = false;
+		}
+	}
+</script>
+
+{#if open}
+	<dialog
+		bind:this={dialogElement}
+		class="fixed inset-0 z-50 w-full max-w-2xl p-0 bg-transparent backdrop:bg-black/50"
+		onclick={handleBackdropClick}
+		onkeydown={handleKeyDown}
+		aria-modal="true"
+		aria-labelledby="import-modal-title"
+	>
+		<div
+			class="bg-white dark:bg-slate-800 rounded-lg shadow-xl max-h-[90vh] overflow-hidden flex flex-col"
+			onclick={(e) => e.stopPropagation()}
+		>
+			<!-- Header -->
+			<div class="flex items-center justify-between p-6 border-b border-slate-200 dark:border-slate-700">
+				<div class="flex items-center gap-3">
+					<div class="flex-shrink-0 w-10 h-10 rounded-full bg-green-100 dark:bg-green-900/20 flex items-center justify-center">
+						<Upload class="w-5 h-5 text-green-600 dark:text-green-400" />
+					</div>
+					<h2 id="import-modal-title" class="text-lg font-semibold text-slate-900 dark:text-white">
+						Import from Forge Steel
+					</h2>
+				</div>
+				<button
+					type="button"
+					class="flex-shrink-0 text-slate-400 hover:text-slate-600 dark:hover:text-slate-200"
+					onclick={handleCancel}
+					aria-label="Close dialog"
+					disabled={isImporting}
+				>
+					<X class="w-5 h-5" />
+				</button>
+			</div>
+
+			<!-- Content -->
+			<div class="flex-1 overflow-y-auto p-6 space-y-6">
+				<!-- File Picker -->
+				<div>
+					<label for="import-file" class="label">
+						Select Forge Steel Character File
+					</label>
+					<input
+						bind:this={fileInput}
+						id="import-file"
+						type="file"
+						class="input"
+						accept=".json,.ds-hero,application/json"
+						onchange={handleFileChange}
+						disabled={isImporting}
+					/>
+					{#if selectedFile}
+						<p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+							Selected: {selectedFile.name}
+						</p>
+					{/if}
+					<p class="mt-2 text-xs text-slate-500 dark:text-slate-400">
+						Accepts .json or .ds-hero files exported from Forge Steel character builder
+					</p>
+				</div>
+
+				<!-- Validation Messages -->
+				{#if hasValidation}
+					<div aria-live="polite" class="space-y-3">
+						<!-- Errors -->
+						{#if hasErrors}
+							<div class="p-4 bg-red-50 dark:bg-red-900/10 border border-red-200 dark:border-red-800 rounded-lg space-y-2">
+								<p class="text-sm font-semibold text-red-900 dark:text-red-200 mb-2">
+									Validation Errors
+								</p>
+								{#each validationResult.errors as error}
+									<p class="text-sm text-red-900 dark:text-red-200 flex items-start gap-2">
+										<AlertTriangle class="w-4 h-4 flex-shrink-0 mt-0.5" />
+										<span>{error}</span>
+									</p>
+								{/each}
+							</div>
+						{/if}
+
+						<!-- Warnings -->
+						{#if hasWarnings}
+							<div class="p-4 bg-yellow-50 dark:bg-yellow-900/10 border border-yellow-200 dark:border-yellow-800 rounded-lg space-y-2">
+								<p class="text-sm font-semibold text-yellow-900 dark:text-yellow-200 mb-2">
+									Warnings
+								</p>
+								{#each validationResult.warnings as warning}
+									<p class="text-sm text-yellow-900 dark:text-yellow-200 flex items-start gap-2">
+										<AlertTriangle class="w-4 h-4 flex-shrink-0 mt-0.5" />
+										<span>{warning}</span>
+									</p>
+								{/each}
+							</div>
+						{/if}
+
+						<!-- Preview (if valid) -->
+						{#if isValid && importData}
+							<div>
+								<h3 class="text-sm font-semibold text-slate-900 dark:text-white mb-3 flex items-center gap-2">
+									<CheckCircle class="w-4 h-4 text-green-600 dark:text-green-400" />
+									Ready to Import
+								</h3>
+								<div class="border border-slate-200 dark:border-slate-700 rounded-lg p-4 space-y-3">
+									<div class="flex items-start justify-between gap-4">
+										<span class="text-sm font-medium text-slate-700 dark:text-slate-300">
+											Name:
+										</span>
+										<span class="text-sm text-slate-900 dark:text-white text-right">
+											{importData.name}
+										</span>
+									</div>
+									{#if importData.ancestry || importData.class}
+										<div class="flex items-start justify-between gap-4">
+											<span class="text-sm font-medium text-slate-700 dark:text-slate-300">
+												Concept:
+											</span>
+											<span class="text-sm text-slate-900 dark:text-white text-right">
+												{[importData.ancestry?.name, importData.class?.name]
+													.filter((x) => x)
+													.join(' ') || 'None'}
+											</span>
+										</div>
+									{/if}
+									{#if importData.state.notes}
+										<div class="flex items-start justify-between gap-4">
+											<span class="text-sm font-medium text-slate-700 dark:text-slate-300">
+												Background:
+											</span>
+											<span class="text-sm text-slate-900 dark:text-white text-right max-w-md">
+												{importData.state.notes.length > 100
+													? importData.state.notes.slice(0, 100) + '...'
+													: importData.state.notes}
+											</span>
+										</div>
+									{/if}
+									<div class="flex items-start justify-between gap-4">
+										<span class="text-sm font-medium text-slate-700 dark:text-slate-300">
+											Status:
+										</span>
+										<span class="text-sm text-slate-900 dark:text-white text-right">
+											{importData.state.defeated ? 'Deceased' : 'Active'}
+										</span>
+									</div>
+								</div>
+							</div>
+						{/if}
+					</div>
+				{/if}
+			</div>
+
+			<!-- Footer -->
+			<div class="flex items-center justify-end gap-3 p-6 border-t border-slate-200 dark:border-slate-700">
+				<button
+					type="button"
+					class="btn btn-secondary"
+					onclick={handleCancel}
+					disabled={isImporting}
+				>
+					Cancel
+				</button>
+				<button
+					type="button"
+					class="btn btn-primary"
+					onclick={handleImport}
+					disabled={!canImport}
+				>
+					{isImporting ? 'Importing...' : 'Import Character'}
+				</button>
+			</div>
+		</div>
+	</dialog>
+{/if}

--- a/src/lib/services/forgeSteelImportService.test.ts
+++ b/src/lib/services/forgeSteelImportService.test.ts
@@ -1,0 +1,848 @@
+/**
+ * Tests for Forge Steel Import Service (TDD RED Phase - Issue #238)
+ *
+ * These tests define expected behavior for importing Forge Steel character data
+ * into Director Assist character entities. Tests should FAIL initially.
+ *
+ * Covers:
+ * - JSON validation and parsing
+ * - Field mapping from Forge Steel to Director Assist
+ * - Conflict detection with existing characters
+ * - Error handling for malformed data
+ * - Edge cases (null/undefined values, empty objects, missing fields)
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+	validateForgeSteelImport,
+	mapForgeSteelHeroToEntity
+} from '$lib/services/forgeSteelImportService';
+import type { ForgeSteelHero } from '$lib/types/forgeSteel';
+import type { NewEntity } from '$lib/types';
+
+describe('forgeSteelImportService', () => {
+	describe('validateForgeSteelImport', () => {
+		describe('Valid Import Data', () => {
+			it('should accept valid Forge Steel hero with all fields', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric Steelheart',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: {
+						notes: 'A brave warrior seeking redemption',
+						defeated: false
+					}
+				};
+				const result = validateForgeSteelImport(hero, []);
+				expect(result.valid).toBe(true);
+				expect(result.errors).toHaveLength(0);
+			});
+
+			it('should accept hero with null ancestry', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Concept Character',
+					ancestry: null,
+					class: { name: 'Shadow', level: 2 },
+					state: {
+						notes: 'Still deciding ancestry',
+						defeated: false
+					}
+				};
+				const result = validateForgeSteelImport(hero, []);
+				expect(result.valid).toBe(true);
+				expect(result.errors).toHaveLength(0);
+				expect(result.warnings).toContain(
+					'Character has no ancestry defined - concept field will be incomplete'
+				);
+			});
+
+			it('should accept hero with null class', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Concept Character',
+					ancestry: { name: 'Dwarf' },
+					class: null,
+					state: {
+						notes: 'Still deciding class',
+						defeated: false
+					}
+				};
+				const result = validateForgeSteelImport(hero, []);
+				expect(result.valid).toBe(true);
+				expect(result.errors).toHaveLength(0);
+				expect(result.warnings).toContain(
+					'Character has no class defined - concept field will be incomplete'
+				);
+			});
+
+			it('should warn when both ancestry and class are null', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Early Concept',
+					ancestry: null,
+					class: null,
+					state: {
+						notes: 'Just a name so far',
+						defeated: false
+					}
+				};
+				const result = validateForgeSteelImport(hero, []);
+				expect(result.valid).toBe(true);
+				expect(result.warnings).toContain(
+					'Character has no ancestry defined - concept field will be incomplete'
+				);
+				expect(result.warnings).toContain(
+					'Character has no class defined - concept field will be incomplete'
+				);
+			});
+
+			it('should accept hero with empty notes', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Silent Bob',
+					ancestry: { name: 'Human' },
+					class: { name: 'Shadow', level: 3 },
+					state: {
+						notes: '',
+						defeated: false
+					}
+				};
+				const result = validateForgeSteelImport(hero, []);
+				expect(result.valid).toBe(true);
+			});
+
+			it('should accept defeated hero', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-456',
+					name: 'Fallen Hero',
+					ancestry: { name: 'Elf' },
+					class: { name: 'Conduit', level: 5 },
+					state: {
+						notes: 'Died in the Battle of the Crimson Fields',
+						defeated: true
+					}
+				};
+				const result = validateForgeSteelImport(hero, []);
+				expect(result.valid).toBe(true);
+			});
+		});
+
+		describe('Invalid Import Data', () => {
+			it('should reject null data', () => {
+				const result = validateForgeSteelImport(null as unknown as ForgeSteelHero, []);
+				expect(result.valid).toBe(false);
+				expect(result.errors).toContain('Import data is null or undefined');
+			});
+
+			it('should reject undefined data', () => {
+				const result = validateForgeSteelImport(undefined as unknown as ForgeSteelHero, []);
+				expect(result.valid).toBe(false);
+				expect(result.errors).toContain('Import data is null or undefined');
+			});
+
+			it('should reject non-object data', () => {
+				const result = validateForgeSteelImport('not an object' as unknown as ForgeSteelHero, []);
+				expect(result.valid).toBe(false);
+				expect(result.errors).toContain('Import data must be an object');
+			});
+
+			it('should reject array data', () => {
+				const result = validateForgeSteelImport([] as unknown as ForgeSteelHero, []);
+				expect(result.valid).toBe(false);
+				expect(result.errors).toContain('Import data must be an object');
+			});
+
+			it('should reject hero missing name field', () => {
+				const hero = {
+					id: 'hero-123',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				} as unknown as ForgeSteelHero;
+				const result = validateForgeSteelImport(hero, []);
+				expect(result.valid).toBe(false);
+				expect(result.errors).toContain('Missing required field: name');
+			});
+
+			it('should reject hero with empty name', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: '',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const result = validateForgeSteelImport(hero, []);
+				expect(result.valid).toBe(false);
+				expect(result.errors).toContain('Character name cannot be empty');
+			});
+
+			it('should reject hero with whitespace-only name', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: '   ',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const result = validateForgeSteelImport(hero, []);
+				expect(result.valid).toBe(false);
+				expect(result.errors).toContain('Character name cannot be empty');
+			});
+
+			it('should reject hero missing id field', () => {
+				const hero = {
+					name: 'Aric',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				} as unknown as ForgeSteelHero;
+				const result = validateForgeSteelImport(hero, []);
+				expect(result.valid).toBe(false);
+				expect(result.errors).toContain('Missing required field: id');
+			});
+
+			it('should reject hero missing state field', () => {
+				const hero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 }
+				} as unknown as ForgeSteelHero;
+				const result = validateForgeSteelImport(hero, []);
+				expect(result.valid).toBe(false);
+				expect(result.errors).toContain('Missing required field: state');
+			});
+
+			it('should reject empty object', () => {
+				const result = validateForgeSteelImport({} as ForgeSteelHero, []);
+				expect(result.valid).toBe(false);
+				expect(result.errors.length).toBeGreaterThan(0);
+			});
+
+			it('should collect multiple validation errors', () => {
+				const hero = {
+					ancestry: null,
+					class: null
+				} as unknown as ForgeSteelHero;
+				const result = validateForgeSteelImport(hero, []);
+				expect(result.valid).toBe(false);
+				expect(result.errors.length).toBeGreaterThan(1);
+			});
+		});
+
+		describe('Conflict Detection', () => {
+			it('should detect conflict when character name already exists', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric Steelheart',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const existingNames = ['Gandalf', 'Aric Steelheart', 'Frodo'];
+				const result = validateForgeSteelImport(hero, existingNames);
+				expect(result.valid).toBe(false);
+				expect(result.errors).toContain(
+					'A character named "Aric Steelheart" already exists. Please rename before importing.'
+				);
+			});
+
+			it('should detect conflict with case-insensitive name matching', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric Steelheart',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const existingNames = ['aric steelheart'];
+				const result = validateForgeSteelImport(hero, existingNames);
+				expect(result.valid).toBe(false);
+				expect(result.errors).toContain(
+					'A character named "Aric Steelheart" already exists. Please rename before importing.'
+				);
+			});
+
+			it('should pass validation when name does not conflict', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric Steelheart',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const existingNames = ['Gandalf', 'Frodo', 'Aragorn'];
+				const result = validateForgeSteelImport(hero, existingNames);
+				expect(result.valid).toBe(true);
+			});
+
+			it('should handle empty existing names array', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric Steelheart',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const result = validateForgeSteelImport(hero, []);
+				expect(result.valid).toBe(true);
+			});
+
+			it('should trim whitespace when checking conflicts', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: ' Aric Steelheart ',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const existingNames = ['Aric Steelheart'];
+				const result = validateForgeSteelImport(hero, existingNames);
+				expect(result.valid).toBe(false);
+			});
+		});
+
+		describe('Malformed JSON Handling', () => {
+			it('should handle object with invalid ancestry type', () => {
+				const hero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: 'Human',
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				} as unknown as ForgeSteelHero;
+				const result = validateForgeSteelImport(hero, []);
+				expect(result.valid).toBe(false);
+				expect(result.errors).toContain('Invalid ancestry structure');
+			});
+
+			it('should handle object with invalid class type', () => {
+				const hero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'Human' },
+					class: 'Fury',
+					state: { notes: '', defeated: false }
+				} as unknown as ForgeSteelHero;
+				const result = validateForgeSteelImport(hero, []);
+				expect(result.valid).toBe(false);
+				expect(result.errors).toContain('Invalid class structure');
+			});
+
+			it('should handle object with invalid state type', () => {
+				const hero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: 'active'
+				} as unknown as ForgeSteelHero;
+				const result = validateForgeSteelImport(hero, []);
+				expect(result.valid).toBe(false);
+				expect(result.errors).toContain('Invalid state structure');
+			});
+		});
+	});
+
+	describe('mapForgeSteelHeroToEntity', () => {
+		describe('Complete Hero Mapping', () => {
+			it('should map hero with all fields to NewEntity', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric Steelheart',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: {
+						notes: 'A brave warrior seeking redemption for past mistakes',
+						defeated: false
+					}
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.type).toBe('character');
+				expect(entity.name).toBe('Aric Steelheart');
+				expect(entity.description).toBe('');
+				expect(entity.tags).toContain('forge-steel-import');
+				expect(entity.fields.concept).toBe('Human Fury');
+				expect(entity.fields.background).toBe(
+					'A brave warrior seeking redemption for past mistakes'
+				);
+				expect(entity.fields.status).toBe('active');
+				expect(entity.notes).toBe('Imported from Forge Steel');
+			});
+
+			it('should map defeated hero with status deceased', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-456',
+					name: 'Fallen Hero',
+					ancestry: { name: 'Elf' },
+					class: { name: 'Conduit', level: 5 },
+					state: {
+						notes: 'Died in the Battle of the Crimson Fields',
+						defeated: true
+					}
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.status).toBe('deceased');
+			});
+
+			it('should map active hero with status active', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-789',
+					name: 'Active Hero',
+					ancestry: { name: 'Dwarf' },
+					class: { name: 'Fury', level: 3 },
+					state: {
+						notes: 'Still adventuring',
+						defeated: false
+					}
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.status).toBe('active');
+			});
+		});
+
+		describe('Field Mapping - Direct Fields', () => {
+			it('should map name field directly', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Test Character',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.name).toBe('Test Character');
+			});
+
+			it('should trim whitespace from name', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: '  Test Character  ',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.name).toBe('Test Character');
+			});
+		});
+
+		describe('Field Mapping - Concept Field', () => {
+			it('should combine ancestry and class into concept field', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.concept).toBe('Human Fury');
+			});
+
+			it('should use only ancestry when class is null', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'Dwarf' },
+					class: null,
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.concept).toBe('Dwarf');
+			});
+
+			it('should use only class when ancestry is null', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: null,
+					class: { name: 'Shadow', level: 2 },
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.concept).toBe('Shadow');
+			});
+
+			it('should set empty concept when both ancestry and class are null', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: null,
+					class: null,
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.concept).toBe('');
+			});
+
+			it('should handle multi-word ancestry names', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'High Elf' },
+					class: { name: 'Conduit', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.concept).toBe('High Elf Conduit');
+			});
+
+			it('should handle multi-word class names', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'Human' },
+					class: { name: 'Shadow Dancer', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.concept).toBe('Human Shadow Dancer');
+			});
+		});
+
+		describe('Field Mapping - Background Field', () => {
+			it('should map state.notes to background field', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: {
+						notes: 'Born in the northern kingdoms, trained as a warrior from youth',
+						defeated: false
+					}
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.background).toBe(
+					'Born in the northern kingdoms, trained as a warrior from youth'
+				);
+			});
+
+			it('should handle empty notes', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: {
+						notes: '',
+						defeated: false
+					}
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.background).toBe('');
+			});
+
+			it('should preserve multiline notes', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: {
+						notes: 'Line 1\nLine 2\nLine 3',
+						defeated: false
+					}
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.background).toBe('Line 1\nLine 2\nLine 3');
+			});
+
+			it('should preserve special characters in notes', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: {
+						notes: 'Notes with "quotes" and \'apostrophes\' and <brackets>',
+						defeated: false
+					}
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.background).toBe(
+					'Notes with "quotes" and \'apostrophes\' and <brackets>'
+				);
+			});
+		});
+
+		describe('Field Mapping - Status Field', () => {
+			it('should map defeated: true to status "deceased"', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Fallen Hero',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: {
+						notes: 'Died in battle',
+						defeated: true
+					}
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.status).toBe('deceased');
+			});
+
+			it('should map defeated: false to status "active"', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Active Hero',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: {
+						notes: 'Still adventuring',
+						defeated: false
+					}
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.status).toBe('active');
+			});
+		});
+
+		describe('Entity Structure', () => {
+			it('should set type to "character"', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.type).toBe('character');
+			});
+
+			it('should set empty description', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.description).toBe('');
+			});
+
+			it('should add "forge-steel-import" tag', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.tags).toContain('forge-steel-import');
+			});
+
+			it('should set notes to "Imported from Forge Steel"', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.notes).toBe('Imported from Forge Steel');
+			});
+
+			it('should initialize empty links array', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.links).toEqual([]);
+			});
+
+			it('should initialize empty metadata object', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.metadata).toEqual({});
+			});
+
+			it('should return a NewEntity type (no id, createdAt, updatedAt)', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero) as NewEntity;
+
+				expect(entity).not.toHaveProperty('id');
+				expect(entity).not.toHaveProperty('createdAt');
+				expect(entity).not.toHaveProperty('updatedAt');
+				expect(entity).toHaveProperty('type');
+				expect(entity).toHaveProperty('name');
+				expect(entity).toHaveProperty('fields');
+			});
+		});
+
+		describe('Edge Cases', () => {
+			it('should handle ancestry with additional properties', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: {
+						name: 'Human',
+						description: 'Versatile and ambitious',
+						traits: ['Bonus Feat']
+					} as any,
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.concept).toBe('Human Fury');
+			});
+
+			it('should handle class with additional properties', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'Human' },
+					class: {
+						name: 'Fury',
+						level: 5,
+						subclass: 'Berserker',
+						abilities: ['Rage', 'Reckless Attack']
+					} as any,
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.concept).toBe('Human Fury');
+			});
+
+			it('should handle state with additional properties', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: {
+						notes: 'Character notes',
+						defeated: false,
+						health: 100,
+						conditions: ['inspired']
+					} as any
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.background).toBe('Character notes');
+				expect(entity.fields.status).toBe('active');
+			});
+
+			it('should handle very long notes', () => {
+				const longNotes = 'A'.repeat(10000);
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: {
+						notes: longNotes,
+						defeated: false
+					}
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.background).toBe(longNotes);
+			});
+
+			it('should handle special characters in ancestry name', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'Half-Elf (High Elf)' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.concept).toBe('Half-Elf (High Elf) Fury');
+			});
+
+			it('should handle special characters in class name', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury (Berserker Path)', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.concept).toBe('Human Fury (Berserker Path)');
+			});
+
+			it('should handle unicode characters in name', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Árïç Stëëlhëärt',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.name).toBe('Árïç Stëëlhëärt');
+			});
+
+			it('should handle emoji in notes', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: {
+						notes: 'A brave warrior 🗡️ seeking redemption ✨',
+						defeated: false
+					}
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.background).toBe('A brave warrior 🗡️ seeking redemption ✨');
+			});
+		});
+	});
+});

--- a/src/lib/services/forgeSteelImportService.ts
+++ b/src/lib/services/forgeSteelImportService.ts
@@ -1,0 +1,119 @@
+/**
+ * Forge Steel Import Service
+ *
+ * Service functions for validating and mapping Forge Steel character data
+ * to Director Assist entities.
+ */
+
+import type { NewEntity } from '$lib/types';
+import type { ForgeSteelHero } from '$lib/types/forgeSteel';
+import { validateForgeSteelHeroStructure } from '$lib/types/forgeSteel';
+
+export interface ImportValidationResult {
+	valid: boolean;
+	errors: string[];
+	warnings: string[];
+}
+
+/**
+ * Validates a Forge Steel hero for import
+ * @param data - The hero data to validate
+ * @param existingCharacterNames - Array of existing character names to check for conflicts
+ * @returns Validation result with errors and warnings
+ */
+export function validateForgeSteelImport(
+	data: unknown,
+	existingCharacterNames: string[]
+): ImportValidationResult {
+	const errors: string[] = [];
+	const warnings: string[] = [];
+
+	// Check for null/undefined
+	if (data === null || data === undefined) {
+		errors.push('Import data is null or undefined');
+		return { valid: false, errors, warnings };
+	}
+
+	// Check that data is an object
+	if (typeof data !== 'object' || Array.isArray(data)) {
+		errors.push('Import data must be an object');
+		return { valid: false, errors, warnings };
+	}
+
+	// Validate structure
+	const structureValidation = validateForgeSteelHeroStructure(data);
+	if (!structureValidation.valid) {
+		// Replace "Hero name" with "Character name" for import context
+		const importErrors = structureValidation.errors.map((error) =>
+			error.replace('Hero name cannot be empty', 'Character name cannot be empty')
+		);
+		errors.push(...importErrors);
+	}
+
+	// If we have fatal errors, return early
+	if (errors.length > 0) {
+		return { valid: false, errors, warnings };
+	}
+
+	// At this point we know it's a valid ForgeSteelHero
+	const hero = data as ForgeSteelHero;
+
+	// Check for name conflicts (case-insensitive)
+	const trimmedName = hero.name.trim();
+	const nameExists = existingCharacterNames.some(
+		(existingName) => existingName.toLowerCase() === trimmedName.toLowerCase()
+	);
+	if (nameExists) {
+		errors.push(
+			`A character named "${hero.name}" already exists. Please rename before importing.`
+		);
+	}
+
+	// Warnings for incomplete data
+	if (hero.ancestry === null) {
+		warnings.push('Character has no ancestry defined - concept field will be incomplete');
+	}
+
+	if (hero.class === null) {
+		warnings.push('Character has no class defined - concept field will be incomplete');
+	}
+
+	return {
+		valid: errors.length === 0,
+		errors,
+		warnings
+	};
+}
+
+/**
+ * Maps a Forge Steel hero to a Director Assist NewEntity
+ * @param hero - The validated Forge Steel hero
+ * @returns A NewEntity ready to be saved
+ */
+export function mapForgeSteelHeroToEntity(hero: ForgeSteelHero): NewEntity {
+	// Build concept field from ancestry and class
+	const ancestryName = hero.ancestry?.name || '';
+	const className = hero.class?.name || '';
+	const concept = [ancestryName, className]
+		.filter((part) => part.trim() !== '')
+		.join(' ')
+		.trim();
+
+	// Map defeated status
+	const status = hero.state.defeated ? 'deceased' : 'active';
+
+	return {
+		type: 'character',
+		name: hero.name.trim(),
+		description: '',
+		tags: ['forge-steel-import'],
+		fields: {
+			concept,
+			background: hero.state.notes,
+			status
+		},
+		links: [],
+		notes: 'Imported from Forge Steel',
+		metadata: {}
+	};
+}

--- a/src/lib/types/forgeSteel.test.ts
+++ b/src/lib/types/forgeSteel.test.ts
@@ -1,0 +1,604 @@
+/**
+ * Tests for Forge Steel Import Type Definitions (TDD RED Phase - Issue #238)
+ *
+ * These tests define expected behavior for Forge Steel type validation and type guards.
+ * Tests should FAIL initially since no implementation exists yet.
+ *
+ * Covers:
+ * - ForgeSteelHero interface validation
+ * - Type guards for Forge Steel data structures
+ * - Required field validation (name)
+ * - Optional field handling (ancestry, class)
+ * - Null/undefined handling for complex nested objects
+ * - State object validation
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+	isForgeSteelHero,
+	isForgeSteelAncestry,
+	isForgeSteelClass,
+	isForgeSteelState,
+	validateForgeSteelHeroStructure
+} from '$lib/types/forgeSteel';
+import type { ForgeSteelHero } from '$lib/types/forgeSteel';
+
+describe('forgeSteel - Type Guards', () => {
+	describe('isForgeSteelHero', () => {
+		describe('Valid Forge Steel Hero Objects', () => {
+			it('should accept valid hero with all required fields', () => {
+				const hero = {
+					id: 'hero-123',
+					name: 'Aric Steelheart',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: {
+						notes: 'A brave warrior',
+						defeated: false
+					}
+				};
+				expect(isForgeSteelHero(hero)).toBe(true);
+			});
+
+			it('should accept hero with null ancestry', () => {
+				const hero = {
+					id: 'hero-123',
+					name: 'Concept Character',
+					ancestry: null,
+					class: { name: 'Fury', level: 1 },
+					state: {
+						notes: '',
+						defeated: false
+					}
+				};
+				expect(isForgeSteelHero(hero)).toBe(true);
+			});
+
+			it('should accept hero with null class', () => {
+				const hero = {
+					id: 'hero-123',
+					name: 'Concept Character',
+					ancestry: { name: 'Dwarf' },
+					class: null,
+					state: {
+						notes: '',
+						defeated: false
+					}
+				};
+				expect(isForgeSteelHero(hero)).toBe(true);
+			});
+
+			it('should accept hero with both ancestry and class null', () => {
+				const hero = {
+					id: 'hero-123',
+					name: 'Early Concept',
+					ancestry: null,
+					class: null,
+					state: {
+						notes: 'Still developing this character',
+						defeated: false
+					}
+				};
+				expect(isForgeSteelHero(hero)).toBe(true);
+			});
+
+			it('should accept hero with empty notes', () => {
+				const hero = {
+					id: 'hero-123',
+					name: 'Silent Bob',
+					ancestry: { name: 'Human' },
+					class: { name: 'Shadow', level: 3 },
+					state: {
+						notes: '',
+						defeated: false
+					}
+				};
+				expect(isForgeSteelHero(hero)).toBe(true);
+			});
+
+			it('should accept hero with defeated true', () => {
+				const hero = {
+					id: 'hero-456',
+					name: 'Fallen Hero',
+					ancestry: { name: 'Elf' },
+					class: { name: 'Conduit', level: 5 },
+					state: {
+						notes: 'Died in the Battle of the Crimson Fields',
+						defeated: true
+					}
+				};
+				expect(isForgeSteelHero(hero)).toBe(true);
+			});
+		});
+
+		describe('Invalid Forge Steel Hero Objects', () => {
+			it('should reject object missing id field', () => {
+				const hero = {
+					name: 'Aric Steelheart',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: {
+						notes: '',
+						defeated: false
+					}
+				};
+				expect(isForgeSteelHero(hero)).toBe(false);
+			});
+
+			it('should reject object missing name field', () => {
+				const hero = {
+					id: 'hero-123',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: {
+						notes: '',
+						defeated: false
+					}
+				};
+				expect(isForgeSteelHero(hero)).toBe(false);
+			});
+
+			it('should reject object with empty string name', () => {
+				const hero = {
+					id: 'hero-123',
+					name: '',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: {
+						notes: '',
+						defeated: false
+					}
+				};
+				expect(isForgeSteelHero(hero)).toBe(false);
+			});
+
+			it('should reject object with whitespace-only name', () => {
+				const hero = {
+					id: 'hero-123',
+					name: '   ',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: {
+						notes: '',
+						defeated: false
+					}
+				};
+				expect(isForgeSteelHero(hero)).toBe(false);
+			});
+
+			it('should reject object missing state field', () => {
+				const hero = {
+					id: 'hero-123',
+					name: 'Aric Steelheart',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 }
+				};
+				expect(isForgeSteelHero(hero)).toBe(false);
+			});
+
+			it('should reject object with invalid id type', () => {
+				const hero = {
+					id: 123,
+					name: 'Aric Steelheart',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: {
+						notes: '',
+						defeated: false
+					}
+				};
+				expect(isForgeSteelHero(hero)).toBe(false);
+			});
+
+			it('should reject object with invalid name type', () => {
+				const hero = {
+					id: 'hero-123',
+					name: 123,
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: {
+						notes: '',
+						defeated: false
+					}
+				};
+				expect(isForgeSteelHero(hero)).toBe(false);
+			});
+
+			it('should reject null', () => {
+				expect(isForgeSteelHero(null)).toBe(false);
+			});
+
+			it('should reject undefined', () => {
+				expect(isForgeSteelHero(undefined)).toBe(false);
+			});
+
+			it('should reject array', () => {
+				expect(isForgeSteelHero([])).toBe(false);
+			});
+
+			it('should reject string', () => {
+				expect(isForgeSteelHero('not a hero')).toBe(false);
+			});
+
+			it('should reject number', () => {
+				expect(isForgeSteelHero(42)).toBe(false);
+			});
+		});
+	});
+
+	describe('isForgeSteelAncestry', () => {
+		it('should accept valid ancestry object with name', () => {
+			const ancestry = { name: 'Human' };
+			expect(isForgeSteelAncestry(ancestry)).toBe(true);
+		});
+
+		it('should accept ancestry with additional properties', () => {
+			const ancestry = {
+				name: 'Dwarf',
+				description: 'Stout and hardy',
+				traits: ['Darkvision', 'Stonecunning']
+			};
+			expect(isForgeSteelAncestry(ancestry)).toBe(true);
+		});
+
+		it('should accept null ancestry', () => {
+			expect(isForgeSteelAncestry(null)).toBe(true);
+		});
+
+		it('should reject ancestry missing name field', () => {
+			const ancestry = { description: 'Some ancestry' };
+			expect(isForgeSteelAncestry(ancestry)).toBe(false);
+		});
+
+		it('should reject ancestry with empty string name', () => {
+			const ancestry = { name: '' };
+			expect(isForgeSteelAncestry(ancestry)).toBe(false);
+		});
+
+		it('should reject ancestry with non-string name', () => {
+			const ancestry = { name: 123 };
+			expect(isForgeSteelAncestry(ancestry)).toBe(false);
+		});
+
+		it('should reject undefined', () => {
+			expect(isForgeSteelAncestry(undefined)).toBe(false);
+		});
+
+		it('should reject non-object types', () => {
+			expect(isForgeSteelAncestry('Human')).toBe(false);
+			expect(isForgeSteelAncestry(123)).toBe(false);
+			expect(isForgeSteelAncestry(true)).toBe(false);
+		});
+	});
+
+	describe('isForgeSteelClass', () => {
+		it('should accept valid class object with name and level', () => {
+			const heroClass = { name: 'Fury', level: 1 };
+			expect(isForgeSteelClass(heroClass)).toBe(true);
+		});
+
+		it('should accept class with higher level', () => {
+			const heroClass = { name: 'Shadow', level: 10 };
+			expect(isForgeSteelClass(heroClass)).toBe(true);
+		});
+
+		it('should accept class with additional properties', () => {
+			const heroClass = {
+				name: 'Conduit',
+				level: 5,
+				subclass: 'Elementalist',
+				abilities: ['Fireball', 'Ice Bolt']
+			};
+			expect(isForgeSteelClass(heroClass)).toBe(true);
+		});
+
+		it('should accept null class', () => {
+			expect(isForgeSteelClass(null)).toBe(true);
+		});
+
+		it('should reject class missing name field', () => {
+			const heroClass = { level: 5 };
+			expect(isForgeSteelClass(heroClass)).toBe(false);
+		});
+
+		it('should reject class missing level field', () => {
+			const heroClass = { name: 'Fury' };
+			expect(isForgeSteelClass(heroClass)).toBe(false);
+		});
+
+		it('should reject class with empty string name', () => {
+			const heroClass = { name: '', level: 1 };
+			expect(isForgeSteelClass(heroClass)).toBe(false);
+		});
+
+		it('should reject class with non-number level', () => {
+			const heroClass = { name: 'Fury', level: '1' };
+			expect(isForgeSteelClass(heroClass)).toBe(false);
+		});
+
+		it('should reject class with zero level', () => {
+			const heroClass = { name: 'Fury', level: 0 };
+			expect(isForgeSteelClass(heroClass)).toBe(false);
+		});
+
+		it('should reject class with negative level', () => {
+			const heroClass = { name: 'Fury', level: -1 };
+			expect(isForgeSteelClass(heroClass)).toBe(false);
+		});
+
+		it('should reject undefined', () => {
+			expect(isForgeSteelClass(undefined)).toBe(false);
+		});
+
+		it('should reject non-object types', () => {
+			expect(isForgeSteelClass('Fury')).toBe(false);
+			expect(isForgeSteelClass(1)).toBe(false);
+		});
+	});
+
+	describe('isForgeSteelState', () => {
+		it('should accept valid state with notes and defeated', () => {
+			const state = {
+				notes: 'Some character notes',
+				defeated: false
+			};
+			expect(isForgeSteelState(state)).toBe(true);
+		});
+
+		it('should accept state with empty notes', () => {
+			const state = {
+				notes: '',
+				defeated: false
+			};
+			expect(isForgeSteelState(state)).toBe(true);
+		});
+
+		it('should accept state with defeated true', () => {
+			const state = {
+				notes: 'Fell in battle',
+				defeated: true
+			};
+			expect(isForgeSteelState(state)).toBe(true);
+		});
+
+		it('should accept state with additional properties', () => {
+			const state = {
+				notes: 'Character notes',
+				defeated: false,
+				health: 100,
+				conditions: ['poisoned']
+			};
+			expect(isForgeSteelState(state)).toBe(true);
+		});
+
+		it('should reject state missing notes field', () => {
+			const state = {
+				defeated: false
+			};
+			expect(isForgeSteelState(state)).toBe(false);
+		});
+
+		it('should reject state missing defeated field', () => {
+			const state = {
+				notes: 'Some notes'
+			};
+			expect(isForgeSteelState(state)).toBe(false);
+		});
+
+		it('should reject state with non-string notes', () => {
+			const state = {
+				notes: 123,
+				defeated: false
+			};
+			expect(isForgeSteelState(state)).toBe(false);
+		});
+
+		it('should reject state with non-boolean defeated', () => {
+			const state = {
+				notes: 'Some notes',
+				defeated: 'false'
+			};
+			expect(isForgeSteelState(state)).toBe(false);
+		});
+
+		it('should reject null', () => {
+			expect(isForgeSteelState(null)).toBe(false);
+		});
+
+		it('should reject undefined', () => {
+			expect(isForgeSteelState(undefined)).toBe(false);
+		});
+
+		it('should reject non-object types', () => {
+			expect(isForgeSteelState('state')).toBe(false);
+			expect(isForgeSteelState(123)).toBe(false);
+		});
+	});
+
+	describe('validateForgeSteelHeroStructure', () => {
+		describe('Valid Heroes', () => {
+			it('should return no errors for complete valid hero', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric Steelheart',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: {
+						notes: 'A brave warrior',
+						defeated: false
+					}
+				};
+				const result = validateForgeSteelHeroStructure(hero);
+				expect(result.valid).toBe(true);
+				expect(result.errors).toHaveLength(0);
+			});
+
+			it('should return no errors for hero with null ancestry', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Concept Hero',
+					ancestry: null,
+					class: { name: 'Fury', level: 1 },
+					state: {
+						notes: '',
+						defeated: false
+					}
+				};
+				const result = validateForgeSteelHeroStructure(hero);
+				expect(result.valid).toBe(true);
+				expect(result.errors).toHaveLength(0);
+			});
+
+			it('should return no errors for hero with null class', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Concept Hero',
+					ancestry: { name: 'Elf' },
+					class: null,
+					state: {
+						notes: '',
+						defeated: false
+					}
+				};
+				const result = validateForgeSteelHeroStructure(hero);
+				expect(result.valid).toBe(true);
+				expect(result.errors).toHaveLength(0);
+			});
+		});
+
+		describe('Invalid Heroes - Missing Fields', () => {
+			it('should return error for missing id', () => {
+				const hero = {
+					name: 'Aric',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				} as unknown as ForgeSteelHero;
+				const result = validateForgeSteelHeroStructure(hero);
+				expect(result.valid).toBe(false);
+				expect(result.errors).toContain('Missing required field: id');
+			});
+
+			it('should return error for missing name', () => {
+				const hero = {
+					id: 'hero-123',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				} as unknown as ForgeSteelHero;
+				const result = validateForgeSteelHeroStructure(hero);
+				expect(result.valid).toBe(false);
+				expect(result.errors).toContain('Missing required field: name');
+			});
+
+			it('should return error for empty name', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: '',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const result = validateForgeSteelHeroStructure(hero);
+				expect(result.valid).toBe(false);
+				expect(result.errors).toContain('Hero name cannot be empty');
+			});
+
+			it('should return error for missing state', () => {
+				const hero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 }
+				} as unknown as ForgeSteelHero;
+				const result = validateForgeSteelHeroStructure(hero);
+				expect(result.valid).toBe(false);
+				expect(result.errors).toContain('Missing required field: state');
+			});
+		});
+
+		describe('Invalid Heroes - Type Errors', () => {
+			it('should return error for invalid id type', () => {
+				const hero = {
+					id: 123,
+					name: 'Aric',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				} as unknown as ForgeSteelHero;
+				const result = validateForgeSteelHeroStructure(hero);
+				expect(result.valid).toBe(false);
+				expect(result.errors).toContain('Field "id" must be a string');
+			});
+
+			it('should return error for invalid name type', () => {
+				const hero = {
+					id: 'hero-123',
+					name: 123,
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				} as unknown as ForgeSteelHero;
+				const result = validateForgeSteelHeroStructure(hero);
+				expect(result.valid).toBe(false);
+				expect(result.errors).toContain('Field "name" must be a string');
+			});
+
+			it('should return error for invalid ancestry structure', () => {
+				const hero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { description: 'No name field' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				} as unknown as ForgeSteelHero;
+				const result = validateForgeSteelHeroStructure(hero);
+				expect(result.valid).toBe(false);
+				expect(result.errors).toContain('Invalid ancestry structure');
+			});
+
+			it('should return error for invalid class structure', () => {
+				const hero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury' },
+					state: { notes: '', defeated: false }
+				} as unknown as ForgeSteelHero;
+				const result = validateForgeSteelHeroStructure(hero);
+				expect(result.valid).toBe(false);
+				expect(result.errors).toContain('Invalid class structure');
+			});
+
+			it('should return error for invalid state structure', () => {
+				const hero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '' }
+				} as unknown as ForgeSteelHero;
+				const result = validateForgeSteelHeroStructure(hero);
+				expect(result.valid).toBe(false);
+				expect(result.errors).toContain('Invalid state structure');
+			});
+		});
+
+		describe('Multiple Errors', () => {
+			it('should return all validation errors', () => {
+				const hero = {
+					id: 123,
+					name: '',
+					ancestry: { description: 'Invalid' },
+					class: { name: 'Fury' },
+					state: null
+				} as unknown as ForgeSteelHero;
+				const result = validateForgeSteelHeroStructure(hero);
+				expect(result.valid).toBe(false);
+				expect(result.errors.length).toBeGreaterThan(1);
+				expect(result.errors).toContain('Field "id" must be a string');
+				expect(result.errors).toContain('Hero name cannot be empty');
+			});
+		});
+	});
+});

--- a/src/lib/types/forgeSteel.ts
+++ b/src/lib/types/forgeSteel.ts
@@ -1,0 +1,182 @@
+/**
+ * Forge Steel Import Type Definitions
+ *
+ * Types and type guards for importing character data from Forge Steel
+ * character builder into Director Assist entities.
+ */
+
+// Forge Steel data structure types
+export interface ForgeSteelAncestry {
+	name: string;
+	[key: string]: unknown; // Allow additional properties
+}
+
+export interface ForgeSteelClass {
+	name: string;
+	level: number;
+	[key: string]: unknown; // Allow additional properties
+}
+
+export interface ForgeSteelState {
+	notes: string;
+	defeated: boolean;
+	[key: string]: unknown; // Allow additional properties
+}
+
+export interface ForgeSteelHero {
+	id: string;
+	name: string;
+	ancestry: ForgeSteelAncestry | null;
+	class: ForgeSteelClass | null;
+	state: ForgeSteelState;
+}
+
+// Validation result type
+export interface ValidationResult {
+	valid: boolean;
+	errors: string[];
+}
+
+// Type guards
+export function isForgeSteelAncestry(value: unknown): value is ForgeSteelAncestry | null {
+	if (value === null) {
+		return true;
+	}
+
+	if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+		return false;
+	}
+
+	const obj = value as Record<string, unknown>;
+
+	if (!('name' in obj) || typeof obj.name !== 'string' || obj.name.trim() === '') {
+		return false;
+	}
+
+	return true;
+}
+
+export function isForgeSteelClass(value: unknown): value is ForgeSteelClass | null {
+	if (value === null) {
+		return true;
+	}
+
+	if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+		return false;
+	}
+
+	const obj = value as Record<string, unknown>;
+
+	if (!('name' in obj) || typeof obj.name !== 'string' || obj.name.trim() === '') {
+		return false;
+	}
+
+	if (!('level' in obj) || typeof obj.level !== 'number' || obj.level <= 0) {
+		return false;
+	}
+
+	return true;
+}
+
+export function isForgeSteelState(value: unknown): value is ForgeSteelState {
+	if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+		return false;
+	}
+
+	const obj = value as Record<string, unknown>;
+
+	if (!('notes' in obj) || typeof obj.notes !== 'string') {
+		return false;
+	}
+
+	if (!('defeated' in obj) || typeof obj.defeated !== 'boolean') {
+		return false;
+	}
+
+	return true;
+}
+
+export function isForgeSteelHero(value: unknown): value is ForgeSteelHero {
+	if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+		return false;
+	}
+
+	const obj = value as Record<string, unknown>;
+
+	// Check required id field
+	if (!('id' in obj) || typeof obj.id !== 'string') {
+		return false;
+	}
+
+	// Check required name field
+	if (!('name' in obj) || typeof obj.name !== 'string' || obj.name.trim() === '') {
+		return false;
+	}
+
+	// Check ancestry field (can be null)
+	if (!('ancestry' in obj) || !isForgeSteelAncestry(obj.ancestry)) {
+		return false;
+	}
+
+	// Check class field (can be null)
+	if (!('class' in obj) || !isForgeSteelClass(obj.class)) {
+		return false;
+	}
+
+	// Check state field (required)
+	if (!('state' in obj) || !isForgeSteelState(obj.state)) {
+		return false;
+	}
+
+	return true;
+}
+
+// Validation function for detailed error messages
+export function validateForgeSteelHeroStructure(hero: unknown): ValidationResult {
+	const errors: string[] = [];
+
+	if (typeof hero !== 'object' || hero === null || Array.isArray(hero)) {
+		errors.push('Hero must be an object');
+		return { valid: false, errors };
+	}
+
+	const obj = hero as Record<string, unknown>;
+
+	// Validate id
+	if (!('id' in obj)) {
+		errors.push('Missing required field: id');
+	} else if (typeof obj.id !== 'string') {
+		errors.push('Field "id" must be a string');
+	}
+
+	// Validate name
+	if (!('name' in obj)) {
+		errors.push('Missing required field: name');
+	} else if (typeof obj.name !== 'string') {
+		errors.push('Field "name" must be a string');
+	} else if (obj.name.trim() === '') {
+		errors.push('Hero name cannot be empty');
+	}
+
+	// Validate ancestry
+	if ('ancestry' in obj && !isForgeSteelAncestry(obj.ancestry)) {
+		errors.push('Invalid ancestry structure');
+	}
+
+	// Validate class
+	if ('class' in obj && !isForgeSteelClass(obj.class)) {
+		errors.push('Invalid class structure');
+	}
+
+	// Validate state
+	if (!('state' in obj)) {
+		errors.push('Missing required field: state');
+	} else if (!isForgeSteelState(obj.state)) {
+		errors.push('Invalid state structure');
+	}
+
+	return {
+		valid: errors.length === 0,
+		errors
+	};
+}

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -21,6 +21,7 @@
 	} from '$lib/services';
 	import { Download, Upload, Moon, Sun, Monitor, Trash2, Key, RefreshCw, Layers, ChevronRight, Users } from 'lucide-svelte';
 	import PlayerExportModal from '$lib/components/settings/PlayerExportModal.svelte';
+	import ForgeSteelImportModal from '$lib/components/settings/ForgeSteelImportModal.svelte';
 	import LoadingButton from '$lib/components/ui/LoadingButton.svelte';
 	import { SystemSelector, CampaignLinkingSettings } from '$lib/components/settings';
 	import { page } from '$app/stores';
@@ -30,6 +31,7 @@
 	let isExporting = $state(false);
 	let isImporting = $state(false);
 	let showPlayerExportModal = $state(false);
+	let showForgeSteelImportModal = $state(false);
 
 	// Model selection state
 	let models = $state<ModelInfo[]>([]);
@@ -728,6 +730,21 @@
 		</button>
 	</section>
 
+	<!-- Forge Steel Import -->
+	<section class="mb-8">
+		<h2 class="text-lg font-semibold text-slate-900 dark:text-white mb-4">Import from Forge Steel</h2>
+		<p class="text-sm text-slate-500 mb-4">
+			Import character data from Forge Steel character builder. Accepts .json or .ds-hero files.
+		</p>
+		<button
+			class="btn btn-secondary inline-flex items-center gap-2"
+			onclick={() => showForgeSteelImportModal = true}
+		>
+			<Upload class="w-4 h-4" />
+			Import Character
+		</button>
+	</section>
+
 	<!-- Advanced -->
 	<section class="mb-8">
 		<h2 class="text-lg font-semibold text-slate-900 dark:text-white mb-4">Advanced</h2>
@@ -773,3 +790,10 @@
 
 <!-- Player Export Modal -->
 <PlayerExportModal bind:open={showPlayerExportModal} onclose={() => showPlayerExportModal = false} />
+
+<!-- Forge Steel Import Modal -->
+<ForgeSteelImportModal
+	bind:open={showForgeSteelImportModal}
+	onimport={() => showForgeSteelImportModal = false}
+	oncancel={() => showForgeSteelImportModal = false}
+/>


### PR DESCRIPTION
## Summary
Implements Forge Steel character import functionality (issue #238). Users can now import character data from Forge Steel's `.ds-hero` files via the Settings page.

## Changes
- New type definitions and validation for Forge Steel hero format
- Import service with field mapping logic
- Modal UI component for file upload and preview
- 119 unit tests covering all functionality
- Documentation updates (CHANGELOG, USER_GUIDE, README)

## Field Mapping
The import service maps Forge Steel hero data to character attributes:
- `name` → hero.name
- `concept` → ancestry + class (e.g., "Human Fury")
- `background` → hero notes  
- `status` → "deceased" if defeated, "active" otherwise

## Testing
- All 119 tests passing
- TypeScript check passing
- Production build successful

Closes #238