### PR TITLE
fix(#292): use correct sceneStatus field and in_progress value

### DIFF
--- a/src/lib/components/scene/SceneHeader.svelte
+++ b/src/lib/components/scene/SceneHeader.svelte
@@ -15,7 +15,7 @@ import { ArrowLeft, Edit, Play, CheckCircle } from 'lucide-svelte';
 interface Props {
 	sceneId: string;
 	sceneName: string;
-	status: 'planned' | 'active' | 'completed';
+	status: 'planned' | 'in_progress' | 'completed';
 	onStart?: () => void;
 	onComplete?: () => void;
 }
@@ -77,7 +77,7 @@ function handleComplete() {
 				</button>
 			{/if}
 
-			{#if status === 'active' && onComplete}
+			{#if status === 'in_progress' && onComplete}
 				<button
 					type="button"
 					class="flex items-center gap-2 px-3 py-2 bg-green-600 hover:bg-green-700 text-white rounded-md"

--- a/src/lib/components/scene/SceneHeader.test.ts
+++ b/src/lib/components/scene/SceneHeader.test.ts
@@ -45,7 +45,7 @@ describe('SceneHeader Component - Basic Rendering', () => {
 			props: {
 				sceneId: 'scene-1',
 				sceneName: 'The Dragon Encounter',
-				status: 'active'
+				status: 'in_progress'
 			}
 		});
 
@@ -69,7 +69,7 @@ describe('SceneHeader Component - Basic Rendering', () => {
 			props: {
 				sceneId: 'scene-1',
 				sceneName: 'Test',
-				status: 'active'
+				status: 'in_progress'
 			}
 		});
 
@@ -100,7 +100,7 @@ describe('SceneHeader Component - Back Button', () => {
 			props: {
 				sceneId: 'scene-1',
 				sceneName: 'Test',
-				status: 'active'
+				status: 'in_progress'
 			}
 		});
 
@@ -112,7 +112,7 @@ describe('SceneHeader Component - Back Button', () => {
 			props: {
 				sceneId: 'scene-1',
 				sceneName: 'Test',
-				status: 'active'
+				status: 'in_progress'
 			}
 		});
 
@@ -127,7 +127,7 @@ describe('SceneHeader Component - Back Button', () => {
 			props: {
 				sceneId: 'scene-1',
 				sceneName: 'Test',
-				status: 'active'
+				status: 'in_progress'
 			}
 		});
 
@@ -147,7 +147,7 @@ describe('SceneHeader Component - Edit Button', () => {
 			props: {
 				sceneId: 'scene-1',
 				sceneName: 'Test',
-				status: 'active'
+				status: 'in_progress'
 			}
 		});
 
@@ -159,7 +159,7 @@ describe('SceneHeader Component - Edit Button', () => {
 			props: {
 				sceneId: 'scene-123',
 				sceneName: 'Test',
-				status: 'active'
+				status: 'in_progress'
 			}
 		});
 
@@ -174,7 +174,7 @@ describe('SceneHeader Component - Edit Button', () => {
 			props: {
 				sceneId: 'scene-1',
 				sceneName: 'Test',
-				status: 'active'
+				status: 'in_progress'
 			}
 		});
 
@@ -193,7 +193,7 @@ describe('SceneHeader Component - Complete Scene Button', () => {
 			props: {
 				sceneId: 'scene-1',
 				sceneName: 'Test',
-				status: 'active'
+				status: 'in_progress'
 			}
 		});
 
@@ -230,7 +230,7 @@ describe('SceneHeader Component - Complete Scene Button', () => {
 			props: {
 				sceneId: 'scene-1',
 				sceneName: 'Test',
-				status: 'active',
+				status: 'in_progress',
 				onComplete
 			}
 		});
@@ -246,7 +246,7 @@ describe('SceneHeader Component - Complete Scene Button', () => {
 			props: {
 				sceneId: 'scene-1',
 				sceneName: 'Test',
-				status: 'active'
+				status: 'in_progress'
 			}
 		});
 
@@ -277,7 +277,7 @@ describe('SceneHeader Component - Start Scene Button', () => {
 			props: {
 				sceneId: 'scene-1',
 				sceneName: 'Test',
-				status: 'active'
+				status: 'in_progress'
 			}
 		});
 
@@ -324,7 +324,7 @@ describe('SceneHeader Component - Layout', () => {
 			props: {
 				sceneId: 'scene-1',
 				sceneName: 'Test',
-				status: 'active'
+				status: 'in_progress'
 			}
 		});
 
@@ -340,7 +340,7 @@ describe('SceneHeader Component - Layout', () => {
 			props: {
 				sceneId: 'scene-1',
 				sceneName: 'Test',
-				status: 'active'
+				status: 'in_progress'
 			}
 		});
 
@@ -359,7 +359,7 @@ describe('SceneHeader Component - Layout', () => {
 			props: {
 				sceneId: 'scene-1',
 				sceneName: 'Test Scene',
-				status: 'active'
+				status: 'in_progress'
 			}
 		});
 
@@ -383,7 +383,7 @@ describe('SceneHeader Component - Accessibility', () => {
 			props: {
 				sceneId: 'scene-1',
 				sceneName: 'Test',
-				status: 'active'
+				status: 'in_progress'
 			}
 		});
 
@@ -395,7 +395,7 @@ describe('SceneHeader Component - Accessibility', () => {
 			props: {
 				sceneId: 'scene-1',
 				sceneName: 'Test',
-				status: 'active'
+				status: 'in_progress'
 			}
 		});
 
@@ -413,7 +413,7 @@ describe('SceneHeader Component - Accessibility', () => {
 			props: {
 				sceneId: 'scene-1',
 				sceneName: 'Test',
-				status: 'active'
+				status: 'in_progress'
 			}
 		});
 

--- a/src/lib/components/scene/SceneStatusBadge.svelte
+++ b/src/lib/components/scene/SceneStatusBadge.svelte
@@ -4,12 +4,12 @@
  *
  * Displays a visual indicator of scene status with appropriate color coding:
  * - 'planned' (blue badge)
- * - 'active' (yellow/amber badge)
+ * - 'in_progress' (yellow/amber badge)
  * - 'completed' (green badge)
  */
 
 interface Props {
-	status?: 'planned' | 'active' | 'completed';
+	status?: 'planned' | 'in_progress' | 'completed';
 }
 
 let { status = 'planned' }: Props = $props();
@@ -17,6 +17,7 @@ let { status = 'planned' }: Props = $props();
 // Derive display values
 const displayText = $derived(() => {
 	const statusValue = status ?? 'planned';
+	if (statusValue === 'in_progress') return 'In Progress';
 	return statusValue.charAt(0).toUpperCase() + statusValue.slice(1);
 });
 
@@ -25,7 +26,7 @@ const badgeClasses = $derived(() => {
 	const baseClasses = 'badge px-2 py-1 rounded text-sm font-medium';
 
 	switch (statusValue) {
-		case 'active':
+		case 'in_progress':
 			return `${baseClasses} bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200`;
 		case 'completed':
 			return `${baseClasses} bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200`;

--- a/src/lib/components/scene/SceneStatusBadge.test.ts
+++ b/src/lib/components/scene/SceneStatusBadge.test.ts
@@ -51,18 +51,18 @@ describe('SceneStatusBadge Component - Planned Status', () => {
 	});
 });
 
-describe('SceneStatusBadge Component - Active Status', () => {
+describe('SceneStatusBadge Component - In Progress Status', () => {
 	it('should display "Active" text for active status', () => {
 		render(SceneStatusBadge, {
-			props: { status: 'active' }
+			props: { status: 'in_progress' }
 		});
 
-		expect(screen.getByText(/active/i)).toBeInTheDocument();
+		expect(screen.getByText(/in.?progress/i)).toBeInTheDocument();
 	});
 
 	it('should apply yellow/amber styling for active status', () => {
 		const { container } = render(SceneStatusBadge, {
-			props: { status: 'active' }
+			props: { status: 'in_progress' }
 		});
 
 		const badge = container.querySelector('[data-testid="scene-status-badge"]');
@@ -71,7 +71,7 @@ describe('SceneStatusBadge Component - Active Status', () => {
 
 	it('should use warning color variant for active status', () => {
 		const { container } = render(SceneStatusBadge, {
-			props: { status: 'active' }
+			props: { status: 'in_progress' }
 		});
 
 		const badge = container.querySelector('[data-testid="scene-status-badge"]');
@@ -128,7 +128,7 @@ describe('SceneStatusBadge Component - Default Behavior', () => {
 
 	it('should be accessible with proper role', () => {
 		const { container } = render(SceneStatusBadge, {
-			props: { status: 'active' }
+			props: { status: 'in_progress' }
 		});
 
 		const badge = container.querySelector('[data-testid="scene-status-badge"]');
@@ -142,7 +142,7 @@ describe('SceneStatusBadge Component - Visual Consistency', () => {
 			props: { status: 'planned' }
 		});
 		const { container: activeContainer } = render(SceneStatusBadge, {
-			props: { status: 'active' }
+			props: { status: 'in_progress' }
 		});
 		const { container: completedContainer } = render(SceneStatusBadge, {
 			props: { status: 'completed' }

--- a/src/routes/scene/+page.svelte
+++ b/src/routes/scene/+page.svelte
@@ -18,7 +18,7 @@ import type { BaseEntity } from '$lib/types';
 
 let scenes = $state<BaseEntity[]>([]);
 let filteredScenes = $state<BaseEntity[]>([]);
-let statusFilter = $state<'all' | 'planned' | 'active' | 'completed'>('all');
+let statusFilter = $state<'all' | 'planned' | 'in_progress' | 'completed'>('all');
 let loading = $state(true);
 
 async function loadScenes() {
@@ -45,7 +45,7 @@ function applyFilter() {
 		filteredScenes = scenes;
 	} else {
 		filteredScenes = scenes.filter((scene) => {
-			const status = (scene.fields.status as string | undefined) ?? 'planned';
+			const status = (scene.fields.sceneStatus as string | undefined) ?? 'planned';
 			return status === statusFilter;
 		});
 	}
@@ -110,12 +110,12 @@ $effect(() => {
 		</button>
 		<button
 			type="button"
-			class="px-3 py-1 rounded-md {statusFilter === 'active'
+			class="px-3 py-1 rounded-md {statusFilter === 'in_progress'
 				? 'bg-blue-600 text-white'
 				: 'bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300'}"
-			onclick={() => handleStatusFilterChange('active')}
+			onclick={() => handleStatusFilterChange('in_progress')}
 		>
-			Active
+			In Progress
 		</button>
 		<button
 			type="button"
@@ -144,7 +144,7 @@ $effect(() => {
 					<div class="flex-1">
 						<div class="flex items-center gap-3 mb-2">
 							<h2 class="text-lg font-semibold">{scene.name}</h2>
-							<SceneStatusBadge status={(scene.fields.status as 'planned' | 'active' | 'completed') ?? 'planned'} />
+							<SceneStatusBadge status={(scene.fields.sceneStatus as 'planned' | 'in_progress' | 'completed') ?? 'planned'} />
 						</div>
 						{#if scene.description}
 							<p class="text-sm text-gray-600 dark:text-gray-400">{scene.description}</p>

--- a/src/routes/scene/[id]/+page.svelte
+++ b/src/routes/scene/[id]/+page.svelte
@@ -100,7 +100,7 @@ onMount(() => {
 		<SceneHeader
 			sceneId={scene.id}
 			sceneName={scene.name}
-			status={(scene.fields.status as 'planned' | 'active' | 'completed') ?? 'planned'}
+			status={(scene.fields.sceneStatus as 'planned' | 'in_progress' | 'completed') ?? 'planned'}
 			onStart={handleStart}
 			onComplete={handleCompleteClick}
 		/>


### PR DESCRIPTION
## Summary

Hotfix for Scene Runner to use the correct field name and status values:

- Scene entity uses `sceneStatus` field (not `status`)
- Status values are: `planned`, `in_progress`, `completed` (not `active`)

This fixes the "Start Scene" button not appearing on the Scene Runner page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)