### PR TITLE
Combat tracker improvements

### DIFF
--- a/src/lib/components/combat/TurnControls.svelte
+++ b/src/lib/components/combat/TurnControls.svelte
@@ -7,7 +7,8 @@
 		Square,
 		Loader2,
 		ChevronRight,
-		ChevronLeft
+		ChevronLeft,
+		RotateCcw
 	} from 'lucide-svelte';
 	import type { CombatSession } from '$lib/types/combat';
 	import { onMount, onDestroy } from 'svelte';
@@ -20,6 +21,7 @@
 		onPauseCombat?: () => void | Promise<void>;
 		onResumeCombat?: () => void | Promise<void>;
 		onEndCombat?: () => void | Promise<void>;
+		onReopenCombat?: () => void | Promise<void>;
 		loading?: boolean;
 		showRoundAdvance?: boolean;
 	}
@@ -32,6 +34,7 @@
 		onPauseCombat,
 		onResumeCombat,
 		onEndCombat,
+		onReopenCombat,
 		loading = false,
 		showRoundAdvance = false
 	}: Props = $props();
@@ -193,6 +196,18 @@
 			>
 				<Square class="w-4 h-4" />
 				End Combat
+			</button>
+		{/if}
+
+		{#if isCompleted && onReopenCombat}
+			<button
+				class="btn btn-primary flex-1"
+				onclick={onReopenCombat}
+				aria-label="Reopen Combat"
+				title="Reopen this combat session"
+			>
+				<RotateCcw class="w-4 h-4" />
+				Reopen Combat
 			</button>
 		{/if}
 	</div>

--- a/src/lib/stores/combat.svelte.ts
+++ b/src/lib/stores/combat.svelte.ts
@@ -239,6 +239,18 @@ function createCombatStore() {
 		}
 	}
 
+	async function reopenCombat(id: string): Promise<CombatSession> {
+		try {
+			error = null;
+			const updated = await combatRepository.reopenCombat(id);
+			updateActiveCombatIfMatch(updated);
+			return updated;
+		} catch (err: any) {
+			error = err.message;
+			throw err;
+		}
+	}
+
 	// ========================================================================
 	// Combatant Management
 	// ========================================================================
@@ -315,6 +327,26 @@ function createCombatStore() {
 		try {
 			error = null;
 			const updated = await combatRepository.removeCombatant(combatId, combatantId);
+			updateActiveCombatIfMatch(updated);
+			return updated;
+		} catch (err: any) {
+			error = err.message;
+			throw err;
+		}
+	}
+
+	async function moveCombatantToPosition(
+		combatId: string,
+		combatantId: string,
+		newPosition: number
+	): Promise<CombatSession> {
+		try {
+			error = null;
+			const updated = await combatRepository.moveCombatantToPosition(
+				combatId,
+				combatantId,
+				newPosition
+			);
 			updateActiveCombatIfMatch(updated);
 			return updated;
 		} catch (err: any) {
@@ -633,6 +665,7 @@ function createCombatStore() {
 		pauseCombat,
 		resumeCombat,
 		endCombat,
+		reopenCombat,
 
 		// Combatants
 		addHero,
@@ -640,6 +673,7 @@ function createCombatStore() {
 		addQuickCombatant,
 		updateCombatant,
 		removeCombatant,
+		moveCombatantToPosition,
 		rollInitiative,
 		rollInitiativeForAll,
 


### PR DESCRIPTION
## Summary

This PR adds several quality-of-life improvements to the combat tracker:

- **Remove combatant from combat** - Button in the combatant detail panel to remove someone from the encounter
- **Delete combat encounter** - Trash button on combat list cards with confirmation dialog
- **Reopen completed combat** - Button to un-complete accidentally ended combats
- **Manual combatant reordering** - Up/down arrows and editable position number to reorder initiative
- **Resizable initiative panel** - Drag handle to adjust the width of the combatant list

## Issues

Closes #264
Closes #265
Closes #266
Closes #267
Closes #268

## Test plan

- [ ] Add combatants to a combat, select one, verify "Remove" button removes them
- [ ] On combat list, click trash icon, verify confirmation appears, confirm deletion works
- [ ] End a combat, verify "Reopen Combat" button appears and works
- [ ] Use up/down arrows to reorder combatants, verify order persists
- [ ] Type a number in the position box and press Enter, verify combatant moves
- [ ] Drag the resize handle between panels, verify width changes and persists on reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)