### PR TITLE
feat(#247): Align Player Character fields with Forge Steel Hero format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+**Character Identity Fields Aligned with Forge Steel Hero Format (Issue #247)**
+- Added 5 new character identity fields to Player Character entity type for better Draw Steel support
+- New fields: ancestry (text), culture (text), career (text), heroClass (text), subclass (text)
+- Fields appear on character creation, edit, and detail pages
+- Draw Steel system profile overrides ancestry and heroClass with select dropdowns containing Draw Steel-specific options
+- Forge Steel import now maps hero data to ancestry and heroClass fields
+- Backward compatible: existing characters without these fields work normally
+- Preserves concept field for backward compatibility while enabling more detailed character information
+- Example usage: ancestry="Human", culture="Nomadic", career="Soldier", heroClass="Fury", subclass="Reaver"
+
 ## [1.1.3] - 2026-02-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ See [DEPLOYMENT.md](./docs/DEPLOYMENT.md) for detailed deployment instructions i
 ### First Steps
 
 1. Create a campaign with a name, game system (Draw Steel or System Agnostic), and setting description
-   - **Draw Steel**: Adds system-specific fields (ancestry, class, threat levels, victory points) and uses "Director" terminology
+   - **Draw Steel**: Adds system-specific fields (ancestry, culture, career, class, subclass, threat levels, victory points) and uses "Director" terminology
    - **System Agnostic**: Generic fields suitable for any TTRPG system
 2. Add an AI provider API key in Settings to enable AI features (optional)
 3. Start adding entities using the sidebar or dashboard
@@ -176,8 +176,8 @@ Each entity type has custom fields relevant to its purpose. When you select a ga
 
 **Draw Steel System Enhancements:**
 - **Characters**:
-  - Identity: Ancestry, Heritage, Ancestry Trait
-  - Class: Class, Kit, Heroic Resource, Class Features
+  - Identity: Ancestry (select dropdown), Culture, Career, Heritage, Ancestry Trait
+  - Class: Class (select dropdown), Subclass, Kit, Heroic Resource, Class Features
   - Characteristics: Might, Agility, Reason, Intuition, Presence
   - Skills with training levels (Trained, Expert, Master)
   - Health: Max Stamina, Current Stamina, Vitality, Conditions

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -95,7 +95,7 @@ Director Assist includes 12 built-in entity types to help you organize your camp
 ### Entity Types
 
 **Player Characters**
-Track your players' characters with background, goals, and secrets. Include the player's name so you remember who plays whom.
+Track your players' characters with comprehensive information including player name, character concept, and detailed identity fields. Standard fields include ancestry, culture, career, class, subclass, background, personality, goals, and secrets. When using the Draw Steel system profile, ancestry and class fields become dropdowns with game-specific options.
 
 **NPCs**
 The heart of your campaign! NPCs have fields for role, personality, appearance, voice, greetings, motivation, secrets, status, and importance. Perfect for everyone from quest-givers to villains.
@@ -1676,8 +1676,8 @@ When you select a game system, entity forms automatically adapt to show system-a
 
 **Draw Steel System Adds:**
 - **Characters**:
-  - Identity: Ancestry, Heritage, Ancestry Trait
-  - Class: Class, Kit, Heroic Resource, Class Features
+  - Identity: Ancestry (select dropdown), Culture, Career, Heritage, Ancestry Trait
+  - Class: Class (select dropdown), Subclass, Kit, Heroic Resource, Class Features
   - Characteristics: Might, Agility, Reason, Intuition, Presence
   - Skills with training levels (Trained, Expert, Master)
   - Health: Max Stamina, Current Stamina, Vitality, Conditions
@@ -2632,7 +2632,8 @@ Director Assist can import character data directly from Forge Steel, the officia
 
 **What Gets Imported**:
 - Character name
-- Ancestry and Class (combined into the "concept" field)
+- Ancestry (imported to both "ancestry" field and combined into "concept" field)
+- Class (imported to both "heroClass" field and combined into "concept" field)
 - Character notes (imported as "background")
 - Defeated status (becomes "active" or "deceased")
 
@@ -2646,7 +2647,9 @@ Director Assist can import character data directly from Forge Steel, the officia
 4. Select your `.ds-hero` or `.json` file
 5. Review the import preview:
    - Character name
-   - Concept (Ancestry + Class)
+   - Ancestry (imported to dedicated field)
+   - Class (imported to dedicated heroClass field)
+   - Concept (Ancestry + Class combined for backward compatibility)
    - Background (notes)
    - Status (active or deceased)
 7. Click "Import Character" to save
@@ -2659,8 +2662,8 @@ Director Assist validates the file before importing and shows:
   - Missing required fields (name, id, state)
   - Duplicate character name (a character with this name already exists)
 - **Warnings** (yellow): Non-critical issues that won't block import
-  - Missing ancestry (concept field will be incomplete)
-  - Missing class (concept field will be incomplete)
+  - Missing ancestry (ancestry and concept fields will be incomplete)
+  - Missing class (heroClass and concept fields will be incomplete)
 
 **What Happens After Import**:
 

--- a/src/lib/config/entityTypes.test.ts
+++ b/src/lib/config/entityTypes.test.ts
@@ -740,6 +740,152 @@ describe('entityTypes.ts - System-Aware Entity Type Resolution', () => {
 });
 
 // =============================================================================
+// Base Character Entity Type Tests (Issue #247)
+// =============================================================================
+
+describe('entityTypes.ts - Base Character Fields (Issue #247)', () => {
+	describe('Character Entity Type - Forge Steel Hero Fields', () => {
+		it('should have ancestry field as text type', () => {
+			const characterType = BUILT_IN_ENTITY_TYPES.find((t) => t.type === 'character');
+			const ancestryField = characterType?.fieldDefinitions.find((f) => f.key === 'ancestry');
+
+			expect(ancestryField).toBeDefined();
+			expect(ancestryField?.label).toBe('Ancestry');
+			expect(ancestryField?.type).toBe('text');
+			expect(ancestryField?.required).toBe(false);
+			expect(ancestryField?.placeholder).toBeTruthy();
+		});
+
+		it('should have culture field as text type', () => {
+			const characterType = BUILT_IN_ENTITY_TYPES.find((t) => t.type === 'character');
+			const cultureField = characterType?.fieldDefinitions.find((f) => f.key === 'culture');
+
+			expect(cultureField).toBeDefined();
+			expect(cultureField?.label).toBe('Culture');
+			expect(cultureField?.type).toBe('text');
+			expect(cultureField?.required).toBe(false);
+			expect(cultureField?.placeholder).toBeTruthy();
+		});
+
+		it('should have career field as text type', () => {
+			const characterType = BUILT_IN_ENTITY_TYPES.find((t) => t.type === 'character');
+			const careerField = characterType?.fieldDefinitions.find((f) => f.key === 'career');
+
+			expect(careerField).toBeDefined();
+			expect(careerField?.label).toBe('Career');
+			expect(careerField?.type).toBe('text');
+			expect(careerField?.required).toBe(false);
+			expect(careerField?.placeholder).toBeTruthy();
+		});
+
+		it('should have heroClass field as text type', () => {
+			const characterType = BUILT_IN_ENTITY_TYPES.find((t) => t.type === 'character');
+			const heroClassField = characterType?.fieldDefinitions.find((f) => f.key === 'heroClass');
+
+			expect(heroClassField).toBeDefined();
+			expect(heroClassField?.label).toBe('Class');
+			expect(heroClassField?.type).toBe('text');
+			expect(heroClassField?.required).toBe(false);
+			expect(heroClassField?.placeholder).toBeTruthy();
+		});
+
+		it('should have subclass field as text type', () => {
+			const characterType = BUILT_IN_ENTITY_TYPES.find((t) => t.type === 'character');
+			const subclassField = characterType?.fieldDefinitions.find((f) => f.key === 'subclass');
+
+			expect(subclassField).toBeDefined();
+			expect(subclassField?.label).toBe('Subclass');
+			expect(subclassField?.type).toBe('text');
+			expect(subclassField?.required).toBe(false);
+			expect(subclassField?.placeholder).toBeTruthy();
+		});
+
+		it('should have all 5 new fields in consecutive order', () => {
+			const characterType = BUILT_IN_ENTITY_TYPES.find((t) => t.type === 'character');
+			const fields = characterType?.fieldDefinitions ?? [];
+
+			const ancestryField = fields.find((f) => f.key === 'ancestry');
+			const cultureField = fields.find((f) => f.key === 'culture');
+			const careerField = fields.find((f) => f.key === 'career');
+			const heroClassField = fields.find((f) => f.key === 'heroClass');
+			const subclassField = fields.find((f) => f.key === 'subclass');
+
+			// Check they exist and have consecutive orders
+			expect(ancestryField?.order).toBeDefined();
+			expect(cultureField?.order).toBeDefined();
+			expect(careerField?.order).toBeDefined();
+			expect(heroClassField?.order).toBeDefined();
+			expect(subclassField?.order).toBeDefined();
+
+			// Verify consecutive ordering
+			const orders = [
+				ancestryField?.order ?? 0,
+				cultureField?.order ?? 0,
+				careerField?.order ?? 0,
+				heroClassField?.order ?? 0,
+				subclassField?.order ?? 0
+			];
+
+			// Check that orders are consecutive and in this sequence
+			for (let i = 1; i < orders.length; i++) {
+				expect(orders[i]).toBe(orders[i - 1] + 1);
+			}
+		});
+
+		it('should place new fields after concept field', () => {
+			const characterType = BUILT_IN_ENTITY_TYPES.find((t) => t.type === 'character');
+			const fields = characterType?.fieldDefinitions ?? [];
+
+			const conceptField = fields.find((f) => f.key === 'concept');
+			const ancestryField = fields.find((f) => f.key === 'ancestry');
+
+			expect(conceptField?.order).toBeDefined();
+			expect(ancestryField?.order).toBeDefined();
+			expect(ancestryField!.order).toBeGreaterThan(conceptField!.order);
+		});
+
+		it('should place new fields before background field', () => {
+			const characterType = BUILT_IN_ENTITY_TYPES.find((t) => t.type === 'character');
+			const fields = characterType?.fieldDefinitions ?? [];
+
+			const subclassField = fields.find((f) => f.key === 'subclass');
+			const backgroundField = fields.find((f) => f.key === 'background');
+
+			expect(subclassField?.order).toBeDefined();
+			expect(backgroundField?.order).toBeDefined();
+			expect(subclassField!.order).toBeLessThan(backgroundField!.order);
+		});
+
+		it('should have appropriate labels for all new fields', () => {
+			const characterType = BUILT_IN_ENTITY_TYPES.find((t) => t.type === 'character');
+
+			const ancestryField = characterType?.fieldDefinitions.find((f) => f.key === 'ancestry');
+			const cultureField = characterType?.fieldDefinitions.find((f) => f.key === 'culture');
+			const careerField = characterType?.fieldDefinitions.find((f) => f.key === 'career');
+			const heroClassField = characterType?.fieldDefinitions.find((f) => f.key === 'heroClass');
+			const subclassField = characterType?.fieldDefinitions.find((f) => f.key === 'subclass');
+
+			expect(ancestryField?.label).toBe('Ancestry');
+			expect(cultureField?.label).toBe('Culture');
+			expect(careerField?.label).toBe('Career');
+			expect(heroClassField?.label).toBe('Class');
+			expect(subclassField?.label).toBe('Subclass');
+		});
+
+		it('should have all new fields as optional (required: false)', () => {
+			const characterType = BUILT_IN_ENTITY_TYPES.find((t) => t.type === 'character');
+
+			const newFieldKeys = ['ancestry', 'culture', 'career', 'heroClass', 'subclass'];
+
+			newFieldKeys.forEach((key) => {
+				const field = characterType?.fieldDefinitions.find((f) => f.key === key);
+				expect(field?.required).toBe(false);
+			});
+		});
+	});
+});
+
+// =============================================================================
 // Entity Type Ordering Functions Tests (Issue #121)
 // =============================================================================
 

--- a/src/lib/config/entityTypes.ts
+++ b/src/lib/config/entityTypes.ts
@@ -33,32 +33,72 @@ export const BUILT_IN_ENTITY_TYPES: EntityTypeDefinition[] = [
 				placeholder: 'e.g., Grizzled veteran seeking redemption'
 			},
 			{
+				key: 'ancestry',
+				label: 'Ancestry',
+				type: 'text',
+				required: false,
+				order: 3,
+				placeholder: 'e.g., Human, Elf, Dwarf'
+			},
+			{
+				key: 'culture',
+				label: 'Culture',
+				type: 'text',
+				required: false,
+				order: 4,
+				placeholder: 'e.g., Nomadic, Urban, Monastic'
+			},
+			{
+				key: 'career',
+				label: 'Career',
+				type: 'text',
+				required: false,
+				order: 5,
+				placeholder: 'e.g., Soldier, Scholar, Craftsperson'
+			},
+			{
+				key: 'heroClass',
+				label: 'Class',
+				type: 'text',
+				required: false,
+				order: 6,
+				placeholder: 'e.g., Fury, Tactician, Shadow'
+			},
+			{
+				key: 'subclass',
+				label: 'Subclass',
+				type: 'text',
+				required: false,
+				order: 7,
+				placeholder: 'e.g., Reaver, Vanguard, Stormwight'
+			},
+			{
 				key: 'background',
 				label: 'Background',
 				type: 'richtext',
 				required: false,
-				order: 3
+				order: 8
 			},
 			{
 				key: 'personality',
 				label: 'Personality',
 				type: 'richtext',
 				required: false,
-				order: 4
+				order: 9
 			},
 			{
 				key: 'goals',
 				label: 'Goals & Motivations',
 				type: 'richtext',
 				required: false,
-				order: 5
+				order: 10
 			},
 			{
 				key: 'secrets',
 				label: 'Secrets',
 				type: 'richtext',
 				required: false,
-				order: 6,
+				order: 11,
 				section: 'hidden'
 			},
 			{
@@ -68,7 +108,7 @@ export const BUILT_IN_ENTITY_TYPES: EntityTypeDefinition[] = [
 				options: ['active', 'inactive', 'deceased'],
 				required: true,
 				defaultValue: 'active',
-				order: 7
+				order: 12
 			}
 		],
 		defaultRelationships: ['knows', 'allied_with', 'enemy_of', 'member_of']

--- a/src/lib/config/systems.test.ts
+++ b/src/lib/config/systems.test.ts
@@ -47,7 +47,7 @@ describe('systems.ts - System Profile Configuration', () => {
 				const fieldKeys = characterMods?.additionalFields?.map((f) => f.key) ?? [];
 
 				expect(fieldKeys).toContain('ancestry');
-				expect(fieldKeys).toContain('class');
+				expect(fieldKeys).toContain('heroClass');
 				expect(fieldKeys).toContain('kit');
 				expect(fieldKeys).toContain('heroicResource');
 			});
@@ -117,10 +117,10 @@ describe('systems.ts - System Profile Configuration', () => {
 				expect(ancestryField?.order).toBeGreaterThan(0);
 			});
 
-			it('should have class field as select type with Draw Steel classes', () => {
+			it('should have heroClass field as select type with Draw Steel classes', () => {
 				const profile = getSystemProfile('draw-steel');
 				const characterMods = profile?.entityTypeModifications?.character;
-				const classField = characterMods?.additionalFields?.find((f) => f.key === 'class');
+				const classField = characterMods?.additionalFields?.find((f) => f.key === 'heroClass');
 
 				expect(classField).toBeDefined();
 				expect(classField?.label).toBe('Class');
@@ -552,6 +552,101 @@ describe('systems.ts - System Profile Configuration', () => {
 
 				expect(negotiationDCField).toBeDefined();
 				expect(negotiationDCField?.type).toBe('number');
+			});
+
+			/**
+			 * Tests for Draw Steel Character Field Overrides (Issue #247)
+			 * These tests verify that Draw Steel profile can override base character fields
+			 * with select types for ancestry and heroClass
+			 */
+
+			describe('Character Field Overrides (Issue #247)', () => {
+				it('should override ancestry field from text to select type', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+					const ancestryField = characterMods?.additionalFields?.find((f) => f.key === 'ancestry');
+
+					expect(ancestryField).toBeDefined();
+					expect(ancestryField?.type).toBe('select');
+					expect(ancestryField?.options).toBeDefined();
+					expect(Array.isArray(ancestryField?.options)).toBe(true);
+				});
+
+				it('should use heroClass key (not class) for consistency with base fields', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+					const heroClassField = characterMods?.additionalFields?.find((f) => f.key === 'heroClass');
+
+					// Draw Steel should have heroClass, not class
+					expect(heroClassField).toBeDefined();
+					expect(heroClassField?.type).toBe('select');
+
+					// Verify no 'class' field exists
+					const classField = characterMods?.additionalFields?.find((f) => f.key === 'class');
+					expect(classField).toBeUndefined();
+				});
+
+				it('should override heroClass field from text to select type', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+					const heroClassField = characterMods?.additionalFields?.find((f) => f.key === 'heroClass');
+
+					expect(heroClassField).toBeDefined();
+					expect(heroClassField?.label).toBe('Class');
+					expect(heroClassField?.type).toBe('select');
+					expect(heroClassField?.options).toBeDefined();
+					expect(Array.isArray(heroClassField?.options)).toBe(true);
+				});
+
+				it('should have ancestry select options matching Draw Steel ancestries', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+					const ancestryField = characterMods?.additionalFields?.find((f) => f.key === 'ancestry');
+
+					expect(ancestryField?.options).toContain('Human');
+					expect(ancestryField?.options).toContain('Dwarf');
+					expect(ancestryField?.options).toContain('High Elf');
+					expect(ancestryField?.options).toContain('Wode Elf');
+					expect(ancestryField?.options).toContain('Orc');
+					expect(ancestryField?.options).toContain('Dragon Knight');
+					expect(ancestryField?.options).toContain('Revenant');
+					expect(ancestryField?.options).toContain('Devil');
+					expect(ancestryField?.options).toContain('Hakaan');
+					expect(ancestryField?.options).toContain('Memonek');
+					expect(ancestryField?.options).toContain('Polder');
+					expect(ancestryField?.options).toContain('Time Raider');
+				});
+
+				it('should have heroClass select options matching Draw Steel classes', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+					const heroClassField = characterMods?.additionalFields?.find((f) => f.key === 'heroClass');
+
+					expect(heroClassField?.options).toContain('Tactician');
+					expect(heroClassField?.options).toContain('Fury');
+					expect(heroClassField?.options).toContain('Shadow');
+					expect(heroClassField?.options).toContain('Elementalist');
+					expect(heroClassField?.options).toContain('Talent');
+					expect(heroClassField?.options).toContain('Censor');
+					expect(heroClassField?.options).toContain('Conduit');
+					expect(heroClassField?.options).toContain('Null');
+					expect(heroClassField?.options).toContain('Troubadour');
+				});
+
+				it('should preserve culture, career, and subclass as text fields', () => {
+					const profile = getSystemProfile('draw-steel');
+					const characterMods = profile?.entityTypeModifications?.character;
+
+					// Draw Steel should NOT override these fields, so they shouldn't appear
+					// in additionalFields (base entity type defines them)
+					const cultureField = characterMods?.additionalFields?.find((f) => f.key === 'culture');
+					const careerField = characterMods?.additionalFields?.find((f) => f.key === 'career');
+					const subclassField = characterMods?.additionalFields?.find((f) => f.key === 'subclass');
+
+					expect(cultureField).toBeUndefined();
+					expect(careerField).toBeUndefined();
+					expect(subclassField).toBeUndefined();
+				});
 			});
 
 			/**

--- a/src/lib/config/systems.ts
+++ b/src/lib/config/systems.ts
@@ -33,7 +33,7 @@ export const DRAW_STEEL_PROFILE: SystemProfile = {
 					order: 10
 				},
 				{
-					key: 'class',
+					key: 'heroClass',
 					label: 'Class',
 					type: 'select',
 					options: [

--- a/src/lib/services/forgeSteelImportService.test.ts
+++ b/src/lib/services/forgeSteelImportService.test.ts
@@ -348,6 +348,132 @@ describe('forgeSteelImportService', () => {
 	});
 
 	describe('mapForgeSteelHeroToEntity', () => {
+		describe('Field Mapping - New Forge Steel Hero Fields (Issue #247)', () => {
+			it('should map ancestry.name to ancestry field', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Test Character',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.ancestry).toBe('Human');
+			});
+
+			it('should map class.name to heroClass field', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Test Character',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.heroClass).toBe('Fury');
+			});
+
+			it('should map ancestry.name to ancestry field when class is null', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Test Character',
+					ancestry: { name: 'Dwarf' },
+					class: null,
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.ancestry).toBe('Dwarf');
+				expect(entity.fields.heroClass).toBeUndefined();
+			});
+
+			it('should map class.name to heroClass field when ancestry is null', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Test Character',
+					ancestry: null,
+					class: { name: 'Shadow', level: 2 },
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.ancestry).toBeUndefined();
+				expect(entity.fields.heroClass).toBe('Shadow');
+			});
+
+			it('should not set ancestry or heroClass when both are null', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Test Character',
+					ancestry: null,
+					class: null,
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.ancestry).toBeUndefined();
+				expect(entity.fields.heroClass).toBeUndefined();
+			});
+
+			it('should preserve existing concept field behavior alongside new fields', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'Human' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				// Verify both old and new mapping behavior
+				expect(entity.fields.concept).toBe('Human Fury');
+				expect(entity.fields.ancestry).toBe('Human');
+				expect(entity.fields.heroClass).toBe('Fury');
+			});
+
+			it('should handle multi-word ancestry names in new field mapping', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Aric',
+					ancestry: { name: 'High Elf' },
+					class: { name: 'Conduit', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.ancestry).toBe('High Elf');
+				expect(entity.fields.heroClass).toBe('Conduit');
+			});
+
+			it('should handle Draw Steel specific ancestries', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Dragon Rider',
+					ancestry: { name: 'Dragon Knight' },
+					class: { name: 'Fury', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.ancestry).toBe('Dragon Knight');
+			});
+
+			it('should handle Draw Steel specific classes', () => {
+				const hero: ForgeSteelHero = {
+					id: 'hero-123',
+					name: 'Tactical Genius',
+					ancestry: { name: 'Human' },
+					class: { name: 'Tactician', level: 1 },
+					state: { notes: '', defeated: false }
+				};
+				const entity = mapForgeSteelHeroToEntity(hero);
+
+				expect(entity.fields.heroClass).toBe('Tactician');
+			});
+		});
+
 		describe('Complete Hero Mapping', () => {
 			it('should map hero with all fields to NewEntity', () => {
 				const hero: ForgeSteelHero = {

--- a/src/lib/services/forgeSteelImportService.ts
+++ b/src/lib/services/forgeSteelImportService.ts
@@ -102,16 +102,28 @@ export function mapForgeSteelHeroToEntity(hero: ForgeSteelHero): NewEntity {
 	// Map defeated status
 	const status = hero.state.defeated ? 'deceased' : 'active';
 
+	// Build fields object
+	const fields: Record<string, any> = {
+		concept,
+		background: hero.state.notes,
+		status
+	};
+
+	// Map new Forge Steel hero fields (Issue #247)
+	if (hero.ancestry?.name) {
+		fields.ancestry = hero.ancestry.name;
+	}
+
+	if (hero.class?.name) {
+		fields.heroClass = hero.class.name;
+	}
+
 	return {
 		type: 'character',
 		name: hero.name.trim(),
 		description: '',
 		tags: ['forge-steel-import'],
-		fields: {
-			concept,
-			background: hero.state.notes,
-			status
-		},
+		fields,
 		links: [],
 		notes: 'Imported from Forge Steel',
 		metadata: {}


### PR DESCRIPTION
## Summary
- Add 5 new character identity fields to align with Forge Steel Hero format: `ancestry`, `culture`, `career`, `heroClass`, `subclass`
- Update Draw Steel profile to use `heroClass` instead of `class` with select dropdown
- Enhance Forge Steel import to map hero data to new dedicated fields

## Changes
- **entityTypes.ts** - Added 5 new optional text fields to base character type
- **systems.ts** - Updated Draw Steel profile to override ancestry/heroClass with select dropdowns
- **forgeSteelImportService.ts** - Map `hero.ancestry.name` → `ancestry`, `hero.class.name` → `heroClass`
- **Tests** - 25 new tests covering all changes
- **Docs** - Updated CHANGELOG, README, and USER_GUIDE

## Test plan
- [x] All 25 new tests pass
- [x] Existing tests unaffected
- [x] TypeScript type checking passes
- [x] Draw Steel accuracy reviewed

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)