### PR TITLE
fix(settings): add dark mode text colors to CampaignLinkingSettings

### DIFF
--- a/src/lib/components/settings/CampaignLinkingSettings.svelte
+++ b/src/lib/components/settings/CampaignLinkingSettings.svelte
@@ -99,7 +99,7 @@
 
 <div class="space-y-4">
 	<div>
-		<h3 class="text-lg font-semibold mb-2">Campaign Linking</h3>
+		<h3 class="text-lg font-semibold mb-2 text-slate-900 dark:text-white">Campaign Linking</h3>
 		<p class="text-sm text-slate-600 dark:text-slate-400 mb-4">
 			Automatically link all new entities to campaigns when this setting is enabled.
 		</p>
@@ -116,7 +116,7 @@
 			aria-label="Enforce Campaign Linking"
 			aria-disabled={hasNoCampaigns ? 'true' : 'false'}
 		/>
-		<label for="enforce-campaign-linking" class="text-sm font-medium">
+		<label for="enforce-campaign-linking" class="label">
 			Enforce Campaign Linking
 		</label>
 	</div>
@@ -129,7 +129,7 @@
 
 	{#if hasMultipleCampaigns && !hasNoCampaigns}
 		<div class="space-y-2">
-			<label for="default-campaign" class="text-sm font-medium">Default Campaign</label>
+			<label for="default-campaign" class="label">Default Campaign</label>
 			<select
 				id="default-campaign"
 				class="input w-full"

--- a/src/lib/components/settings/CampaignLinkingSettings.test.ts
+++ b/src/lib/components/settings/CampaignLinkingSettings.test.ts
@@ -461,4 +461,71 @@ describe('CampaignLinkingSettings Component', () => {
 			expect(toggle).toHaveAttribute('aria-disabled', 'true');
 		});
 	});
+
+	describe('Dark Mode Text Styling - Issue #306', () => {
+		it('should have proper dark mode text classes on the h3 heading', () => {
+			const { container } = render(CampaignLinkingSettings);
+
+			const heading = screen.getByRole('heading', { name: /campaign linking/i });
+
+			// Should have both light and dark mode text color classes
+			expect(heading).toHaveClass('text-slate-900');
+			expect(heading).toHaveClass('dark:text-white');
+		});
+
+		it('should use global .label class for enforce campaign linking label', () => {
+			const { container } = render(CampaignLinkingSettings);
+
+			// Find the label element for the enforce-campaign-linking checkbox
+			const label = container.querySelector('label[for="enforce-campaign-linking"]');
+			expect(label).toBeTruthy();
+
+			// Should use the global .label class which includes dark mode styling
+			expect(label).toHaveClass('label');
+		});
+
+		it('should use global .label class for default campaign label', () => {
+			// Setup multiple campaigns to show the default campaign selector
+			const campaign2 = {
+				...mockCampaignStore.current!.campaign,
+				id: 'campaign-2',
+				name: 'Another Campaign'
+			};
+
+			mockCampaignStore.current!.allCampaigns = [mockCampaignStore.current!.campaign, campaign2];
+
+			const { container } = render(CampaignLinkingSettings);
+
+			// Find the label element for the default-campaign select
+			const label = container.querySelector('label[for="default-campaign"]');
+			expect(label).toBeTruthy();
+
+			// Should use the global .label class which includes dark mode styling
+			expect(label).toHaveClass('label');
+		});
+
+		it('should ensure all labels have proper text color in dark mode', () => {
+			// Setup multiple campaigns to test all labels
+			const campaign2 = {
+				...mockCampaignStore.current!.campaign,
+				id: 'campaign-2',
+				name: 'Another Campaign'
+			};
+
+			mockCampaignStore.current!.allCampaigns = [mockCampaignStore.current!.campaign, campaign2];
+
+			const { container } = render(CampaignLinkingSettings);
+
+			// Get all label elements
+			const labels = container.querySelectorAll('label');
+
+			// Should have at least 2 labels (enforce and default campaign)
+			expect(labels.length).toBeGreaterThanOrEqual(2);
+
+			// All labels should have the .label class for consistent dark mode styling
+			labels.forEach((label) => {
+				expect(label).toHaveClass('label');
+			});
+		});
+	});
 });


### PR DESCRIPTION
## Summary
- Added `text-slate-900 dark:text-white` to the Campaign Linking h3 heading
- Updated labels to use the global `.label` class for proper dark mode support
- Added 4 comprehensive tests for dark mode text styling

## Test plan
- [x] All 29 component tests pass
- [x] Dark mode text is now readable in CampaignLinkingSettings
- [x] Light mode appearance unchanged

Closes #306

🤖 Generated with [Claude Code](https://claude.ai/code)