### PR TITLE
fix(#256): serialize entity before IndexedDB storage to prevent DataCloneError

### DIFF
--- a/src/lib/db/repositories/entityRepository.ts
+++ b/src/lib/db/repositories/entityRepository.ts
@@ -148,9 +148,12 @@ export const entityRepository = {
 	async create(newEntity: NewEntity): Promise<BaseEntity> {
 		await ensureDbReady();
 
+		// Serialize to strip any reactive proxies (Issue #256)
+		const plainEntity = JSON.parse(JSON.stringify(newEntity));
+
 		const now = new Date();
 		const entity: BaseEntity = {
-			...newEntity,
+			...plainEntity,
 			id: nanoid(),
 			createdAt: now,
 			updatedAt: now
@@ -166,6 +169,9 @@ export const entityRepository = {
 		pendingLinks: import('$lib/types').PendingRelationship[]
 	): Promise<BaseEntity> {
 		await ensureDbReady();
+
+		// Serialize to strip any reactive proxies (Issue #256)
+		const plainEntity = JSON.parse(JSON.stringify(newEntity));
 
 		return await db.transaction('rw', db.entities, async () => {
 			const now = new Date();
@@ -214,7 +220,7 @@ export const entityRepository = {
 
 			// Create the entity with its links
 			const entity: BaseEntity = {
-				...newEntity,
+				...plainEntity,
 				id: entityId,
 				links,
 				createdAt: now,


### PR DESCRIPTION
## Summary

Fixed DataCloneError that occurred when creating entities (e.g., factions) by adding JSON serialization to strip Svelte 5 reactive proxies before storage.

- Added JSON serialization in `entityRepository.create()` to strip Svelte 5 reactive proxies
- Added JSON serialization in `entityRepository.createWithLinks()` with same pattern
- Follows existing pattern used elsewhere in the file (addLink, updateLink, etc.)

IndexedDB's structured clone algorithm cannot handle Svelte 5 proxy objects, so we serialize to JSON and parse back to get plain objects before storage.

Fixes #256