### PR TITLE
fix: add inline 'Add Field' button to entity edit/new pages (#311)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2] - TBD
+
+### Added
+
+**Inline Field Creation on Entity Forms (Issue #311)**
+- New "Add Field" button on entity edit and new pages for quick custom field creation
+- AddFieldInline component with modal interface for defining fields without navigating to Settings
+- Configure field label, type, options (for select types), section, and required status
+- Automatically generates field key from label (sanitized, lowercase with underscores)
+- Duplicate key detection prevents field conflicts
+- Works for both built-in entity types (via setEntityTypeOverride) and custom entity types (via updateCustomEntityType)
+- New fields appear at the end of forms with high order number (1000)
+- Streamlines workflow: add fields while working on entities without context switching
+- Modal includes helpful preview of generated field key
+
 ## [1.1.1] - 2026-01-23
 
 ### Added

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -419,6 +419,23 @@ Extend built-in types with additional fields:
 
 All customizations are per-campaign, so different campaigns can have different configurations.
 
+**Quick Field Creation: Inline "Add Field" Button**
+
+When creating or editing entities, you can add custom fields directly from the form without navigating to Settings:
+
+1. On any entity edit or new page, look for the "Add Field" button at the top of the form
+2. Click the button to open the field creation modal
+3. Configure your new field:
+   - **Field Label**: The display name (e.g., "Motivation")
+   - **Field Type**: Choose from text, textarea, richtext, number, boolean, select, multi-select, tags, date, url, or image
+   - **Options**: For select/multi-select types, enter one option per line
+   - **Section**: Choose Default, Hidden (DM Only), or Preparation
+   - **Required**: Toggle whether this field must be filled
+4. The field key is automatically generated from the label (lowercase with underscores)
+5. Click "Add Field" to save
+
+The new field immediately appears at the end of the form and is added to the entity type definition for all entities of that type. This streamlines your workflow by allowing you to extend entity types as you work, without breaking your creative flow to navigate to Settings.
+
 ### Custom Type Examples
 
 **Example 1: Spell Entity Type**

--- a/src/lib/components/entity/AddFieldInline.svelte
+++ b/src/lib/components/entity/AddFieldInline.svelte
@@ -1,0 +1,289 @@
+<script lang="ts">
+	import { Plus, X } from 'lucide-svelte';
+	import { campaignStore, notificationStore } from '$lib/stores';
+	import type { FieldDefinition, FieldType, EntityType } from '$lib/types';
+
+	interface Props {
+		entityType: string;
+	}
+
+	let { entityType }: Props = $props();
+
+	let showModal = $state(false);
+	let isSaving = $state(false);
+
+	// Form state
+	let fieldLabel = $state('');
+	let fieldType = $state<FieldType>('text');
+	let fieldOptions = $state('');
+	let fieldSection = $state<'' | 'hidden' | 'prep'>('');
+	let fieldRequired = $state(false);
+
+	// Field type options (simplified from FieldDefinitionEditor)
+	const FIELD_TYPES: { value: FieldType; label: string }[] = [
+		{ value: 'text', label: 'Short Text' },
+		{ value: 'textarea', label: 'Long Text' },
+		{ value: 'richtext', label: 'Rich Text (Markdown)' },
+		{ value: 'number', label: 'Number' },
+		{ value: 'boolean', label: 'Checkbox' },
+		{ value: 'select', label: 'Dropdown' },
+		{ value: 'multi-select', label: 'Multi-Select' },
+		{ value: 'tags', label: 'Tags' },
+		{ value: 'date', label: 'Date' },
+		{ value: 'url', label: 'URL' },
+		{ value: 'image', label: 'Image' }
+	];
+
+	const SECTION_OPTIONS = [
+		{ value: '', label: 'Default' },
+		{ value: 'hidden', label: 'Hidden (DM Only)' },
+		{ value: 'prep', label: 'Preparation' }
+	];
+
+	// Check if this is a built-in entity type
+	const isBuiltInType = $derived(() => {
+		const customTypes = campaignStore.customEntityTypes;
+		return !customTypes.some((t) => t.type === entityType);
+	});
+
+	function generateKey(label: string): string {
+		return label
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/g, '_')
+			.replace(/^_|_$/g, '') || `field_${Date.now()}`;
+	}
+
+	function resetForm() {
+		fieldLabel = '';
+		fieldType = 'text';
+		fieldOptions = '';
+		fieldSection = '';
+		fieldRequired = false;
+	}
+
+	function openModal() {
+		resetForm();
+		showModal = true;
+	}
+
+	function closeModal() {
+		showModal = false;
+		resetForm();
+	}
+
+	async function handleSave() {
+		if (!fieldLabel.trim()) {
+			notificationStore.error('Field label is required');
+			return;
+		}
+
+		isSaving = true;
+
+		try {
+			const fieldKey = generateKey(fieldLabel);
+			const newField: FieldDefinition = {
+				key: fieldKey,
+				label: fieldLabel.trim(),
+				type: fieldType,
+				required: fieldRequired,
+				order: 1000 // High order number so it appears at the end
+			};
+
+			// Add section if not default
+			if (fieldSection) {
+				newField.section = fieldSection;
+			}
+
+			// Add options for select/multi-select
+			if ((fieldType === 'select' || fieldType === 'multi-select') && fieldOptions.trim()) {
+				newField.options = fieldOptions
+					.split('\n')
+					.map((o) => o.trim())
+					.filter((o) => o);
+			}
+
+			if (isBuiltInType()) {
+				// For built-in types, use setEntityTypeOverride
+				const existingOverride = campaignStore.getEntityTypeOverride(entityType);
+				const existingFields = existingOverride?.additionalFields ?? [];
+
+				// Check for duplicate key
+				if (existingFields.some((f) => f.key === fieldKey)) {
+					notificationStore.error(`A field with key "${fieldKey}" already exists`);
+					isSaving = false;
+					return;
+				}
+
+				await campaignStore.setEntityTypeOverride({
+					type: entityType as EntityType,
+					...existingOverride,
+					additionalFields: [...existingFields, newField]
+				});
+			} else {
+				// For custom types, use updateCustomEntityType
+				const customType = campaignStore.getCustomEntityType(entityType);
+				if (!customType) {
+					throw new Error(`Custom entity type "${entityType}" not found`);
+				}
+
+				const existingFields = customType.fieldDefinitions ?? [];
+
+				// Check for duplicate key
+				if (existingFields.some((f) => f.key === fieldKey)) {
+					notificationStore.error(`A field with key "${fieldKey}" already exists`);
+					isSaving = false;
+					return;
+				}
+
+				await campaignStore.updateCustomEntityType(entityType, {
+					fieldDefinitions: [...existingFields, newField]
+				});
+			}
+
+			notificationStore.success(`Field "${fieldLabel}" added successfully`);
+			closeModal();
+		} catch (error) {
+			console.error('Failed to add field:', error);
+			notificationStore.error('Failed to add field. Please try again.');
+		} finally {
+			isSaving = false;
+		}
+	}
+</script>
+
+<!-- Add Field Button -->
+<button
+	type="button"
+	class="btn btn-secondary"
+	onclick={openModal}
+	aria-label="Add custom field to this entity type"
+>
+	<Plus class="w-4 h-4" />
+	Add Field
+</button>
+
+<!-- Modal -->
+{#if showModal}
+	<!-- Backdrop -->
+	<div
+		class="fixed inset-0 bg-black/50 z-40"
+		onclick={closeModal}
+		onkeydown={(e) => e.key === 'Escape' && closeModal()}
+		role="button"
+		tabindex="-1"
+		aria-label="Close modal"
+	></div>
+
+	<!-- Modal content -->
+	<div class="fixed inset-0 z-50 flex items-center justify-center p-4">
+		<div
+			class="bg-white dark:bg-slate-800 rounded-lg shadow-xl max-w-md w-full max-h-[90vh] overflow-y-auto"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="add-field-modal-title"
+		>
+			<!-- Header -->
+			<div class="flex items-center justify-between p-4 border-b border-slate-200 dark:border-slate-700">
+				<h2 id="add-field-modal-title" class="text-lg font-semibold text-slate-900 dark:text-white">
+					Add Custom Field
+				</h2>
+				<button
+					type="button"
+					onclick={closeModal}
+					class="p-1 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 rounded"
+					aria-label="Close modal"
+				>
+					<X class="w-5 h-5" />
+				</button>
+			</div>
+
+			<!-- Body -->
+			<div class="p-4 space-y-4">
+				<p class="text-sm text-slate-600 dark:text-slate-400">
+					This field will be added to all {isBuiltInType() ? 'entities of this type' : 'entities of this custom type'}.
+				</p>
+
+				<!-- Field Label -->
+				<div>
+					<label for="field-label" class="label">Field Label *</label>
+					<input
+						id="field-label"
+						type="text"
+						class="input"
+						bind:value={fieldLabel}
+						placeholder="e.g., Motivation"
+					/>
+					{#if fieldLabel}
+						<p class="text-xs text-slate-500 mt-1">
+							Key: <code class="bg-slate-100 dark:bg-slate-700 px-1 rounded">{generateKey(fieldLabel)}</code>
+						</p>
+					{/if}
+				</div>
+
+				<!-- Field Type -->
+				<div>
+					<label for="field-type" class="label">Field Type</label>
+					<select id="field-type" class="input" bind:value={fieldType}>
+						{#each FIELD_TYPES as type}
+							<option value={type.value}>{type.label}</option>
+						{/each}
+					</select>
+				</div>
+
+				<!-- Options (for select/multi-select) -->
+				{#if fieldType === 'select' || fieldType === 'multi-select'}
+					<div>
+						<label for="field-options" class="label">Options (one per line)</label>
+						<textarea
+							id="field-options"
+							class="input min-h-[80px]"
+							bind:value={fieldOptions}
+							placeholder="Option 1&#10;Option 2&#10;Option 3"
+						></textarea>
+					</div>
+				{/if}
+
+				<!-- Section -->
+				<div>
+					<label for="field-section" class="label">Section</label>
+					<select id="field-section" class="input" bind:value={fieldSection}>
+						{#each SECTION_OPTIONS as section}
+							<option value={section.value}>{section.label}</option>
+						{/each}
+					</select>
+				</div>
+
+				<!-- Required -->
+				<div>
+					<label class="flex items-center gap-2 cursor-pointer">
+						<input
+							type="checkbox"
+							class="w-4 h-4 rounded border-slate-300 dark:border-slate-600"
+							bind:checked={fieldRequired}
+						/>
+						<span class="text-sm text-slate-700 dark:text-slate-300">Required field</span>
+					</label>
+				</div>
+			</div>
+
+			<!-- Footer -->
+			<div class="flex items-center justify-end gap-2 p-4 border-t border-slate-200 dark:border-slate-700">
+				<button type="button" class="btn btn-secondary" onclick={closeModal} disabled={isSaving}>
+					Cancel
+				</button>
+				<button
+					type="button"
+					class="btn btn-primary"
+					onclick={handleSave}
+					disabled={isSaving || !fieldLabel.trim()}
+				>
+					{#if isSaving}
+						Adding...
+					{:else}
+						Add Field
+					{/if}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/entity/AddFieldInline.test.ts
+++ b/src/lib/components/entity/AddFieldInline.test.ts
@@ -1,0 +1,1562 @@
+/**
+ * Tests for AddFieldInline Component
+ *
+ * This component provides an inline "Add Field" button that opens a modal
+ * for creating custom fields on entity types (both built-in and custom).
+ *
+ * Key Features:
+ * - Displays "Add Field" button
+ * - Opens modal with field creation form
+ * - Auto-generates field key from label
+ * - Detects built-in vs custom entity types
+ * - Saves to appropriate store method based on type
+ * - Validates field data before saving
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import AddFieldInline from './AddFieldInline.svelte';
+import type { EntityTypeDefinition, EntityTypeOverride } from '$lib/types';
+
+// Mock the stores
+vi.mock('$lib/stores', () => ({
+	campaignStore: {
+		customEntityTypes: [],
+		getEntityTypeOverride: vi.fn(),
+		setEntityTypeOverride: vi.fn(),
+		getCustomEntityType: vi.fn(),
+		updateCustomEntityType: vi.fn()
+	},
+	notificationStore: {
+		success: vi.fn(),
+		error: vi.fn()
+	}
+}));
+
+describe('AddFieldInline Component - Basic Rendering', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should render without crashing', () => {
+		const { container } = render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+		expect(container).toBeInTheDocument();
+	});
+
+	it('should render "Add Field" button', () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		expect(button).toBeInTheDocument();
+	});
+
+	it('should show Plus icon on button', () => {
+		const { container } = render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		// Lucide icons render as SVG elements
+		const svg = button.querySelector('svg');
+		expect(svg).toBeInTheDocument();
+	});
+
+	it('should not show modal initially', () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const modal = screen.queryByRole('dialog');
+		expect(modal).not.toBeInTheDocument();
+	});
+});
+
+describe('AddFieldInline Component - Modal Open/Close', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should open modal when button clicked', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		const modal = screen.getByRole('dialog');
+		expect(modal).toBeInTheDocument();
+	});
+
+	it('should show modal title', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		expect(screen.getByText(/add custom field/i)).toBeInTheDocument();
+	});
+
+	it('should close modal when X button clicked', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		// Open modal
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		// Close modal - use getAllByRole since there are multiple elements with this label
+		const closeButtons = screen.getAllByRole('button', { name: /close modal/i });
+		// The actual button is the one with an X icon (second match)
+		const closeButton = closeButtons.find(btn => btn.tagName === 'BUTTON');
+		if (closeButton) {
+			await fireEvent.click(closeButton);
+		}
+
+		await waitFor(() => {
+			const modal = screen.queryByRole('dialog');
+			expect(modal).not.toBeInTheDocument();
+		});
+	});
+
+	it('should close modal when Cancel button clicked', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		// Open modal
+		const openButton = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(openButton);
+
+		// Click cancel
+		const cancelButton = screen.getByRole('button', { name: /cancel/i });
+		await fireEvent.click(cancelButton);
+
+		await waitFor(() => {
+			const modal = screen.queryByRole('dialog');
+			expect(modal).not.toBeInTheDocument();
+		});
+	});
+
+	it('should close modal when backdrop clicked', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		// Open modal
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		// Click backdrop - it's the first element with close modal label
+		const backdrops = screen.getAllByRole('button', { name: /close modal/i });
+		const backdrop = backdrops[0]; // First one is the backdrop div
+		await fireEvent.click(backdrop);
+
+		// Modal should close
+		await waitFor(() => {
+			const modal = screen.queryByRole('dialog');
+			expect(modal).not.toBeInTheDocument();
+		});
+	});
+
+	it('should reset form when modal closes', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		// Open modal and fill form
+		const openButton = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(openButton);
+
+		const labelInput = screen.getByLabelText(/field label/i);
+		await fireEvent.input(labelInput, { target: { value: 'Test Field' } });
+
+		// Close modal
+		const cancelButton = screen.getByRole('button', { name: /cancel/i });
+		await fireEvent.click(cancelButton);
+
+		// Reopen modal
+		await fireEvent.click(openButton);
+
+		// Form should be reset
+		const resetInput = screen.getByLabelText(/field label/i) as HTMLInputElement;
+		expect(resetInput.value).toBe('');
+	});
+});
+
+describe('AddFieldInline Component - Form Fields', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should render field label input', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		const labelInput = screen.getByLabelText(/field label/i);
+		expect(labelInput).toBeInTheDocument();
+	});
+
+	it('should render field type select', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		const typeSelect = screen.getByLabelText(/field type/i);
+		expect(typeSelect).toBeInTheDocument();
+	});
+
+	it('should render section select', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		const sectionSelect = screen.getByLabelText(/section/i);
+		expect(sectionSelect).toBeInTheDocument();
+	});
+
+	it('should render required checkbox', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		const requiredCheckbox = screen.getByLabelText(/required field/i);
+		expect(requiredCheckbox).toBeInTheDocument();
+	});
+
+	it('should have all field type options', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		const typeSelect = screen.getByLabelText(/field type/i);
+		const options = Array.from(typeSelect.querySelectorAll('option'));
+		const optionTexts = options.map(opt => opt.textContent);
+
+		expect(optionTexts).toContain('Short Text');
+		expect(optionTexts).toContain('Long Text');
+		expect(optionTexts).toContain('Rich Text (Markdown)');
+		expect(optionTexts).toContain('Number');
+		expect(optionTexts).toContain('Checkbox');
+		expect(optionTexts).toContain('Dropdown');
+		expect(optionTexts).toContain('Multi-Select');
+		expect(optionTexts).toContain('Tags');
+		expect(optionTexts).toContain('Date');
+		expect(optionTexts).toContain('URL');
+		expect(optionTexts).toContain('Image');
+	});
+
+	it('should default to "text" field type', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		const typeSelect = screen.getByLabelText(/field type/i) as HTMLSelectElement;
+		expect(typeSelect.value).toBe('text');
+	});
+
+	it('should have section options', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		const sectionSelect = screen.getByLabelText(/section/i);
+		const options = Array.from(sectionSelect.querySelectorAll('option'));
+		const optionTexts = options.map(opt => opt.textContent);
+
+		expect(optionTexts).toContain('Default');
+		expect(optionTexts).toContain('Hidden (DM Only)');
+		expect(optionTexts).toContain('Preparation');
+	});
+
+	it('should default to empty section', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		const sectionSelect = screen.getByLabelText(/section/i) as HTMLSelectElement;
+		expect(sectionSelect.value).toBe('');
+	});
+
+	it('should default to not required', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		const requiredCheckbox = screen.getByLabelText(/required field/i) as HTMLInputElement;
+		expect(requiredCheckbox.checked).toBe(false);
+	});
+});
+
+describe('AddFieldInline Component - Field Key Generation', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should show generated key preview when label entered', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		const labelInput = screen.getByLabelText(/field label/i);
+		await fireEvent.input(labelInput, { target: { value: 'My Custom Field' } });
+
+		await waitFor(() => {
+			expect(screen.getByText(/key:/i)).toBeInTheDocument();
+			expect(screen.getByText('my_custom_field')).toBeInTheDocument();
+		});
+	});
+
+	it('should generate key with underscores', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		const labelInput = screen.getByLabelText(/field label/i);
+		await fireEvent.input(labelInput, { target: { value: 'Field With Spaces' } });
+
+		await waitFor(() => {
+			expect(screen.getByText('field_with_spaces')).toBeInTheDocument();
+		});
+	});
+
+	it('should convert to lowercase', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		const labelInput = screen.getByLabelText(/field label/i);
+		await fireEvent.input(labelInput, { target: { value: 'UPPERCASE FIELD' } });
+
+		await waitFor(() => {
+			expect(screen.getByText('uppercase_field')).toBeInTheDocument();
+		});
+	});
+
+	it('should strip special characters', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		const labelInput = screen.getByLabelText(/field label/i);
+		await fireEvent.input(labelInput, { target: { value: 'Field@#$%Name!' } });
+
+		await waitFor(() => {
+			expect(screen.getByText('field_name')).toBeInTheDocument();
+		});
+	});
+
+	it('should handle multiple consecutive special chars', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		const labelInput = screen.getByLabelText(/field label/i);
+		await fireEvent.input(labelInput, { target: { value: 'Field   ---   Name' } });
+
+		await waitFor(() => {
+			expect(screen.getByText('field_name')).toBeInTheDocument();
+		});
+	});
+
+	it('should strip leading/trailing underscores', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		const labelInput = screen.getByLabelText(/field label/i);
+		await fireEvent.input(labelInput, { target: { value: '___Field___' } });
+
+		await waitFor(() => {
+			expect(screen.getByText('field')).toBeInTheDocument();
+		});
+	});
+});
+
+describe('AddFieldInline Component - Options Field (Select Types)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should show options field for select type', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		// Change type to select
+		const typeSelect = screen.getByLabelText(/field type/i);
+		await fireEvent.change(typeSelect, { target: { value: 'select' } });
+
+		await waitFor(() => {
+			const optionsField = screen.queryByLabelText(/options.*one per line/i);
+			expect(optionsField).toBeInTheDocument();
+		}, { timeout: 2000 });
+	});
+
+	it('should show options field for multi-select type', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		// Change type to multi-select
+		const typeSelect = screen.getByLabelText(/field type/i);
+		await fireEvent.change(typeSelect, { target: { value: 'multi-select' } });
+
+		await waitFor(() => {
+			const optionsField = screen.queryByLabelText(/options.*one per line/i);
+			expect(optionsField).toBeInTheDocument();
+		}, { timeout: 2000 });
+	});
+
+	it('should hide options field for text type', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		// Type is already 'text' by default
+		const optionsField = screen.queryByLabelText(/options.*one per line/i);
+		expect(optionsField).not.toBeInTheDocument();
+	});
+
+	it('should hide options field when switching from select to text', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		// Change to select
+		const typeSelect = screen.getByLabelText(/field type/i);
+		await fireEvent.change(typeSelect, { target: { value: 'select' } });
+
+		// Options should show
+		await waitFor(() => {
+			expect(screen.queryByLabelText(/options.*one per line/i)).toBeInTheDocument();
+		}, { timeout: 2000 });
+
+		// Change back to text
+		await fireEvent.change(typeSelect, { target: { value: 'text' } });
+
+		// Options should hide
+		await waitFor(() => {
+			const optionsField = screen.queryByLabelText(/options.*one per line/i);
+			expect(optionsField).not.toBeInTheDocument();
+		}, { timeout: 2000 });
+	});
+
+	it('should be a textarea element', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		const typeSelect = screen.getByLabelText(/field type/i);
+		await fireEvent.change(typeSelect, { target: { value: 'select' } });
+
+		await waitFor(() => {
+			const optionsField = screen.queryByLabelText(/options.*one per line/i);
+			expect(optionsField?.tagName).toBe('TEXTAREA');
+		}, { timeout: 2000 });
+	});
+});
+
+describe('AddFieldInline Component - Form Validation', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should disable Add Field button when label is empty', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const openButton = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(openButton);
+
+		const addButton = screen.getByRole('button', { name: /^add field$/i });
+		expect(addButton).toBeDisabled();
+	});
+
+	it('should enable Add Field button when label is filled', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const openButton = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(openButton);
+
+		const labelInput = screen.getByLabelText(/field label/i);
+		await fireEvent.input(labelInput, { target: { value: 'Test Field' } });
+
+		await waitFor(() => {
+			const addButton = screen.getByRole('button', { name: /^add field$/i });
+			expect(addButton).not.toBeDisabled();
+		});
+	});
+
+	it('should show error when trying to save without label', async () => {
+		const { notificationStore } = await import('$lib/stores');
+
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const openButton = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(openButton);
+
+		// Try to manually trigger save (button should be disabled, but test the function)
+		// This tests the validation logic directly
+		const addButton = screen.getByRole('button', { name: /^add field$/i });
+
+		// Button is disabled, so we can't click it
+		expect(addButton).toBeDisabled();
+	});
+
+	it('should trim whitespace from label', async () => {
+		const { campaignStore, notificationStore } = await import('$lib/stores');
+
+		// Mock for built-in type
+		vi.mocked(campaignStore.getEntityTypeOverride).mockReturnValue(undefined);
+		vi.mocked(campaignStore.setEntityTypeOverride).mockResolvedValue(undefined);
+
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const openButton = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(openButton);
+
+		const labelInput = screen.getByLabelText(/field label/i);
+		await fireEvent.input(labelInput, { target: { value: '  Test Field  ' } });
+
+		const addButton = screen.getByRole('button', { name: /^add field$/i });
+		await fireEvent.click(addButton);
+
+		await waitFor(() => {
+			expect(campaignStore.setEntityTypeOverride).toHaveBeenCalledWith(
+				expect.objectContaining({
+					additionalFields: expect.arrayContaining([
+						expect.objectContaining({
+							label: 'Test Field' // Trimmed
+						})
+					])
+				})
+			);
+		});
+	});
+});
+
+describe('AddFieldInline Component - Built-in Type Detection', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should detect built-in type when not in customEntityTypes', async () => {
+		const { campaignStore } = await import('$lib/stores');
+
+		// Mock empty custom types array (meaning 'npc' is built-in)
+		Object.defineProperty(campaignStore, 'customEntityTypes', {
+			get: () => [],
+			configurable: true
+		});
+
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		// Check the description text
+		expect(screen.getByText(/entities of this type/i)).toBeInTheDocument();
+	});
+
+	it('should detect custom type when in customEntityTypes', async () => {
+		const { campaignStore } = await import('$lib/stores');
+
+		// Mock custom types array containing our type
+		Object.defineProperty(campaignStore, 'customEntityTypes', {
+			get: () => [
+				{
+					type: 'quest',
+					label: 'Quest',
+					labelPlural: 'Quests',
+					icon: 'target',
+					color: 'custom',
+					isBuiltIn: false,
+					fieldDefinitions: []
+				}
+			],
+			configurable: true
+		});
+
+		render(AddFieldInline, {
+			props: {
+				entityType: 'quest'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		// Check the description text
+		expect(screen.getByText(/entities of this custom type/i)).toBeInTheDocument();
+	});
+});
+
+describe('AddFieldInline Component - Save Functionality for Built-in Types', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should call setEntityTypeOverride for built-in types', async () => {
+		const { campaignStore, notificationStore } = await import('$lib/stores');
+
+		// Mock for built-in type
+		Object.defineProperty(campaignStore, 'customEntityTypes', {
+			get: () => [],
+			configurable: true
+		});
+		vi.mocked(campaignStore.getEntityTypeOverride).mockReturnValue(undefined);
+		vi.mocked(campaignStore.setEntityTypeOverride).mockResolvedValue(undefined);
+
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const openButton = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(openButton);
+
+		const labelInput = screen.getByLabelText(/field label/i);
+		await fireEvent.input(labelInput, { target: { value: 'Test Field' } });
+
+		const addButton = screen.getByRole('button', { name: /^add field$/i });
+		await fireEvent.click(addButton);
+
+		await waitFor(() => {
+			expect(campaignStore.setEntityTypeOverride).toHaveBeenCalled();
+		});
+	});
+
+	it('should add field to additionalFields array', async () => {
+		const { campaignStore, notificationStore } = await import('$lib/stores');
+
+		Object.defineProperty(campaignStore, 'customEntityTypes', {
+			get: () => [],
+			configurable: true
+		});
+		vi.mocked(campaignStore.getEntityTypeOverride).mockReturnValue(undefined);
+		vi.mocked(campaignStore.setEntityTypeOverride).mockResolvedValue(undefined);
+
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const openButton = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(openButton);
+
+		const labelInput = screen.getByLabelText(/field label/i);
+		await fireEvent.input(labelInput, { target: { value: 'Custom Field' } });
+
+		const addButton = screen.getByRole('button', { name: /^add field$/i });
+		await fireEvent.click(addButton);
+
+		await waitFor(() => {
+			expect(campaignStore.setEntityTypeOverride).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: 'npc',
+					additionalFields: expect.arrayContaining([
+						expect.objectContaining({
+							key: 'custom_field',
+							label: 'Custom Field',
+							type: 'text',
+							required: false
+						})
+					])
+				})
+			);
+		});
+	});
+
+	it('should preserve existing additionalFields', async () => {
+		const { campaignStore, notificationStore } = await import('$lib/stores');
+
+		Object.defineProperty(campaignStore, 'customEntityTypes', {
+			get: () => [],
+			configurable: true
+		});
+
+		// Mock existing override with fields
+		const existingOverride = {
+			type: 'npc',
+			additionalFields: [
+				{ key: 'existing', label: 'Existing', type: 'text' as const, required: false, order: 1 }
+			]
+		};
+		vi.mocked(campaignStore.getEntityTypeOverride).mockReturnValue(existingOverride);
+		vi.mocked(campaignStore.setEntityTypeOverride).mockResolvedValue(undefined);
+
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const openButton = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(openButton);
+
+		const labelInput = screen.getByLabelText(/field label/i);
+		await fireEvent.input(labelInput, { target: { value: 'New Field' } });
+
+		const addButton = screen.getByRole('button', { name: /^add field$/i });
+		await fireEvent.click(addButton);
+
+		await waitFor(() => {
+			expect(campaignStore.setEntityTypeOverride).toHaveBeenCalledWith(
+				expect.objectContaining({
+					additionalFields: expect.arrayContaining([
+						expect.objectContaining({ key: 'existing' }),
+						expect.objectContaining({ key: 'new_field' })
+					])
+				})
+			);
+		});
+	});
+
+	it('should show success notification after save', async () => {
+		const { campaignStore, notificationStore } = await import('$lib/stores');
+
+		Object.defineProperty(campaignStore, 'customEntityTypes', {
+			get: () => [],
+			configurable: true
+		});
+		vi.mocked(campaignStore.getEntityTypeOverride).mockReturnValue(undefined);
+		vi.mocked(campaignStore.setEntityTypeOverride).mockResolvedValue(undefined);
+
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const openButton = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(openButton);
+
+		const labelInput = screen.getByLabelText(/field label/i);
+		await fireEvent.input(labelInput, { target: { value: 'Test Field' } });
+
+		const addButton = screen.getByRole('button', { name: /^add field$/i });
+		await fireEvent.click(addButton);
+
+		await waitFor(() => {
+			expect(notificationStore.success).toHaveBeenCalledWith(
+				expect.stringContaining('Test Field')
+			);
+		});
+	});
+
+	it('should close modal after successful save', async () => {
+		const { campaignStore, notificationStore } = await import('$lib/stores');
+
+		Object.defineProperty(campaignStore, 'customEntityTypes', {
+			get: () => [],
+			configurable: true
+		});
+		vi.mocked(campaignStore.getEntityTypeOverride).mockReturnValue(undefined);
+		vi.mocked(campaignStore.setEntityTypeOverride).mockResolvedValue(undefined);
+
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const openButton = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(openButton);
+
+		const labelInput = screen.getByLabelText(/field label/i);
+		await fireEvent.input(labelInput, { target: { value: 'Test Field' } });
+
+		const addButton = screen.getByRole('button', { name: /^add field$/i });
+		await fireEvent.click(addButton);
+
+		await waitFor(() => {
+			const modal = screen.queryByRole('dialog');
+			expect(modal).not.toBeInTheDocument();
+		});
+	});
+});
+
+describe('AddFieldInline Component - Save Functionality for Custom Types', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should call updateCustomEntityType for custom types', async () => {
+		const { campaignStore, notificationStore } = await import('$lib/stores');
+
+		// Mock for custom type
+		const customType: EntityTypeDefinition = {
+			type: 'quest',
+			label: 'Quest',
+			labelPlural: 'Quests',
+			icon: 'target',
+			color: 'custom',
+			isBuiltIn: false,
+			fieldDefinitions: []
+		};
+
+		Object.defineProperty(campaignStore, 'customEntityTypes', {
+			get: () => [customType],
+			configurable: true
+		});
+		vi.mocked(campaignStore.getCustomEntityType).mockReturnValue(customType);
+		vi.mocked(campaignStore.updateCustomEntityType).mockResolvedValue(undefined);
+
+		render(AddFieldInline, {
+			props: {
+				entityType: 'quest'
+			}
+		});
+
+		const openButton = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(openButton);
+
+		const labelInput = screen.getByLabelText(/field label/i);
+		await fireEvent.input(labelInput, { target: { value: 'Quest Goal' } });
+
+		const addButton = screen.getByRole('button', { name: /^add field$/i });
+		await fireEvent.click(addButton);
+
+		await waitFor(() => {
+			expect(campaignStore.updateCustomEntityType).toHaveBeenCalledWith(
+				'quest',
+				expect.objectContaining({
+					fieldDefinitions: expect.arrayContaining([
+						expect.objectContaining({
+							key: 'quest_goal',
+							label: 'Quest Goal'
+						})
+					])
+				})
+			);
+		});
+	});
+
+	it('should preserve existing fieldDefinitions', async () => {
+		const { campaignStore, notificationStore } = await import('$lib/stores');
+
+		const customType: EntityTypeDefinition = {
+			type: 'quest',
+			label: 'Quest',
+			labelPlural: 'Quests',
+			icon: 'target',
+			color: 'custom',
+			isBuiltIn: false,
+			fieldDefinitions: [
+				{ key: 'existing', label: 'Existing', type: 'text', required: false, order: 1 }
+			]
+		};
+
+		Object.defineProperty(campaignStore, 'customEntityTypes', {
+			get: () => [customType],
+			configurable: true
+		});
+		vi.mocked(campaignStore.getCustomEntityType).mockReturnValue(customType);
+		vi.mocked(campaignStore.updateCustomEntityType).mockResolvedValue(undefined);
+
+		render(AddFieldInline, {
+			props: {
+				entityType: 'quest'
+			}
+		});
+
+		const openButton = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(openButton);
+
+		const labelInput = screen.getByLabelText(/field label/i);
+		await fireEvent.input(labelInput, { target: { value: 'New Field' } });
+
+		const addButton = screen.getByRole('button', { name: /^add field$/i });
+		await fireEvent.click(addButton);
+
+		await waitFor(() => {
+			expect(campaignStore.updateCustomEntityType).toHaveBeenCalledWith(
+				'quest',
+				expect.objectContaining({
+					fieldDefinitions: expect.arrayContaining([
+						expect.objectContaining({ key: 'existing' }),
+						expect.objectContaining({ key: 'new_field' })
+					])
+				})
+			);
+		});
+	});
+});
+
+describe('AddFieldInline Component - Field Properties', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should save field with selected type', async () => {
+		const { campaignStore, notificationStore } = await import('$lib/stores');
+
+		Object.defineProperty(campaignStore, 'customEntityTypes', {
+			get: () => [],
+			configurable: true
+		});
+		vi.mocked(campaignStore.getEntityTypeOverride).mockReturnValue(undefined);
+		vi.mocked(campaignStore.setEntityTypeOverride).mockResolvedValue(undefined);
+
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const openButton = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(openButton);
+
+		const labelInput = screen.getByLabelText(/field label/i);
+		await fireEvent.input(labelInput, { target: { value: 'Number Field' } });
+
+		const typeSelect = screen.getByLabelText(/field type/i);
+		await fireEvent.change(typeSelect, { target: { value: 'number' } });
+
+		// Wait for any reactive updates to complete
+		await new Promise(resolve => setTimeout(resolve, 50));
+
+		const addButton = screen.getByRole('button', { name: /^add field$/i });
+		await fireEvent.click(addButton);
+
+		await waitFor(() => {
+			expect(campaignStore.setEntityTypeOverride).toHaveBeenCalledWith(
+				expect.objectContaining({
+					additionalFields: expect.arrayContaining([
+						expect.objectContaining({
+							type: 'number'
+						})
+					])
+				})
+			);
+		}, { timeout: 2000 });
+	});
+
+	it('should save field with selected section', async () => {
+		const { campaignStore, notificationStore } = await import('$lib/stores');
+
+		Object.defineProperty(campaignStore, 'customEntityTypes', {
+			get: () => [],
+			configurable: true
+		});
+		vi.mocked(campaignStore.getEntityTypeOverride).mockReturnValue(undefined);
+		vi.mocked(campaignStore.setEntityTypeOverride).mockResolvedValue(undefined);
+
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const openButton = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(openButton);
+
+		const labelInput = screen.getByLabelText(/field label/i);
+		await fireEvent.input(labelInput, { target: { value: 'Hidden Field' } });
+
+		const sectionSelect = screen.getByLabelText(/section/i);
+		await fireEvent.change(sectionSelect, { target: { value: 'hidden' } });
+
+		// Wait for any reactive updates to complete
+		await new Promise(resolve => setTimeout(resolve, 50));
+
+		const addButton = screen.getByRole('button', { name: /^add field$/i });
+		await fireEvent.click(addButton);
+
+		await waitFor(() => {
+			expect(campaignStore.setEntityTypeOverride).toHaveBeenCalledWith(
+				expect.objectContaining({
+					additionalFields: expect.arrayContaining([
+						expect.objectContaining({
+							section: 'hidden'
+						})
+					])
+				})
+			);
+		}, { timeout: 2000 });
+	});
+
+	it('should save field as required when checked', async () => {
+		const { campaignStore, notificationStore } = await import('$lib/stores');
+
+		Object.defineProperty(campaignStore, 'customEntityTypes', {
+			get: () => [],
+			configurable: true
+		});
+		vi.mocked(campaignStore.getEntityTypeOverride).mockReturnValue(undefined);
+		vi.mocked(campaignStore.setEntityTypeOverride).mockResolvedValue(undefined);
+
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const openButton = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(openButton);
+
+		const labelInput = screen.getByLabelText(/field label/i);
+		await fireEvent.input(labelInput, { target: { value: 'Required Field' } });
+
+		const requiredCheckbox = screen.getByLabelText(/required field/i);
+		await fireEvent.click(requiredCheckbox);
+
+		const addButton = screen.getByRole('button', { name: /^add field$/i });
+		await fireEvent.click(addButton);
+
+		await waitFor(() => {
+			expect(campaignStore.setEntityTypeOverride).toHaveBeenCalledWith(
+				expect.objectContaining({
+					additionalFields: expect.arrayContaining([
+						expect.objectContaining({
+							required: true
+						})
+					])
+				})
+			);
+		});
+	});
+
+	it('should save options for select field', async () => {
+		const { campaignStore, notificationStore } = await import('$lib/stores');
+
+		Object.defineProperty(campaignStore, 'customEntityTypes', {
+			get: () => [],
+			configurable: true
+		});
+		vi.mocked(campaignStore.getEntityTypeOverride).mockReturnValue(undefined);
+		vi.mocked(campaignStore.setEntityTypeOverride).mockResolvedValue(undefined);
+
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const openButton = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(openButton);
+
+		const labelInput = screen.getByLabelText(/field label/i);
+		await fireEvent.input(labelInput, { target: { value: 'Status' } });
+
+		const typeSelect = screen.getByLabelText(/field type/i);
+		await fireEvent.change(typeSelect, { target: { value: 'select' } });
+
+		await waitFor(async () => {
+			const optionsField = screen.queryByLabelText(/options.*one per line/i);
+			expect(optionsField).toBeInTheDocument();
+			if (optionsField) {
+				await fireEvent.input(optionsField, { target: { value: 'Active\nInactive\nPending' } });
+			}
+		}, { timeout: 2000 });
+
+		// Wait for any reactive updates to complete
+		await new Promise(resolve => setTimeout(resolve, 50));
+
+		const addButton = screen.getByRole('button', { name: /^add field$/i });
+		await fireEvent.click(addButton);
+
+		await waitFor(() => {
+			expect(campaignStore.setEntityTypeOverride).toHaveBeenCalledWith(
+				expect.objectContaining({
+					additionalFields: expect.arrayContaining([
+						expect.objectContaining({
+							type: 'select',
+							options: ['Active', 'Inactive', 'Pending']
+						})
+					])
+				})
+			);
+		}, { timeout: 2000 });
+	});
+
+	it('should save field with high order number', async () => {
+		const { campaignStore, notificationStore } = await import('$lib/stores');
+
+		Object.defineProperty(campaignStore, 'customEntityTypes', {
+			get: () => [],
+			configurable: true
+		});
+		vi.mocked(campaignStore.getEntityTypeOverride).mockReturnValue(undefined);
+		vi.mocked(campaignStore.setEntityTypeOverride).mockResolvedValue(undefined);
+
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const openButton = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(openButton);
+
+		const labelInput = screen.getByLabelText(/field label/i);
+		await fireEvent.input(labelInput, { target: { value: 'Last Field' } });
+
+		const addButton = screen.getByRole('button', { name: /^add field$/i });
+		await fireEvent.click(addButton);
+
+		await waitFor(() => {
+			expect(campaignStore.setEntityTypeOverride).toHaveBeenCalledWith(
+				expect.objectContaining({
+					additionalFields: expect.arrayContaining([
+						expect.objectContaining({
+							order: 1000 // High number to appear at end
+						})
+					])
+				})
+			);
+		});
+	});
+});
+
+describe('AddFieldInline Component - Error Handling', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should show error for duplicate key in built-in type', async () => {
+		const { campaignStore, notificationStore } = await import('$lib/stores');
+
+		Object.defineProperty(campaignStore, 'customEntityTypes', {
+			get: () => [],
+			configurable: true
+		});
+
+		const existingOverride = {
+			type: 'npc',
+			additionalFields: [
+				{ key: 'custom_field', label: 'Custom Field', type: 'text' as const, required: false, order: 1 }
+			]
+		};
+		vi.mocked(campaignStore.getEntityTypeOverride).mockReturnValue(existingOverride);
+
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const openButton = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(openButton);
+
+		const labelInput = screen.getByLabelText(/field label/i);
+		await fireEvent.input(labelInput, { target: { value: 'Custom Field' } }); // Same key
+
+		const addButton = screen.getByRole('button', { name: /^add field$/i });
+		await fireEvent.click(addButton);
+
+		await waitFor(() => {
+			expect(notificationStore.error).toHaveBeenCalledWith(
+				expect.stringContaining('custom_field')
+			);
+		});
+	});
+
+	it('should show error for duplicate key in custom type', async () => {
+		const { campaignStore, notificationStore } = await import('$lib/stores');
+
+		const customType: EntityTypeDefinition = {
+			type: 'quest',
+			label: 'Quest',
+			labelPlural: 'Quests',
+			icon: 'target',
+			color: 'custom',
+			isBuiltIn: false,
+			fieldDefinitions: [
+				{ key: 'goal', label: 'Goal', type: 'text', required: false, order: 1 }
+			]
+		};
+
+		Object.defineProperty(campaignStore, 'customEntityTypes', {
+			get: () => [customType],
+			configurable: true
+		});
+		vi.mocked(campaignStore.getCustomEntityType).mockReturnValue(customType);
+
+		render(AddFieldInline, {
+			props: {
+				entityType: 'quest'
+			}
+		});
+
+		const openButton = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(openButton);
+
+		const labelInput = screen.getByLabelText(/field label/i);
+		await fireEvent.input(labelInput, { target: { value: 'Goal' } }); // Duplicate key
+
+		const addButton = screen.getByRole('button', { name: /^add field$/i });
+		await fireEvent.click(addButton);
+
+		await waitFor(() => {
+			expect(notificationStore.error).toHaveBeenCalledWith(
+				expect.stringContaining('goal')
+			);
+		});
+	});
+
+	it('should handle save error gracefully', async () => {
+		const { campaignStore, notificationStore } = await import('$lib/stores');
+
+		Object.defineProperty(campaignStore, 'customEntityTypes', {
+			get: () => [],
+			configurable: true
+		});
+		vi.mocked(campaignStore.getEntityTypeOverride).mockReturnValue(undefined);
+		vi.mocked(campaignStore.setEntityTypeOverride).mockRejectedValue(new Error('Save failed'));
+
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const openButton = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(openButton);
+
+		const labelInput = screen.getByLabelText(/field label/i);
+		await fireEvent.input(labelInput, { target: { value: 'Test Field' } });
+
+		const addButton = screen.getByRole('button', { name: /^add field$/i });
+		await fireEvent.click(addButton);
+
+		await waitFor(() => {
+			expect(notificationStore.error).toHaveBeenCalledWith(
+				expect.stringContaining('Failed')
+			);
+		});
+	});
+
+	it('should keep modal open after error', async () => {
+		const { campaignStore, notificationStore } = await import('$lib/stores');
+
+		Object.defineProperty(campaignStore, 'customEntityTypes', {
+			get: () => [],
+			configurable: true
+		});
+		vi.mocked(campaignStore.getEntityTypeOverride).mockReturnValue(undefined);
+		vi.mocked(campaignStore.setEntityTypeOverride).mockRejectedValue(new Error('Save failed'));
+
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const openButton = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(openButton);
+
+		const labelInput = screen.getByLabelText(/field label/i);
+		await fireEvent.input(labelInput, { target: { value: 'Test Field' } });
+
+		const addButton = screen.getByRole('button', { name: /^add field$/i });
+		await fireEvent.click(addButton);
+
+		await waitFor(() => {
+			expect(notificationStore.error).toHaveBeenCalled();
+		});
+
+		// Modal should still be open
+		const modal = screen.getByRole('dialog');
+		expect(modal).toBeInTheDocument();
+	});
+});
+
+describe('AddFieldInline Component - Loading State', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should show "Adding..." text while saving', async () => {
+		const { campaignStore, notificationStore } = await import('$lib/stores');
+
+		Object.defineProperty(campaignStore, 'customEntityTypes', {
+			get: () => [],
+			configurable: true
+		});
+		vi.mocked(campaignStore.getEntityTypeOverride).mockReturnValue(undefined);
+
+		// Mock slow save
+		vi.mocked(campaignStore.setEntityTypeOverride).mockImplementation(() =>
+			new Promise(resolve => setTimeout(() => resolve(undefined), 100))
+		);
+
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const openButton = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(openButton);
+
+		const labelInput = screen.getByLabelText(/field label/i);
+		await fireEvent.input(labelInput, { target: { value: 'Test Field' } });
+
+		const addButton = screen.getByRole('button', { name: /^add field$/i });
+		await fireEvent.click(addButton);
+
+		// Should show "Adding..." while saving
+		await waitFor(() => {
+			expect(screen.getByText(/adding/i)).toBeInTheDocument();
+		});
+	});
+
+	it('should disable buttons while saving', async () => {
+		const { campaignStore, notificationStore } = await import('$lib/stores');
+
+		Object.defineProperty(campaignStore, 'customEntityTypes', {
+			get: () => [],
+			configurable: true
+		});
+		vi.mocked(campaignStore.getEntityTypeOverride).mockReturnValue(undefined);
+
+		// Mock slow save
+		vi.mocked(campaignStore.setEntityTypeOverride).mockImplementation(() =>
+			new Promise(resolve => setTimeout(() => resolve(undefined), 100))
+		);
+
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const openButton = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(openButton);
+
+		const labelInput = screen.getByLabelText(/field label/i);
+		await fireEvent.input(labelInput, { target: { value: 'Test Field' } });
+
+		const addButton = screen.getByRole('button', { name: /^add field$/i });
+		await fireEvent.click(addButton);
+
+		// Buttons should be disabled while saving
+		await waitFor(() => {
+			const cancelButton = screen.getByRole('button', { name: /cancel/i });
+			expect(addButton).toBeDisabled();
+			expect(cancelButton).toBeDisabled();
+		});
+	});
+});
+
+describe('AddFieldInline Component - Accessibility', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should have proper modal aria attributes', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		const modal = screen.getByRole('dialog');
+		expect(modal).toHaveAttribute('aria-modal', 'true');
+		expect(modal).toHaveAttribute('aria-labelledby');
+	});
+
+	it('should have proper labels for all inputs', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		expect(screen.getByLabelText(/field label/i)).toBeInTheDocument();
+		expect(screen.getByLabelText(/field type/i)).toBeInTheDocument();
+		expect(screen.getByLabelText(/section/i)).toBeInTheDocument();
+		expect(screen.getByLabelText(/required field/i)).toBeInTheDocument();
+	});
+
+	it('should support keyboard navigation', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		button.focus();
+
+		expect(document.activeElement).toBe(button);
+	});
+
+	it('should close on Escape key', async () => {
+		render(AddFieldInline, {
+			props: {
+				entityType: 'npc'
+			}
+		});
+
+		const button = screen.getByRole('button', { name: /add.*field/i });
+		await fireEvent.click(button);
+
+		// Press Escape on the backdrop
+		const backdrops = screen.getAllByRole('button', { name: /close modal/i });
+		const backdrop = backdrops[0]; // First one is the backdrop div
+		await fireEvent.keyDown(backdrop, { key: 'Escape' });
+
+		await waitFor(() => {
+			const modal = screen.queryByRole('dialog');
+			expect(modal).not.toBeInTheDocument();
+		});
+	});
+});

--- a/src/lib/components/entity/index.ts
+++ b/src/lib/components/entity/index.ts
@@ -5,3 +5,4 @@ export { default as RelationshipCard } from './RelationshipCard.svelte';
 export { default as EditRelationshipModal } from './EditRelationshipModal.svelte';
 export { default as PendingRelationshipList } from './PendingRelationshipList.svelte';
 export { default as CreateRelateCommand } from './CreateRelateCommand.svelte';
+export { default as AddFieldInline } from './AddFieldInline.svelte';

--- a/src/lib/utils/entityFormUtils.ts
+++ b/src/lib/utils/entityFormUtils.ts
@@ -54,11 +54,12 @@ export function getSystemAwareEntityType(
 	}
 
 	// Apply system modifications using the existing function
+	// Note: Don't pass overrides here - they're already applied in baseDefinition
 	return getEntityTypeDefinitionWithSystem(
 		entityType as any, // Cast to EntityType - getEntityTypeDefinitionWithSystem expects this
 		baseDefinition,
 		systemProfile,
 		customTypes ?? [],
-		overrides ?? []
+		[] // Overrides already applied above, don't apply again
 	);
 }

--- a/src/routes/entities/[type]/[id]/edit/+page.svelte
+++ b/src/routes/entities/[type]/[id]/edit/+page.svelte
@@ -17,6 +17,7 @@
 	import { MarkdownEditor } from '$lib/components/markdown';
 	import { ConfirmDialog, FormActionBar } from '$lib/components/ui';
 	import RelationshipContextSelector, { type RelationshipContextData } from '$lib/components/entity/RelationshipContextSelector.svelte';
+	import { AddFieldInline } from '$lib/components/entity';
 
 	const entityId = $derived($page.params.id ?? '');
 	const entityType = $derived($page.params.type ?? '');
@@ -1091,6 +1092,11 @@
 						{/if}
 					</div>
 				{/each}
+
+				<!-- Add Field Button -->
+				<div class="pt-2">
+					<AddFieldInline {entityType} />
+				</div>
 
 				<!-- Hidden/Secret fields -->
 				{@const secretFields = typeDefinition.fieldDefinitions.filter(

--- a/src/routes/entities/[type]/new/+page.svelte
+++ b/src/routes/entities/[type]/new/+page.svelte
@@ -15,7 +15,7 @@
 	import FieldGenerateButton from '$lib/components/entity/FieldGenerateButton.svelte';
 	import LoadingButton from '$lib/components/ui/LoadingButton.svelte';
 	import { MarkdownEditor } from '$lib/components/markdown';
-	import { PendingRelationshipList, CreateRelateCommand } from '$lib/components/entity';
+	import { PendingRelationshipList, CreateRelateCommand, AddFieldInline } from '$lib/components/entity';
 	import { FormActionBar } from '$lib/components/ui';
 	import { buildPendingRelationshipsContext } from './pendingRelationshipsContext';
 
@@ -873,6 +873,11 @@
 					{/if}
 				</div>
 			{/each}
+
+			<!-- Add Field Button -->
+			<div class="pt-2">
+				<AddFieldInline {entityType} />
+			</div>
 
 			<!-- Hidden/Secret fields -->
 			{@const secretFields = typeDefinition.fieldDefinitions.filter(


### PR DESCRIPTION
## Summary

- Add `AddFieldInline` component allowing users to define new custom fields directly from entity edit/new pages
- For built-in types: saves to `additionalFields` via `setEntityTypeOverride()`
- For custom types: appends to `fieldDefinitions` via `updateCustomEntityType()`

Closes #311

## Test plan

- [ ] Create/edit a built-in entity (e.g., NPC) → click "Add Field" → define a text field → field appears in form → fill and save → verify field data persists
- [ ] Create/edit a custom entity type → same flow
- [ ] Export backup → verify new field definitions and values are in the JSON
- [ ] Import backup → verify fields and values are restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)