### PR TITLE
fix(#253): markdown editor defaults to full-width edit mode

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2580,7 +2580,7 @@ interface MarkdownEditorProps {
   placeholder?: string;                 // Placeholder text for empty editor
   disabled?: boolean;                   // Disable editing
   readonly?: boolean;                   // Read-only mode
-  mode?: 'edit' | 'preview' | 'split';  // Editor display mode (default: 'split')
+  mode?: 'edit' | 'preview' | 'split';  // Editor display mode (default: 'edit')
   minHeight?: string;                   // Minimum height (default: '150px')
   maxHeight?: string;                   // Maximum height (default: '400px')
   class?: string;                       // Additional CSS classes
@@ -2592,11 +2592,12 @@ interface MarkdownEditorProps {
 
 **Features:**
 
-- Formatting toolbar with buttons for bold, italic, heading, code, link, and list
+- Formatting toolbar with buttons for bold, italic, heading, code, link, list, and preview toggle
 - Three editing modes:
-  - **Edit**: Show only markdown editor
+  - **Edit**: Show only markdown editor (default)
   - **Preview**: Show only rendered preview
   - **Split**: Show editor and preview side-by-side
+- Preview/Edit toggle button in toolbar for quick mode switching
 - Keyboard shortcuts: Ctrl+B (bold), Ctrl+I (italic)
 - Real-time preview with HTML sanitization
 - Automatic textarea resizing within min/max bounds

--- a/src/routes/entities/[type]/[id]/edit/+page.svelte
+++ b/src/routes/entities/[type]/[id]/edit/+page.svelte
@@ -763,7 +763,6 @@
 								placeholder={field.placeholder}
 								error={errors[field.key]}
 								onchange={(value) => updateField(field.key, value)}
-								mode="split"
 								minHeight="200px"
 								maxHeight="600px"
 							/>

--- a/src/routes/entities/[type]/new/+page.svelte
+++ b/src/routes/entities/[type]/new/+page.svelte
@@ -545,7 +545,6 @@
 							placeholder={field.placeholder}
 							error={errors[field.key]}
 							onchange={(value) => updateField(field.key, value)}
-							mode="split"
 							minHeight="200px"
 							maxHeight="600px"
 						/>


### PR DESCRIPTION
## Summary
- Removed `mode="split"` prop from MarkdownEditor in entity new/edit pages
- Updated ARCHITECTURE.md documentation to reflect correct default mode
- The markdown editor now properly defaults to full-width edit mode with Preview toggle button

This fixes issue #253 and aligns behavior with the original implementation from issue #236.