### PR TITLE
fix(montage): use deep clone for IndexedDB data

### DIFF
--- a/src/lib/components/montage/MontageSetup.svelte
+++ b/src/lib/components/montage/MontageSetup.svelte
@@ -40,9 +40,9 @@
 		isSubmitting = true;
 
 		try {
-			// Convert $state proxy to plain objects for IndexedDB
+			// Deep clone to convert all $state proxies (including nested arrays) to plain objects for IndexedDB
 			const plainChallenges = predefinedChallenges.length > 0
-				? predefinedChallenges.map(c => ({ ...c }))
+				? JSON.parse(JSON.stringify(predefinedChallenges))
 				: undefined;
 
 			await onSubmit({

--- a/src/lib/components/montage/PredefinedChallengeInput.svelte
+++ b/src/lib/components/montage/PredefinedChallengeInput.svelte
@@ -43,8 +43,8 @@
 			})
 		};
 
-		// Convert existing challenges to plain objects to avoid $state proxy issues with IndexedDB
-		const plainChallenges = challenges.map(c => ({ ...c }));
+		// Deep clone existing challenges to convert all $state proxies (including nested arrays) to plain objects
+		const plainChallenges = JSON.parse(JSON.stringify(challenges));
 		onUpdate([...plainChallenges, newChallenge]);
 
 		// Reset form
@@ -55,8 +55,9 @@
 	}
 
 	function handleRemove(index: number) {
-		// Convert to plain objects to avoid $state proxy issues with IndexedDB
-		const updated = challenges.filter((_, i) => i !== index).map(c => ({ ...c }));
+		// Deep clone to convert all $state proxies (including nested arrays) to plain objects
+		const filtered = challenges.filter((_, i) => i !== index);
+		const updated = JSON.parse(JSON.stringify(filtered));
 		onUpdate(updated);
 	}
 </script>

--- a/src/routes/montage/[id]/+page.svelte
+++ b/src/routes/montage/[id]/+page.svelte
@@ -72,8 +72,8 @@
 
 	async function handleUpdatePredefinedChallenges(challenges: (PredefinedChallenge | Omit<PredefinedChallenge, 'id'>)[]) {
 		if (!montage) return;
-		// Convert $state proxy to plain objects for IndexedDB
-		const plainChallenges = challenges.map(c => ({ ...c }));
+		// Deep clone to convert all $state proxies (including nested arrays) to plain objects for IndexedDB
+		const plainChallenges = JSON.parse(JSON.stringify(challenges));
 		await montageStore.updateMontage(montage.id, {
 			predefinedChallenges: plainChallenges
 		});


### PR DESCRIPTION
## Problem
Adding a second predefined challenge still caused `DataCloneError` because shallow spread `({ ...obj })` doesn't clone nested arrays like `suggestedSkills`.

## Solution
Changed all conversions to use `JSON.parse(JSON.stringify())` for deep cloning:
- `MontageSetup.svelte`
- `PredefinedChallengeInput.svelte`
- `[id]/+page.svelte`

## Documentation
Updated `AGENT_WORKFLOW.md` to emphasize deep cloning over shallow spread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)