### PR TITLE
fix(montage): convert challenges to plain objects in PredefinedChallengeInput

### DIFF
--- a/src/lib/components/montage/PredefinedChallengeInput.svelte
+++ b/src/lib/components/montage/PredefinedChallengeInput.svelte
@@ -43,7 +43,9 @@
 			})
 		};
 
-		onUpdate([...challenges, newChallenge]);
+		// Convert existing challenges to plain objects to avoid $state proxy issues with IndexedDB
+		const plainChallenges = challenges.map(c => ({ ...c }));
+		onUpdate([...plainChallenges, newChallenge]);
 
 		// Reset form
 		isAdding = false;
@@ -53,7 +55,8 @@
 	}
 
 	function handleRemove(index: number) {
-		const updated = challenges.filter((_, i) => i !== index);
+		// Convert to plain objects to avoid $state proxy issues with IndexedDB
+		const updated = challenges.filter((_, i) => i !== index).map(c => ({ ...c }));
 		onUpdate(updated);
 	}
 </script>


### PR DESCRIPTION
## Problem
When adding a second predefined challenge in the preparing state, `DataCloneError: Proxy object could not be cloned` occurs.

## Cause
The `challenges` prop is a `$derived` proxy from the parent. When spreading `[...challenges, newChallenge]`, existing items remain as proxies.

## Solution
Convert all challenges to plain objects with `.map(c => ({ ...c }))` in both `handleSave` and `handleRemove` functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)