### PR TITLE
fix(montage): convert $state proxies to plain objects for IndexedDB

### DIFF
--- a/src/lib/components/montage/MontageSetup.svelte
+++ b/src/lib/components/montage/MontageSetup.svelte
@@ -40,12 +40,17 @@
 		isSubmitting = true;
 
 		try {
+			// Convert $state proxy to plain objects for IndexedDB
+			const plainChallenges = predefinedChallenges.length > 0
+				? predefinedChallenges.map(c => ({ ...c }))
+				: undefined;
+
 			await onSubmit({
 				name: name.trim(),
 				description: description.trim() || undefined,
 				difficulty,
 				playerCount,
-				...(predefinedChallenges.length > 0 && { predefinedChallenges })
+				...(plainChallenges && { predefinedChallenges: plainChallenges })
 			});
 		} catch (err: any) {
 			error = err.message;

--- a/src/routes/montage/[id]/+page.svelte
+++ b/src/routes/montage/[id]/+page.svelte
@@ -72,8 +72,10 @@
 
 	async function handleUpdatePredefinedChallenges(challenges: (PredefinedChallenge | Omit<PredefinedChallenge, 'id'>)[]) {
 		if (!montage) return;
+		// Convert $state proxy to plain objects for IndexedDB
+		const plainChallenges = challenges.map(c => ({ ...c }));
 		await montageStore.updateMontage(montage.id, {
-			predefinedChallenges: challenges
+			predefinedChallenges: plainChallenges
 		});
 	}
 </script>


### PR DESCRIPTION
## Problem
Svelte 5's `$state` creates Proxy objects that cannot be cloned by IndexedDB's structured clone algorithm, causing `DataCloneError: Proxy object could not be cloned`.

## Solution
- Convert `$state` proxy objects to plain objects using spread/map before passing to database
- Updated `MontageSetup.svelte` and `[id]/+page.svelte` to convert predefinedChallenges

## Documentation
Added guidance to `AGENT_WORKFLOW.md` for:
- **unit-test-expert**: Test for DataCloneError scenarios
- **senior-web-architect**: Always convert $state proxies before DB calls
- **qa-expert**: Checklist item to verify no DataCloneError in console
- **Troubleshooting**: New section explaining the problem and solution

🤖 Generated with [Claude Code](https://claude.com/claude-code)