### PR TITLE
feat(generation): include full player character context when generating related entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - TBD
+
+### Added
+
+**Full Player Character Context in AI Generation (Issue #319)**
+- AI generation now includes complete player character information when generating content for related entities
+- New `playerCharacterContextService` automatically detects relationships to player characters
+- When generating fields, summaries, or descriptions for entities linked to PCs, the AI receives the full character context including all custom fields
+- Privacy protected: hidden section fields (secrets) are excluded from context
+- Works bidirectionally: detects both outgoing and incoming relationships to characters
+- Provides richer, more personalized AI-generated content that references specific character details
+- Example: generating an NPC who is "mentor to Kira" now includes Kira's full backstory, personality, goals, and custom fields in the generation prompt
+- Backward compatible: generation still works for entities without player character relationships
+
 ## [1.1.2] - TBD
 
 ### Added

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -2080,9 +2080,68 @@ When generating content, the AI looks at:
 - Your campaign setting and system
 - Field hints and placeholders
 - **Related entities** (for existing entities with relationships, when enabled)
+- **Full player character details** (when entity is linked to player characters)
 
 **Example**:
 If you create an NPC named "Grimwald the Wise" with the description "elderly wizard" and role "apothecary owner", then click generate on the Personality field, the AI will create a personality that fits an elderly wizard who runs an apothecary.
+
+### Player Character Context in Generation
+
+When generating content for an entity that has a relationship to a player character, Director Assist automatically includes the full character information in the AI context. This enables more personalized, contextually rich content that references specific character details.
+
+**How It Works:**
+
+The system automatically detects when an entity is linked to a player character (type: "character") through relationships. When you generate content for that entity, the AI receives complete information about the linked character including:
+
+- Full description and summary
+- All standard fields (backstory, personality, goals, etc.)
+- All custom fields you've defined for characters
+- Character-specific details like ancestry, class, and background
+
+**Privacy Protection:**
+
+Fields in the "Hidden" section (typically used for secrets or DM-only notes) are automatically excluded from the generation context to maintain player privacy.
+
+**Bidirectional Detection:**
+
+The system finds player character relationships in both directions:
+- **Outgoing links**: NPC has "mentor to Kira" relationship
+- **Incoming links**: Kira has "student of" relationship to the NPC
+
+Both cases will include Kira's full context when generating content for the NPC.
+
+**Example:**
+
+Creating an NPC with a "mentor to Kira" relationship:
+
+*Without player character context:*
+"Generate a backstory for this NPC. They are mentor to Kira (Human Tactician)."
+
+*With player character context:*
+"Generate a backstory for this NPC. They are mentor to Kira.
+
+**Full Character Context - Kira:**
+- Name: Kira Thorne
+- Ancestry: Human
+- Class: Tactician
+- Backstory: [Kira's complete backstory]
+- Personality: [Kira's personality traits]
+- Goals: [Kira's character goals]
+- Custom Fields: [All custom field values]"
+
+The AI can now generate a mentor who specifically references Kira's past, complements their tactical abilities, or has opinions about their goals.
+
+**Use Cases:**
+
+- **NPCs related to PCs**: Mentors, rivals, family members, allies get personalized content
+- **Locations**: A character's hometown can reference their specific background
+- **Factions**: Organizations linked to PCs can acknowledge character-specific relationships
+- **Items**: Personal belongings can reflect the character's history and abilities
+- **Scenes**: Encounters involving PCs become more personalized and relevant
+
+**Token Usage:**
+
+Including full character context uses more API tokens per generation. This provides higher quality, more personalized content at a slightly higher cost. The feature is automatically enabled for all player character relationships.
 
 ### Relationship Context in Field Generation
 

--- a/src/lib/services/fieldGenerationService.ts
+++ b/src/lib/services/fieldGenerationService.ts
@@ -40,8 +40,10 @@ export interface FieldGenerationContext {
 	};
 	/** Campaign information for additional context */
 	campaignContext?: { name: string; setting: string; system: string };
-/** Formatted relationship context to include in prompt (optional, Issues #59/#60) */
+	/** Formatted relationship context to include in prompt (optional, Issues #59/#60) */
 	relationshipContext?: string;
+	/** Formatted player character context to include in prompt (optional, Issue #319) */
+	playerCharacterContext?: string;
 }
 
 /**
@@ -114,7 +116,7 @@ export function isGeneratableField(fieldTypeOrDefinition: FieldType | FieldDefin
  * @private
  */
 function buildFieldPrompt(context: FieldGenerationContext): string {
-	const { entityType, typeDefinition, targetField, currentValues, campaignContext, relationshipContext } = context;
+	const { entityType, typeDefinition, targetField, currentValues, campaignContext, relationshipContext, playerCharacterContext } = context;
 
 	// Build context from existing values (EXCLUDING hidden fields)
 	let existingContext = '';
@@ -158,10 +160,16 @@ function buildFieldPrompt(context: FieldGenerationContext): string {
 `;
 	}
 
-// Build relationship context section (Issues #59/#60)
+	// Build relationship context section (Issues #59/#60)
 	let relationshipInfo = '';
 	if (relationshipContext && relationshipContext.trim()) {
 		relationshipInfo = `\n${relationshipContext}\n`;
+	}
+
+	// Build player character context section (Issue #319)
+	let pcInfo = '';
+	if (playerCharacterContext && playerCharacterContext.trim()) {
+		pcInfo = `\n${playerCharacterContext}\n`;
 	}
 
 	// Build field-specific hints
@@ -178,7 +186,7 @@ function buildFieldPrompt(context: FieldGenerationContext): string {
 
 	return `You are a TTRPG campaign assistant. Generate content for a single field of a ${entityLabel}.
 ${campaignInfo}
-${existingContext ? `\nExisting Context:\n${existingContext}` : ''}${relationshipInfo}
+${existingContext ? `\nExisting Context:\n${existingContext}` : ''}${relationshipInfo}${pcInfo}
 FIELD TO GENERATE: ${fieldLabel} (${targetField.key})
 Field Type: ${targetField.type}${fieldHints}
 
@@ -400,6 +408,8 @@ export interface CoreFieldGenerationContext {
 	campaignContext?: { name: string; setting: string; system: string };
 	/** Relationship context for this entity (Issue #59) */
 	relationshipContext?: string;
+	/** Player character context for this entity (Issue #319) */
+	playerCharacterContext?: string;
 }
 
 /**
@@ -413,7 +423,7 @@ export interface CoreFieldGenerationContext {
  * @private
  */
 function buildSummaryPrompt(context: CoreFieldGenerationContext): string {
-	const { entityType, typeDefinition, currentValues, campaignContext, relationshipContext } = context;
+	const { entityType, typeDefinition, currentValues, campaignContext, relationshipContext, playerCharacterContext } = context;
 
 	// Build context from existing values (EXCLUDING hidden fields)
 	let existingContext = '';
@@ -463,11 +473,17 @@ function buildSummaryPrompt(context: CoreFieldGenerationContext): string {
 		relationshipInfo = `\nRelationships:\n${relationshipContext}\n`;
 	}
 
+	// Build player character context (Issue #319)
+	let pcInfo = '';
+	if (playerCharacterContext && playerCharacterContext.trim()) {
+		pcInfo = `\n${playerCharacterContext}\n`;
+	}
+
 	const entityLabel = typeDefinition.label;
 
 	return `You are a TTRPG campaign assistant. Generate a brief summary for a ${entityLabel}.
 ${campaignInfo}
-${existingContext ? `\nExisting Context:\n${existingContext}` : ''}${relationshipInfo}
+${existingContext ? `\nExisting Context:\n${existingContext}` : ''}${relationshipInfo}${pcInfo}
 TASK: Generate a concise summary (1-2 sentences) that captures the essence of this ${entityLabel}.
 
 IMPORTANT RULES:
@@ -491,7 +507,7 @@ Respond with ONLY the summary text (no JSON, no markdown formatting, no explanat
  * @private
  */
 function buildDescriptionPrompt(context: CoreFieldGenerationContext): string {
-	const { entityType, typeDefinition, currentValues, campaignContext, relationshipContext } = context;
+	const { entityType, typeDefinition, currentValues, campaignContext, relationshipContext, playerCharacterContext } = context;
 
 	// Build context from existing values (EXCLUDING hidden fields)
 	let existingContext = '';
@@ -541,11 +557,17 @@ function buildDescriptionPrompt(context: CoreFieldGenerationContext): string {
 		relationshipInfo = `\nRelationships:\n${relationshipContext}\n`;
 	}
 
+	// Build player character context (Issue #319)
+	let pcInfo = '';
+	if (playerCharacterContext && playerCharacterContext.trim()) {
+		pcInfo = `\n${playerCharacterContext}\n`;
+	}
+
 	const entityLabel = typeDefinition.label;
 
 	return `You are a TTRPG campaign assistant. Generate a detailed description for a ${entityLabel}.
 ${campaignInfo}
-${existingContext ? `\nExisting Context:\n${existingContext}` : ''}${relationshipInfo}
+${existingContext ? `\nExisting Context:\n${existingContext}` : ''}${relationshipInfo}${pcInfo}
 TASK: Generate a rich, evocative description (1-3 paragraphs) for this ${entityLabel}.
 
 IMPORTANT RULES:

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -142,3 +142,16 @@ export {
 	resetAllStores,
 	refreshAfterCampaignSwitch
 } from './stateRefreshService';
+
+// Player character context service (Issue #319)
+export {
+	findLinkedPlayerCharacters,
+	buildFullCharacterContext,
+	formatPlayerCharacterContextForPrompt,
+	buildPlayerCharacterContext
+} from './playerCharacterContextService';
+export type {
+	LinkedCharacterInfo,
+	PlayerCharacterContext,
+	PlayerCharacterContextResult
+} from './playerCharacterContextService';

--- a/src/lib/services/playerCharacterContextService.test.ts
+++ b/src/lib/services/playerCharacterContextService.test.ts
@@ -1,0 +1,1098 @@
+/**
+ * Tests for Player Character Context Service
+ *
+ * Tests the service that builds full player character context for AI generation
+ * when generating content for entities linked to player characters.
+ *
+ * Key Features Tested:
+ * - Finding player characters linked to an entity
+ * - Building full character context (all fields: standard + custom)
+ * - Formatting context for AI prompts
+ * - Privacy protection (excluding hidden/secrets fields)
+ * - Backward compatibility (generation works without PC relationships)
+ *
+ * @see GitHub Issue #319
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+	findLinkedPlayerCharacters,
+	buildFullCharacterContext,
+	formatPlayerCharacterContextForPrompt,
+	buildPlayerCharacterContext,
+	type LinkedCharacterInfo,
+	type PlayerCharacterContext,
+	type PlayerCharacterContextResult
+} from './playerCharacterContextService';
+import type { BaseEntity, EntityId, EntityLink, FieldDefinition } from '$lib/types';
+
+// Mock the entity repository
+vi.mock('$lib/db/repositories', () => ({
+	entityRepository: {
+		getById: vi.fn(),
+		getByIds: vi.fn(),
+		getEntitiesLinkingTo: vi.fn()
+	}
+}));
+
+// Mock the entity types config
+vi.mock('$lib/config/entityTypes', () => ({
+	getEntityTypeDefinition: vi.fn()
+}));
+
+describe('playerCharacterContextService', () => {
+	// Mock entities for testing
+	const mockCharacterId: EntityId = 'char-001';
+	const mockEntityId: EntityId = 'entity-001';
+
+	const mockPlayerCharacter: BaseEntity = {
+		id: mockCharacterId,
+		type: 'character',
+		name: 'Thorin Ironhammer',
+		description: 'A grizzled dwarven fighter with a mysterious past',
+		summary: 'A veteran warrior seeking redemption',
+		tags: ['warrior', 'dwarf', 'party-member'],
+		fields: {
+			playerName: 'John Smith',
+			concept: 'Grizzled veteran seeking redemption',
+			background: 'Once a royal guard, now a wandering adventurer',
+			personality: 'Brave, loyal, but haunted by past failures',
+			goals: 'Find and destroy the artifact that caused his disgrace',
+			status: 'active',
+			// Custom field added by user
+			favoriteDrink: 'Dwarven ale',
+			battleCry: 'For honor and stone!'
+		},
+		links: [],
+		notes: 'Player enjoys combat encounters',
+		createdAt: new Date('2024-01-01'),
+		updatedAt: new Date('2024-01-02'),
+		metadata: {}
+	};
+
+	const mockPlayerCharacterWithSecrets: BaseEntity = {
+		...mockPlayerCharacter,
+		fields: {
+			...mockPlayerCharacter.fields,
+			secrets: 'Secretly working for the enemy' // Should be excluded from context
+		}
+	};
+
+	const mockNPC: BaseEntity = {
+		id: mockEntityId,
+		type: 'npc',
+		name: 'Merchant Goldweaver',
+		description: 'A shrewd trader',
+		tags: ['merchant'],
+		fields: {
+			role: 'Guild Master'
+		},
+		links: [
+			{
+				id: 'link-001',
+				targetId: mockCharacterId,
+				targetType: 'character',
+				relationship: 'knows',
+				bidirectional: true
+			}
+		],
+		notes: '',
+		createdAt: new Date('2024-01-01'),
+		updatedAt: new Date('2024-01-02'),
+		metadata: {}
+	};
+
+	beforeEach(() => {
+		// Clear all mocks before each test
+		vi.clearAllMocks();
+	});
+
+	describe('findLinkedPlayerCharacters', () => {
+		it('should find characters linked via outgoing relationships', async () => {
+			const { entityRepository } = await import('$lib/db/repositories');
+			vi.mocked(entityRepository.getById).mockResolvedValue(mockNPC);
+			vi.mocked(entityRepository.getByIds).mockResolvedValue([mockPlayerCharacter]);
+			vi.mocked(entityRepository.getEntitiesLinkingTo).mockResolvedValue([]);
+
+			const result = await findLinkedPlayerCharacters(mockEntityId);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].character.id).toBe(mockCharacterId);
+			expect(result[0].character.type).toBe('character');
+			expect(result[0].relationship).toBe('knows');
+		});
+
+		it('should find characters linking to the entity (incoming relationships)', async () => {
+			const entityWithNoOutgoing: BaseEntity = {
+				...mockNPC,
+				links: []
+			};
+
+			const characterLinkingToEntity: BaseEntity = {
+				...mockPlayerCharacter,
+				links: [
+					{
+						id: 'link-002',
+						targetId: mockEntityId,
+						targetType: 'npc',
+						relationship: 'trusts',
+						bidirectional: false
+					}
+				]
+			};
+
+			const { entityRepository } = await import('$lib/db/repositories');
+			vi.mocked(entityRepository.getById).mockResolvedValue(entityWithNoOutgoing);
+			vi.mocked(entityRepository.getByIds).mockResolvedValue([]);
+			vi.mocked(entityRepository.getEntitiesLinkingTo).mockResolvedValue([
+				characterLinkingToEntity
+			]);
+
+			const result = await findLinkedPlayerCharacters(mockEntityId);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].character.id).toBe(mockCharacterId);
+			expect(result[0].relationship).toBe('trusts');
+		});
+
+		it('should return empty array when no characters are linked', async () => {
+			const entityWithNoLinks: BaseEntity = {
+				...mockNPC,
+				links: []
+			};
+
+			const { entityRepository } = await import('$lib/db/repositories');
+			vi.mocked(entityRepository.getById).mockResolvedValue(entityWithNoLinks);
+			vi.mocked(entityRepository.getByIds).mockResolvedValue([]);
+			vi.mocked(entityRepository.getEntitiesLinkingTo).mockResolvedValue([]);
+
+			const result = await findLinkedPlayerCharacters(mockEntityId);
+
+			expect(result).toEqual([]);
+		});
+
+		it('should not return non-character entity types', async () => {
+			const entityLinkedToNPC: BaseEntity = {
+				...mockNPC,
+				links: [
+					{
+						id: 'link-003',
+						targetId: 'npc-002',
+						targetType: 'npc', // Not a character
+						relationship: 'knows',
+						bidirectional: false
+					}
+				]
+			};
+
+			const linkedNPC: BaseEntity = {
+				id: 'npc-002',
+				type: 'npc',
+				name: 'Another NPC',
+				description: 'Not a player character',
+				tags: [],
+				fields: {},
+				links: [],
+				notes: '',
+				createdAt: new Date(),
+				updatedAt: new Date(),
+				metadata: {}
+			};
+
+			const { entityRepository } = await import('$lib/db/repositories');
+			vi.mocked(entityRepository.getById).mockResolvedValue(entityLinkedToNPC);
+			vi.mocked(entityRepository.getByIds).mockResolvedValue([linkedNPC]);
+			vi.mocked(entityRepository.getEntitiesLinkingTo).mockResolvedValue([]);
+
+			const result = await findLinkedPlayerCharacters(mockEntityId);
+
+			expect(result).toEqual([]);
+		});
+
+		it('should handle entities with no links array', async () => {
+			const entityWithNoLinksArray: BaseEntity = {
+				...mockNPC,
+				links: []
+			};
+
+			const { entityRepository } = await import('$lib/db/repositories');
+			vi.mocked(entityRepository.getById).mockResolvedValue(entityWithNoLinksArray);
+			vi.mocked(entityRepository.getByIds).mockResolvedValue([]);
+			vi.mocked(entityRepository.getEntitiesLinkingTo).mockResolvedValue([]);
+
+			const result = await findLinkedPlayerCharacters(mockEntityId);
+
+			expect(result).toEqual([]);
+		});
+
+		it('should handle multiple linked player characters', async () => {
+			const secondCharacter: BaseEntity = {
+				...mockPlayerCharacter,
+				id: 'char-002',
+				name: 'Elara Swiftwind',
+				fields: {
+					playerName: 'Jane Doe',
+					concept: 'Elven ranger'
+				}
+			};
+
+			const entityLinkedToMultiple: BaseEntity = {
+				...mockNPC,
+				links: [
+					{
+						id: 'link-004',
+						targetId: mockCharacterId,
+						targetType: 'character',
+						relationship: 'knows',
+						bidirectional: true
+					},
+					{
+						id: 'link-005',
+						targetId: 'char-002',
+						targetType: 'character',
+						relationship: 'trusts',
+						bidirectional: false
+					}
+				]
+			};
+
+			const { entityRepository } = await import('$lib/db/repositories');
+			vi.mocked(entityRepository.getById).mockResolvedValue(entityLinkedToMultiple);
+			vi.mocked(entityRepository.getByIds).mockResolvedValue([
+				mockPlayerCharacter,
+				secondCharacter
+			]);
+			vi.mocked(entityRepository.getEntitiesLinkingTo).mockResolvedValue([]);
+
+			const result = await findLinkedPlayerCharacters(mockEntityId);
+
+			expect(result).toHaveLength(2);
+			expect(result[0].character.name).toBe('Thorin Ironhammer');
+			expect(result[1].character.name).toBe('Elara Swiftwind');
+		});
+
+		it('should handle entity not found error', async () => {
+			const { entityRepository } = await import('$lib/db/repositories');
+			vi.mocked(entityRepository.getById).mockResolvedValue(null);
+
+			await expect(findLinkedPlayerCharacters('nonexistent-id')).rejects.toThrow(
+				'Entity not found'
+			);
+		});
+	});
+
+	describe('buildFullCharacterContext', () => {
+		it('should include all standard character fields', async () => {
+			const { getEntityTypeDefinition } = await import('$lib/config/entityTypes');
+			vi.mocked(getEntityTypeDefinition).mockReturnValue({
+				type: 'character',
+				label: 'Player Character',
+				labelPlural: 'Player Characters',
+				icon: 'user',
+				color: 'character',
+				isBuiltIn: true,
+				fieldDefinitions: [
+					{
+						key: 'playerName',
+						label: 'Player Name',
+						type: 'text',
+						required: true,
+						order: 1
+					},
+					{
+						key: 'concept',
+						label: 'Character Concept',
+						type: 'text',
+						required: false,
+						order: 2
+					}
+				],
+				defaultRelationships: []
+			});
+
+			const linkedChar: LinkedCharacterInfo = {
+				character: mockPlayerCharacter,
+				relationship: 'knows'
+			};
+
+			const result = await buildFullCharacterContext(linkedChar);
+
+			expect(result.characterName).toBe('Thorin Ironhammer');
+			expect(result.relationship).toBe('knows');
+			expect(result.fields).toBeDefined();
+			expect(result.fields['playerName']).toBe('John Smith');
+			expect(result.fields['concept']).toBe('Grizzled veteran seeking redemption');
+		});
+
+		it('should include custom fields added by users', async () => {
+			const { getEntityTypeDefinition } = await import('$lib/config/entityTypes');
+			vi.mocked(getEntityTypeDefinition).mockReturnValue({
+				type: 'character',
+				label: 'Player Character',
+				labelPlural: 'Player Characters',
+				icon: 'user',
+				color: 'character',
+				isBuiltIn: true,
+				fieldDefinitions: [
+					{
+						key: 'playerName',
+						label: 'Player Name',
+						type: 'text',
+						required: true,
+						order: 1
+					},
+					{
+						key: 'favoriteDrink',
+						label: 'Favorite Drink',
+						type: 'text',
+						required: false,
+						order: 10
+					}
+				],
+				defaultRelationships: []
+			});
+
+			const linkedChar: LinkedCharacterInfo = {
+				character: mockPlayerCharacter,
+				relationship: 'knows'
+			};
+
+			const result = await buildFullCharacterContext(linkedChar);
+
+			expect(result.fields['favoriteDrink']).toBe('Dwarven ale');
+			expect(result.fields['battleCry']).toBe('For honor and stone!');
+		});
+
+		it('should exclude hidden/secrets fields from context', async () => {
+			const { getEntityTypeDefinition } = await import('$lib/config/entityTypes');
+			vi.mocked(getEntityTypeDefinition).mockReturnValue({
+				type: 'character',
+				label: 'Player Character',
+				labelPlural: 'Player Characters',
+				icon: 'user',
+				color: 'character',
+				isBuiltIn: true,
+				fieldDefinitions: [
+					{
+						key: 'playerName',
+						label: 'Player Name',
+						type: 'text',
+						required: true,
+						order: 1
+					},
+					{
+						key: 'secrets',
+						label: 'Secrets',
+						type: 'richtext',
+						required: false,
+						order: 6,
+						section: 'hidden'
+					}
+				],
+				defaultRelationships: []
+			});
+
+			const linkedChar: LinkedCharacterInfo = {
+				character: mockPlayerCharacterWithSecrets,
+				relationship: 'knows'
+			};
+
+			const result = await buildFullCharacterContext(linkedChar);
+
+			expect(result.fields['secrets']).toBeUndefined();
+			expect(result.fields['playerName']).toBe('John Smith');
+		});
+
+		it('should properly format field labels', async () => {
+			const { getEntityTypeDefinition } = await import('$lib/config/entityTypes');
+			vi.mocked(getEntityTypeDefinition).mockReturnValue({
+				type: 'character',
+				label: 'Player Character',
+				labelPlural: 'Player Characters',
+				icon: 'user',
+				color: 'character',
+				isBuiltIn: true,
+				fieldDefinitions: [
+					{
+						key: 'goals',
+						label: 'Goals & Motivations',
+						type: 'richtext',
+						required: false,
+						order: 5
+					}
+				],
+				defaultRelationships: []
+			});
+
+			const linkedChar: LinkedCharacterInfo = {
+				character: mockPlayerCharacter,
+				relationship: 'knows'
+			};
+
+			const result = await buildFullCharacterContext(linkedChar);
+
+			// The service should preserve the field definition label
+			expect(result.fieldLabels['goals']).toBe('Goals & Motivations');
+		});
+
+		it('should handle empty/null field values gracefully', async () => {
+			const { getEntityTypeDefinition } = await import('$lib/config/entityTypes');
+			vi.mocked(getEntityTypeDefinition).mockReturnValue({
+				type: 'character',
+				label: 'Player Character',
+				labelPlural: 'Player Characters',
+				icon: 'user',
+				color: 'character',
+				isBuiltIn: true,
+				fieldDefinitions: [
+					{
+						key: 'playerName',
+						label: 'Player Name',
+						type: 'text',
+						required: true,
+						order: 1
+					}
+				],
+				defaultRelationships: []
+			});
+
+			const characterWithEmptyFields: BaseEntity = {
+				...mockPlayerCharacter,
+				fields: {
+					playerName: 'John Smith',
+					concept: '',
+					background: null,
+					personality: undefined
+				}
+			};
+
+			const linkedChar: LinkedCharacterInfo = {
+				character: characterWithEmptyFields,
+				relationship: 'knows'
+			};
+
+			const result = await buildFullCharacterContext(linkedChar);
+
+			expect(result.fields['playerName']).toBe('John Smith');
+			// Empty/null/undefined values should be excluded or handled gracefully
+			expect(result.fields['concept']).toBeUndefined();
+		});
+
+		it('should include character description and summary', async () => {
+			const { getEntityTypeDefinition } = await import('$lib/config/entityTypes');
+			vi.mocked(getEntityTypeDefinition).mockReturnValue({
+				type: 'character',
+				label: 'Player Character',
+				labelPlural: 'Player Characters',
+				icon: 'user',
+				color: 'character',
+				isBuiltIn: true,
+				fieldDefinitions: [],
+				defaultRelationships: []
+			});
+
+			const linkedChar: LinkedCharacterInfo = {
+				character: mockPlayerCharacter,
+				relationship: 'knows'
+			};
+
+			const result = await buildFullCharacterContext(linkedChar);
+
+			expect(result.description).toBe(mockPlayerCharacter.description);
+			expect(result.summary).toBe(mockPlayerCharacter.summary);
+		});
+
+		it('should handle character with no type definition (fallback)', async () => {
+			const { getEntityTypeDefinition } = await import('$lib/config/entityTypes');
+			vi.mocked(getEntityTypeDefinition).mockReturnValue(undefined);
+
+			const linkedChar: LinkedCharacterInfo = {
+				character: mockPlayerCharacter,
+				relationship: 'knows'
+			};
+
+			const result = await buildFullCharacterContext(linkedChar);
+
+			// Should still include character data even without type definition
+			expect(result.characterName).toBe('Thorin Ironhammer');
+			expect(result.fields).toBeDefined();
+		});
+	});
+
+	describe('formatPlayerCharacterContextForPrompt', () => {
+		it('should create clearly labeled section header', () => {
+			const contexts: PlayerCharacterContext[] = [
+				{
+					characterName: 'Thorin Ironhammer',
+					relationship: 'knows',
+					description: 'A grizzled dwarven fighter',
+					summary: 'A veteran warrior',
+					fields: {
+						playerName: 'John Smith',
+						concept: 'Grizzled veteran'
+					},
+					fieldLabels: {
+						playerName: 'Player Name',
+						concept: 'Character Concept'
+					}
+				}
+			];
+
+			const result = formatPlayerCharacterContextForPrompt(contexts);
+
+			expect(result).toContain('=== Player Character Context ===');
+		});
+
+		it('should list all character fields readably', () => {
+			const contexts: PlayerCharacterContext[] = [
+				{
+					characterName: 'Thorin Ironhammer',
+					relationship: 'knows',
+					description: 'A grizzled dwarven fighter',
+					fields: {
+						playerName: 'John Smith',
+						concept: 'Grizzled veteran seeking redemption',
+						background: 'Once a royal guard'
+					},
+					fieldLabels: {
+						playerName: 'Player Name',
+						concept: 'Character Concept',
+						background: 'Background'
+					}
+				}
+			];
+
+			const result = formatPlayerCharacterContextForPrompt(contexts);
+
+			expect(result).toContain('Thorin Ironhammer');
+			expect(result).toContain('Player Name: John Smith');
+			expect(result).toContain('Character Concept: Grizzled veteran seeking redemption');
+			expect(result).toContain('Background: Once a royal guard');
+		});
+
+		it('should include the relationship type', () => {
+			const contexts: PlayerCharacterContext[] = [
+				{
+					characterName: 'Thorin Ironhammer',
+					relationship: 'trusts',
+					description: 'A grizzled dwarven fighter',
+					fields: {
+						playerName: 'John Smith'
+					},
+					fieldLabels: {
+						playerName: 'Player Name'
+					}
+				}
+			];
+
+			const result = formatPlayerCharacterContextForPrompt(contexts);
+
+			expect(result).toContain('Relationship: trusts');
+		});
+
+		it('should handle multiple linked characters', () => {
+			const contexts: PlayerCharacterContext[] = [
+				{
+					characterName: 'Thorin Ironhammer',
+					relationship: 'knows',
+					description: 'A grizzled dwarven fighter',
+					fields: {
+						playerName: 'John Smith'
+					},
+					fieldLabels: {
+						playerName: 'Player Name'
+					}
+				},
+				{
+					characterName: 'Elara Swiftwind',
+					relationship: 'trusts',
+					description: 'An elven ranger',
+					fields: {
+						playerName: 'Jane Doe'
+					},
+					fieldLabels: {
+						playerName: 'Player Name'
+					}
+				}
+			];
+
+			const result = formatPlayerCharacterContextForPrompt(contexts);
+
+			expect(result).toContain('Thorin Ironhammer');
+			expect(result).toContain('Elara Swiftwind');
+			expect(result).toContain('John Smith');
+			expect(result).toContain('Jane Doe');
+		});
+
+		it('should handle empty character list (return empty string)', () => {
+			const contexts: PlayerCharacterContext[] = [];
+
+			const result = formatPlayerCharacterContextForPrompt(contexts);
+
+			expect(result).toBe('');
+		});
+
+		it('should format description and summary fields', () => {
+			const contexts: PlayerCharacterContext[] = [
+				{
+					characterName: 'Thorin Ironhammer',
+					relationship: 'knows',
+					description: 'A grizzled dwarven fighter with a mysterious past',
+					summary: 'A veteran warrior seeking redemption',
+					fields: {},
+					fieldLabels: {}
+				}
+			];
+
+			const result = formatPlayerCharacterContextForPrompt(contexts);
+
+			expect(result).toContain('A grizzled dwarven fighter with a mysterious past');
+			expect(result).toContain('A veteran warrior seeking redemption');
+		});
+
+		it('should handle characters with many custom fields', () => {
+			const contexts: PlayerCharacterContext[] = [
+				{
+					characterName: 'Thorin Ironhammer',
+					relationship: 'knows',
+					description: 'A grizzled dwarven fighter',
+					fields: {
+						playerName: 'John Smith',
+						concept: 'Veteran',
+						background: 'Royal guard',
+						personality: 'Brave',
+						goals: 'Redemption',
+						favoriteDrink: 'Ale',
+						battleCry: 'For honor!',
+						weaponOfChoice: 'Warhammer'
+					},
+					fieldLabels: {
+						playerName: 'Player Name',
+						concept: 'Character Concept',
+						background: 'Background',
+						personality: 'Personality',
+						goals: 'Goals & Motivations',
+						favoriteDrink: 'Favorite Drink',
+						battleCry: 'Battle Cry',
+						weaponOfChoice: 'Weapon of Choice'
+					}
+				}
+			];
+
+			const result = formatPlayerCharacterContextForPrompt(contexts);
+
+			// All fields should be included
+			expect(result).toContain('Favorite Drink: Ale');
+			expect(result).toContain('Battle Cry: For honor!');
+			expect(result).toContain('Weapon of Choice: Warhammer');
+		});
+	});
+
+	describe('buildPlayerCharacterContext', () => {
+		it('should return hasContext: false when no PCs linked', async () => {
+			const { entityRepository } = await import('$lib/db/repositories');
+			const entityWithNoLinks: BaseEntity = {
+				...mockNPC,
+				links: []
+			};
+
+			vi.mocked(entityRepository.getById).mockResolvedValue(entityWithNoLinks);
+			vi.mocked(entityRepository.getByIds).mockResolvedValue([]);
+			vi.mocked(entityRepository.getEntitiesLinkingTo).mockResolvedValue([]);
+
+			const result = await buildPlayerCharacterContext(mockEntityId);
+
+			expect(result.hasContext).toBe(false);
+			expect(result.formattedContext).toBe('');
+		});
+
+		it('should return full context when PCs are linked', async () => {
+			const { entityRepository } = await import('$lib/db/repositories');
+			const { getEntityTypeDefinition } = await import('$lib/config/entityTypes');
+
+			vi.mocked(entityRepository.getById).mockResolvedValue(mockNPC);
+			vi.mocked(entityRepository.getByIds).mockResolvedValue([mockPlayerCharacter]);
+			vi.mocked(entityRepository.getEntitiesLinkingTo).mockResolvedValue([]);
+			vi.mocked(getEntityTypeDefinition).mockReturnValue({
+				type: 'character',
+				label: 'Player Character',
+				labelPlural: 'Player Characters',
+				icon: 'user',
+				color: 'character',
+				isBuiltIn: true,
+				fieldDefinitions: [
+					{
+						key: 'playerName',
+						label: 'Player Name',
+						type: 'text',
+						required: true,
+						order: 1
+					}
+				],
+				defaultRelationships: []
+			});
+
+			const result = await buildPlayerCharacterContext(mockEntityId);
+
+			expect(result.hasContext).toBe(true);
+			expect(result.formattedContext).toContain('Thorin Ironhammer');
+			expect(result.formattedContext).toContain('Player Character Context');
+			expect(result.contexts).toHaveLength(1);
+		});
+
+		it('should handle multiple linked PCs', async () => {
+			const { entityRepository } = await import('$lib/db/repositories');
+			const { getEntityTypeDefinition } = await import('$lib/config/entityTypes');
+
+			const secondCharacter: BaseEntity = {
+				...mockPlayerCharacter,
+				id: 'char-002',
+				name: 'Elara Swiftwind',
+				fields: {
+					playerName: 'Jane Doe',
+					concept: 'Elven ranger'
+				}
+			};
+
+			const entityLinkedToMultiple: BaseEntity = {
+				...mockNPC,
+				links: [
+					{
+						id: 'link-006',
+						targetId: mockCharacterId,
+						targetType: 'character',
+						relationship: 'knows',
+						bidirectional: true
+					},
+					{
+						id: 'link-007',
+						targetId: 'char-002',
+						targetType: 'character',
+						relationship: 'trusts',
+						bidirectional: false
+					}
+				]
+			};
+
+			vi.mocked(entityRepository.getById).mockResolvedValue(entityLinkedToMultiple);
+			vi.mocked(entityRepository.getByIds).mockResolvedValue([
+				mockPlayerCharacter,
+				secondCharacter
+			]);
+			vi.mocked(entityRepository.getEntitiesLinkingTo).mockResolvedValue([]);
+			vi.mocked(getEntityTypeDefinition).mockReturnValue({
+				type: 'character',
+				label: 'Player Character',
+				labelPlural: 'Player Characters',
+				icon: 'user',
+				color: 'character',
+				isBuiltIn: true,
+				fieldDefinitions: [
+					{
+						key: 'playerName',
+						label: 'Player Name',
+						type: 'text',
+						required: true,
+						order: 1
+					}
+				],
+				defaultRelationships: []
+			});
+
+			const result = await buildPlayerCharacterContext(mockEntityId);
+
+			expect(result.hasContext).toBe(true);
+			expect(result.contexts).toHaveLength(2);
+			expect(result.formattedContext).toContain('Thorin Ironhammer');
+			expect(result.formattedContext).toContain('Elara Swiftwind');
+		});
+
+		it('should work for entities that are being generated for (backward compatibility)', async () => {
+			const { entityRepository } = await import('$lib/db/repositories');
+
+			// Entity exists but has no player character relationships
+			const locationEntity: BaseEntity = {
+				id: 'location-001',
+				type: 'location',
+				name: 'The Tavern',
+				description: 'A cozy tavern',
+				tags: [],
+				fields: {},
+				links: [],
+				notes: '',
+				createdAt: new Date(),
+				updatedAt: new Date(),
+				metadata: {}
+			};
+
+			vi.mocked(entityRepository.getById).mockResolvedValue(locationEntity);
+			vi.mocked(entityRepository.getByIds).mockResolvedValue([]);
+			vi.mocked(entityRepository.getEntitiesLinkingTo).mockResolvedValue([]);
+
+			const result = await buildPlayerCharacterContext('location-001');
+
+			// Should work without error and return no context
+			expect(result.hasContext).toBe(false);
+			expect(result.formattedContext).toBe('');
+		});
+
+		it('should handle errors gracefully', async () => {
+			const { entityRepository } = await import('$lib/db/repositories');
+			vi.mocked(entityRepository.getById).mockRejectedValue(new Error('Database error'));
+
+			await expect(buildPlayerCharacterContext('bad-id')).rejects.toThrow('Database error');
+		});
+	});
+
+	describe('Integration: Full workflow', () => {
+		it('should build complete PC context for an NPC that knows a player character', async () => {
+			const { entityRepository } = await import('$lib/db/repositories');
+			const { getEntityTypeDefinition } = await import('$lib/config/entityTypes');
+
+			// Setup: NPC knows a player character
+			vi.mocked(entityRepository.getById).mockResolvedValue(mockNPC);
+			vi.mocked(entityRepository.getByIds).mockResolvedValue([mockPlayerCharacter]);
+			vi.mocked(entityRepository.getEntitiesLinkingTo).mockResolvedValue([]);
+			vi.mocked(getEntityTypeDefinition).mockReturnValue({
+				type: 'character',
+				label: 'Player Character',
+				labelPlural: 'Player Characters',
+				icon: 'user',
+				color: 'character',
+				isBuiltIn: true,
+				fieldDefinitions: [
+					{
+						key: 'playerName',
+						label: 'Player Name',
+						type: 'text',
+						required: true,
+						order: 1
+					},
+					{
+						key: 'concept',
+						label: 'Character Concept',
+						type: 'text',
+						required: false,
+						order: 2
+					},
+					{
+						key: 'background',
+						label: 'Background',
+						type: 'richtext',
+						required: false,
+						order: 3
+					},
+					{
+						key: 'personality',
+						label: 'Personality',
+						type: 'richtext',
+						required: false,
+						order: 4
+					}
+				],
+				defaultRelationships: []
+			});
+
+			// Execute: Build context
+			const result = await buildPlayerCharacterContext(mockEntityId);
+
+			// Verify: Complete context is built
+			expect(result.hasContext).toBe(true);
+			expect(result.contexts).toHaveLength(1);
+			expect(result.contexts![0].characterName).toBe('Thorin Ironhammer');
+			expect(result.contexts![0].fields['playerName']).toBe('John Smith');
+			expect(result.contexts![0].fields['concept']).toBe('Grizzled veteran seeking redemption');
+
+			// Verify: Formatted context is ready for AI prompt
+			expect(result.formattedContext).toContain('=== Player Character Context ===');
+			expect(result.formattedContext).toContain('Thorin Ironhammer');
+			expect(result.formattedContext).toContain('Player Name: John Smith');
+		});
+
+		it('should exclude secrets from PC context', async () => {
+			const { entityRepository } = await import('$lib/db/repositories');
+			const { getEntityTypeDefinition } = await import('$lib/config/entityTypes');
+
+			vi.mocked(entityRepository.getById).mockResolvedValue(mockNPC);
+			vi.mocked(entityRepository.getByIds).mockResolvedValue([mockPlayerCharacterWithSecrets]);
+			vi.mocked(entityRepository.getEntitiesLinkingTo).mockResolvedValue([]);
+			vi.mocked(getEntityTypeDefinition).mockReturnValue({
+				type: 'character',
+				label: 'Player Character',
+				labelPlural: 'Player Characters',
+				icon: 'user',
+				color: 'character',
+				isBuiltIn: true,
+				fieldDefinitions: [
+					{
+						key: 'playerName',
+						label: 'Player Name',
+						type: 'text',
+						required: true,
+						order: 1
+					},
+					{
+						key: 'secrets',
+						label: 'Secrets',
+						type: 'richtext',
+						required: false,
+						order: 6,
+						section: 'hidden'
+					}
+				],
+				defaultRelationships: []
+			});
+
+			const result = await buildPlayerCharacterContext(mockEntityId);
+
+			expect(result.hasContext).toBe(true);
+			expect(result.formattedContext).not.toContain('Secretly working for the enemy');
+			expect(result.formattedContext).toContain('Player Name: John Smith');
+		});
+	});
+
+	describe('Edge Cases', () => {
+		it('should handle character with only required fields', async () => {
+			const { entityRepository } = await import('$lib/db/repositories');
+			const { getEntityTypeDefinition } = await import('$lib/config/entityTypes');
+
+			const minimalCharacter: BaseEntity = {
+				id: 'char-minimal',
+				type: 'character',
+				name: 'Minimal Character',
+				description: '',
+				tags: [],
+				fields: {
+					playerName: 'Test Player'
+				},
+				links: [],
+				notes: '',
+				createdAt: new Date(),
+				updatedAt: new Date(),
+				metadata: {}
+			};
+
+			const entityLinkedToMinimal: BaseEntity = {
+				...mockNPC,
+				links: [
+					{
+						id: 'link-minimal',
+						targetId: 'char-minimal',
+						targetType: 'character',
+						relationship: 'knows',
+						bidirectional: false
+					}
+				]
+			};
+
+			vi.mocked(entityRepository.getById).mockResolvedValue(entityLinkedToMinimal);
+			vi.mocked(entityRepository.getByIds).mockResolvedValue([minimalCharacter]);
+			vi.mocked(entityRepository.getEntitiesLinkingTo).mockResolvedValue([]);
+			vi.mocked(getEntityTypeDefinition).mockReturnValue({
+				type: 'character',
+				label: 'Player Character',
+				labelPlural: 'Player Characters',
+				icon: 'user',
+				color: 'character',
+				isBuiltIn: true,
+				fieldDefinitions: [
+					{
+						key: 'playerName',
+						label: 'Player Name',
+						type: 'text',
+						required: true,
+						order: 1
+					}
+				],
+				defaultRelationships: []
+			});
+
+			const result = await buildPlayerCharacterContext(mockEntityId);
+
+			expect(result.hasContext).toBe(true);
+			expect(result.contexts![0].fields['playerName']).toBe('Test Player');
+		});
+
+		it('should handle very long field values', async () => {
+			const { entityRepository } = await import('$lib/db/repositories');
+			const { getEntityTypeDefinition } = await import('$lib/config/entityTypes');
+
+			const longText = 'A'.repeat(5000);
+			const characterWithLongFields: BaseEntity = {
+				...mockPlayerCharacter,
+				fields: {
+					playerName: 'John Smith',
+					background: longText
+				}
+			};
+
+			vi.mocked(entityRepository.getById).mockResolvedValue(mockNPC);
+			vi.mocked(entityRepository.getByIds).mockResolvedValue([characterWithLongFields]);
+			vi.mocked(entityRepository.getEntitiesLinkingTo).mockResolvedValue([]);
+			vi.mocked(getEntityTypeDefinition).mockReturnValue({
+				type: 'character',
+				label: 'Player Character',
+				labelPlural: 'Player Characters',
+				icon: 'user',
+				color: 'character',
+				isBuiltIn: true,
+				fieldDefinitions: [
+					{
+						key: 'background',
+						label: 'Background',
+						type: 'richtext',
+						required: false,
+						order: 3
+					}
+				],
+				defaultRelationships: []
+			});
+
+			const result = await buildPlayerCharacterContext(mockEntityId);
+
+			expect(result.hasContext).toBe(true);
+			expect(result.formattedContext.length).toBeGreaterThan(1000);
+		});
+
+		it('should handle special characters in field values', async () => {
+			const { entityRepository } = await import('$lib/db/repositories');
+			const { getEntityTypeDefinition } = await import('$lib/config/entityTypes');
+
+			const characterWithSpecialChars: BaseEntity = {
+				...mockPlayerCharacter,
+				name: "O'Brien the \"Lucky\"",
+				fields: {
+					playerName: 'John <Smith>',
+					concept: 'A character with & special characters'
+				}
+			};
+
+			vi.mocked(entityRepository.getById).mockResolvedValue(mockNPC);
+			vi.mocked(entityRepository.getByIds).mockResolvedValue([characterWithSpecialChars]);
+			vi.mocked(entityRepository.getEntitiesLinkingTo).mockResolvedValue([]);
+			vi.mocked(getEntityTypeDefinition).mockReturnValue({
+				type: 'character',
+				label: 'Player Character',
+				labelPlural: 'Player Characters',
+				icon: 'user',
+				color: 'character',
+				isBuiltIn: true,
+				fieldDefinitions: [
+					{
+						key: 'playerName',
+						label: 'Player Name',
+						type: 'text',
+						required: true,
+						order: 1
+					}
+				],
+				defaultRelationships: []
+			});
+
+			const result = await buildPlayerCharacterContext(mockEntityId);
+
+			expect(result.hasContext).toBe(true);
+			expect(result.formattedContext).toContain('O\'Brien the "Lucky"');
+			expect(result.formattedContext).toContain('John <Smith>');
+		});
+	});
+});

--- a/src/lib/services/playerCharacterContextService.ts
+++ b/src/lib/services/playerCharacterContextService.ts
@@ -1,0 +1,254 @@
+/**
+ * Player Character Context Service
+ *
+ * Builds full player character context for AI generation when generating content
+ * for entities linked to player characters.
+ *
+ * Key Features:
+ * - Finds player characters linked to an entity (both outgoing and incoming)
+ * - Builds full character context including all fields (standard + custom)
+ * - Excludes hidden/secrets fields for privacy protection
+ * - Formats context for AI prompt injection
+ *
+ * @see GitHub Issue #319
+ */
+
+import type { BaseEntity, EntityId } from '$lib/types';
+import { entityRepository } from '$lib/db/repositories';
+import { getEntityTypeDefinition } from '$lib/config/entityTypes';
+
+/**
+ * Information about a linked player character
+ */
+export interface LinkedCharacterInfo {
+	/** The player character entity */
+	character: BaseEntity;
+	/** The relationship type (e.g., 'knows', 'trusts') */
+	relationship: string;
+	/** Direction of the relationship (optional, for internal use) */
+	direction?: 'outgoing' | 'incoming';
+}
+
+/**
+ * Full context for a player character
+ */
+export interface PlayerCharacterContext {
+	/** Character name */
+	characterName: string;
+	/** Relationship to the entity being generated for */
+	relationship: string;
+	/** Character description */
+	description?: string;
+	/** Character summary */
+	summary?: string;
+	/** All character fields (excluding hidden/secrets) */
+	fields: Record<string, any>;
+	/** Field labels for proper formatting */
+	fieldLabels: Record<string, string>;
+}
+
+/**
+ * Result of building player character context
+ */
+export interface PlayerCharacterContextResult {
+	/** Whether any player character context exists */
+	hasContext: boolean;
+	/** List of linked characters (if any) */
+	linkedCharacters?: LinkedCharacterInfo[];
+	/** Full context for each character (if any) */
+	contexts?: PlayerCharacterContext[];
+	/** Formatted context string ready for AI prompt */
+	formattedContext: string;
+	/** Number of linked characters */
+	characterCount?: number;
+}
+
+/**
+ * Find all player characters linked to an entity.
+ * Checks both outgoing and incoming relationships.
+ *
+ * @param entityId - The entity to find linked characters for
+ * @returns Array of linked player character information
+ * @throws Error if entity not found
+ */
+export async function findLinkedPlayerCharacters(
+	entityId: EntityId
+): Promise<LinkedCharacterInfo[]> {
+	// Get the source entity
+	const entity = await entityRepository.getById(entityId);
+	if (!entity) {
+		throw new Error('Entity not found');
+	}
+
+	const linkedCharacters: LinkedCharacterInfo[] = [];
+
+	// Find outgoing relationships to characters
+	if (entity.links && entity.links.length > 0) {
+		const characterLinks = entity.links.filter((link) => link.targetType === 'character');
+
+		if (characterLinks.length > 0) {
+			const targetIds = characterLinks.map((link) => link.targetId);
+			const targetEntities = await entityRepository.getByIds(targetIds);
+
+			if (targetEntities) {
+				for (const link of characterLinks) {
+					const character = targetEntities.find((e) => e.id === link.targetId);
+					if (character && character.type === 'character') {
+						linkedCharacters.push({
+							character,
+							relationship: link.relationship,
+							direction: 'outgoing'
+						});
+					}
+				}
+			}
+		}
+	}
+
+	// Find incoming relationships from characters
+	const incomingEntities = await entityRepository.getEntitiesLinkingTo(entityId);
+	for (const incomingEntity of incomingEntities) {
+		if (incomingEntity.type === 'character') {
+			// Find the link that points to our entity
+			const link = incomingEntity.links.find((l) => l.targetId === entityId);
+			if (link) {
+				linkedCharacters.push({
+					character: incomingEntity,
+					relationship: link.relationship,
+					direction: 'incoming'
+				});
+			}
+		}
+	}
+
+	return linkedCharacters;
+}
+
+/**
+ * Build full context for a player character.
+ * Includes all fields (standard + custom) except hidden/secrets fields.
+ *
+ * @param linkedChar - The linked character information
+ * @returns Full character context with all non-hidden fields
+ */
+export async function buildFullCharacterContext(
+	linkedChar: LinkedCharacterInfo
+): Promise<PlayerCharacterContext> {
+	const { character, relationship } = linkedChar;
+
+	// Get the character type definition to access field definitions
+	const typeDef = getEntityTypeDefinition('character');
+
+	const fields: Record<string, any> = {};
+	const fieldLabels: Record<string, string> = {};
+
+	// Process all fields from the character
+	for (const [key, value] of Object.entries(character.fields)) {
+		// Skip empty/null/undefined values
+		if (value === null || value === undefined || value === '') {
+			continue;
+		}
+
+		// Find the field definition
+		const fieldDef = typeDef?.fieldDefinitions.find((f) => f.key === key);
+
+		// Skip hidden section fields (like secrets)
+		if (fieldDef?.section === 'hidden') {
+			continue;
+		}
+
+		// Include the field
+		fields[key] = value;
+
+		// Store the label
+		fieldLabels[key] = fieldDef?.label ?? key;
+	}
+
+	return {
+		characterName: character.name,
+		relationship,
+		description: character.description,
+		summary: character.summary,
+		fields,
+		fieldLabels
+	};
+}
+
+/**
+ * Format player character contexts for AI prompt injection.
+ * Creates a clearly labeled section with all character information.
+ *
+ * @param contexts - Array of player character contexts
+ * @returns Formatted string for AI prompt (empty string if no contexts)
+ */
+export function formatPlayerCharacterContextForPrompt(
+	contexts: PlayerCharacterContext[]
+): string {
+	if (contexts.length === 0) {
+		return '';
+	}
+
+	let output = '=== Player Character Context ===\n';
+
+	for (const context of contexts) {
+		output += `\nCharacter: ${context.characterName}\n`;
+		output += `Relationship: ${context.relationship}\n`;
+
+		if (context.description) {
+			output += `Description: ${context.description}\n`;
+		}
+
+		if (context.summary) {
+			output += `Summary: ${context.summary}\n`;
+		}
+
+		// Add all fields
+		for (const [key, value] of Object.entries(context.fields)) {
+			const label = context.fieldLabels[key] || key;
+			const displayValue = Array.isArray(value) ? value.join(', ') : String(value);
+			output += `${label}: ${displayValue}\n`;
+		}
+	}
+
+	return output;
+}
+
+/**
+ * Build complete player character context for an entity.
+ * This is the main entry point that combines all the functionality.
+ *
+ * @param entityId - The entity to build PC context for
+ * @returns Complete context result with formatted prompt section
+ */
+export async function buildPlayerCharacterContext(
+	entityId: EntityId
+): Promise<PlayerCharacterContextResult> {
+	// Find linked player characters
+	const linkedCharacters = await findLinkedPlayerCharacters(entityId);
+
+	// If no linked characters, return empty result
+	if (linkedCharacters.length === 0) {
+		return {
+			hasContext: false,
+			formattedContext: ''
+		};
+	}
+
+	// Build full context for each character
+	const contexts: PlayerCharacterContext[] = [];
+	for (const linkedChar of linkedCharacters) {
+		const context = await buildFullCharacterContext(linkedChar);
+		contexts.push(context);
+	}
+
+	// Format for AI prompt
+	const formattedContext = formatPlayerCharacterContextForPrompt(contexts);
+
+	return {
+		hasContext: true,
+		linkedCharacters,
+		contexts,
+		formattedContext,
+		characterCount: linkedCharacters.length
+	};
+}

--- a/src/routes/entities/[type]/[id]/edit/+page.svelte
+++ b/src/routes/entities/[type]/[id]/edit/+page.svelte
@@ -3,7 +3,7 @@
 	import { goto } from '$app/navigation';
 	import { aiSettings, entitiesStore, notificationStore, campaignStore } from '$lib/stores';
 	import { getEntityTypeDefinition } from '$lib/config/entityTypes';
-	import { hasGenerationApiKey, buildFieldRelationshipContext } from '$lib/services';
+	import { hasGenerationApiKey, buildFieldRelationshipContext, buildPlayerCharacterContext } from '$lib/services';
 	import { generateField, generateSummaryContent, generateDescriptionContent, isGeneratableField } from '$lib/services/fieldGenerationService';
 	import { buildRelationshipContext, formatRelationshipContextForPrompt, getRelationshipContextStats } from '$lib/services/relationshipContextBuilder';
 	import { getRelationshipContextSettings } from '$lib/services/relationshipContextSettingsService';
@@ -257,13 +257,23 @@
 				}
 			}
 
+			// Build player character context (Issue #319)
+			let playerCharacterContextStr: string | undefined = undefined;
+			if (entityId) {
+				const pcContextResult = await buildPlayerCharacterContext(entityId);
+				if (pcContextResult.hasContext) {
+					playerCharacterContextStr = pcContextResult.formattedContext;
+				}
+			}
+
 			const result = await generateField({
 				entityType,
 				typeDefinition,
 				targetField,
 				currentValues,
 				campaignContext,
-				relationshipContext: relationshipContextStr
+				relationshipContext: relationshipContextStr,
+				playerCharacterContext: playerCharacterContextStr
 			});
 
 			if (result.success && result.value !== undefined) {
@@ -532,12 +542,27 @@
 				}
 			}
 
+			// Build player character context (Issue #319)
+			let playerCharacterContextStr: string | undefined = undefined;
+			if (entityId) {
+				try {
+					const pcContextResult = await buildPlayerCharacterContext(entityId);
+					if (pcContextResult.hasContext) {
+						playerCharacterContextStr = pcContextResult.formattedContext;
+					}
+				} catch (error) {
+					console.error('Failed to build player character context:', error);
+					// Continue without player character context if it fails
+				}
+			}
+
 			const result = await generateSummaryContent({
 				entityType,
 				typeDefinition,
 				currentValues,
 				campaignContext,
-				relationshipContext: relationshipContextStr
+				relationshipContext: relationshipContextStr,
+				playerCharacterContext: playerCharacterContextStr
 			});
 
 			if (result.success && result.value !== undefined) {
@@ -616,12 +641,27 @@
 				}
 			}
 
+			// Build player character context (Issue #319)
+			let playerCharacterContextStr: string | undefined = undefined;
+			if (entityId) {
+				try {
+					const pcContextResult = await buildPlayerCharacterContext(entityId);
+					if (pcContextResult.hasContext) {
+						playerCharacterContextStr = pcContextResult.formattedContext;
+					}
+				} catch (error) {
+					console.error('Failed to build player character context:', error);
+					// Continue without player character context if it fails
+				}
+			}
+
 			const result = await generateDescriptionContent({
 				entityType,
 				typeDefinition,
 				currentValues,
 				campaignContext,
-				relationshipContext: relationshipContextStr
+				relationshipContext: relationshipContextStr,
+				playerCharacterContext: playerCharacterContextStr
 			});
 
 			if (result.success && result.value !== undefined) {


### PR DESCRIPTION
## Summary

When AI-generating content for entities linked to player characters, the full PC information is now included in the generation context for richer, more personalized results.

- Automatically detects player characters linked to the entity being edited (bidirectional)
- Includes all standard fields (backstory, personality, goals, etc.)
- Includes all custom fields defined by the user
- Excludes hidden/secret fields for privacy protection
- Backward compatible with existing generation workflows

## Example

When generating an NPC who is "mentor to Kira" (a player character), the AI now receives:
- Kira's full backstory and history
- Kira's class, ancestry, abilities
- Kira's motivations and personality
- All custom fields on the character

This allows the generated NPC to have specific connections to the character.

## Changes

- **New service**: `playerCharacterContextService.ts` with full test coverage (31 tests)
- **Integration**: Entity edit page calls service for field, summary, and description generation
- **Types**: Added `playerCharacterContext` parameter to generation interfaces
- **Docs**: Updated CHANGELOG, USER_GUIDE, and ARCHITECTURE docs

## Test plan

- [x] 31 unit tests for playerCharacterContextService pass
- [x] 84 field generation service tests still pass
- [x] TypeScript type checking passes
- [x] Production build succeeds
- [x] Backward compatible (generation works without PC relationships)

Fixes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)