### PR TITLE
fix(settings): resolve infinite effect loop causing API rate limiting (#302)

### DIFF
--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -52,26 +52,24 @@
 	let lastExportedAt = $state<Date | null>(null);
 	let daysSinceExport = $state<number | null>(null);
 
-	// Load API key and models from storage
-	$effect(() => {
-		if (typeof window !== 'undefined') {
-			const stored = localStorage.getItem('dm-assist-api-key');
-			if (stored) {
-				apiKey = stored;
-				loadModels(stored);
-			}
-			selectedModel = getSelectedModel();
-
-			// Load last export info
-			lastExportedAt = getLastExportedAt();
-			daysSinceExport = getDaysSinceExport(lastExportedAt);
-		}
-	});
-
-	// Handle action parameter (e.g., ?action=export)
+	// Handle initialization and action parameters
 	onMount(() => {
 		debugStore.load();
 
+		// Load API key and models from storage
+		const stored = localStorage.getItem('dm-assist-api-key');
+		if (stored) {
+			apiKey = stored;
+			loadModels(stored);
+		}
+		selectedModel = getSelectedModel();
+
+		// Load last export info
+		const exportDate = getLastExportedAt();
+		lastExportedAt = exportDate;
+		daysSinceExport = getDaysSinceExport(exportDate);
+
+		// Handle action parameter (e.g., ?action=export)
 		const actionParam = $page.url.searchParams.get('action');
 		if (actionParam === 'export') {
 			// Trigger export
@@ -79,10 +77,10 @@
 		}
 	});
 
-	// Load current system profile from campaign
+	// Sync current system profile from campaign (only update if different)
 	$effect(() => {
 		const systemProfile = campaignStore.getCurrentSystemProfile();
-		if (systemProfile) {
+		if (systemProfile && systemProfile.id !== currentSystemId) {
 			currentSystemId = systemProfile.id;
 		}
 	});


### PR DESCRIPTION
## Summary

- Move initialization logic from `$effect` to `onMount` to prevent Svelte 5 dependency tracking from creating an update loop
- Add guard to system profile sync effect to prevent unnecessary state updates

## Problem

The Settings page had an `$effect` that was reading `$state` variables it had just written (`lastExportedAt`), causing Svelte 5's automatic dependency tracking to re-run the effect repeatedly. This resulted in:
- `effect_update_depth_exceeded` errors
- 500+ API calls to `api.anthropic.com/v1/models` (hitting rate limits)
- Settings page becoming unusable

## Solution

1. **Moved initialization to `onMount`**: The original `$effect` was being used for one-time initialization, which is what `onMount` is for. This prevents Svelte from tracking dependencies on state that's being written.

2. **Added guard to system profile effect**: Added `systemProfile.id !== currentSystemId` check to prevent unnecessary state updates when the value hasn't changed.

Fixes #302

## Test plan

- [x] Visit Settings page - no console errors
- [x] No repeated API calls to Anthropic
- [x] Settings functionality works normally

🤖 Generated with [Claude Code](https://claude.ai/code)