### PR TITLE
feat(narrative-trail): Implement Narrative Trail feature (Epic #397)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+**Narrative Trail System (Epic #397, Issues #398-401)**
+- New Narrative Event entity type for tracking game moments in chronological sequence
+- Automatic narrative event creation when combat encounters and montage challenges complete
+- Timeline view UI components (NarrativeTimeline and TimelineEvent) for visualizing story flow
+- Session summary service generates human-readable narrative text from event chains
+- NarrativeEvent entity with fields: eventType (scene/combat/montage/negotiation/other), sourceId, outcome, session
+- Auto-creation triggers: combat sessions on endCombat(), montage sessions on completeMontage()
+- Temporal relationship system using leads_to/follows relationships to chain events
+- Topological sort algorithm orders events by relationships, falls back to creation time
+- Timeline filtering by session for focused session review
+- Click-through from timeline events to source combat/montage/scene entities
+- Event linking UI for manual story flow adjustment
+- Narrative summary generation with contextual transitions and outcome formatting
+
 **Character Identity Fields Aligned with Forge Steel Hero Format (Issue #247)**
 - Added 5 new character identity fields to Player Character entity type for better Draw Steel support
 - New fields: ancestry (text), culture (text), career (text), heroClass (text), subclass (text)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Director Assist features a **system-aware architecture** with first-class suppor
 
 ## Features
 
-- **Track Everything**: Characters, NPCs, locations, factions, items, encounters, sessions, scenes, deities, timeline events, world rules, and player profiles
+- **Track Everything**: Characters, NPCs, locations, factions, items, encounters, sessions, scenes, deities, timeline events, world rules, player profiles, and narrative events
 - **Connect the Dots**: Create relationships between entities (knows, allied with, member of, located at)
 - **Visualize Connections**: Relationship Matrix View shows a 2D grid of relationships between entity types with filtering, sorting, and color-coded cell density
 - **Find Anything Fast**: Global search with Cmd/Ctrl+K shortcut, results grouped by type, keyboard navigation
@@ -19,6 +19,7 @@ Director Assist features a **system-aware architecture** with first-class suppor
 - **Forge Steel Integration**: Import character data directly from Forge Steel character builder
 - **Montage Challenge Tracker**: Track Draw Steel montage challenges with player count-based limits, success/failure tracking across two rounds, difficulty-based outcomes (Easy, Moderate, Hard), and automatic victory point awards
 - **Negotiation Tracker**: Manage Draw Steel negotiations with Interest/Patience tracking (0-5 scale), NPC motivations and pitfalls, tier-based argument outcomes, and built-in rules reference
+- **Narrative Trail System**: Link game moments (combat, montages, scenes) into a chronological story chain with automatic event creation and session summaries
 - **Responsive Loading States**: Polished loading feedback with skeleton screens, spinners, and loading buttons
 
 ## Quick Start
@@ -158,7 +159,7 @@ When generating fields for existing entities, Director Assist automatically incl
 
 ### Entity Types
 
-Director Assist includes 12 built-in entity types:
+Director Assist includes 13 built-in entity types:
 
 - **Characters** - Player characters with background, goals, and secrets
 - **NPCs** - Non-player characters with personality and motivations
@@ -172,6 +173,7 @@ Director Assist includes 12 built-in entity types:
 - **Timeline Events** - Historical events with dates and consequences
 - **World Rules** - How magic, society, or nature works in your world
 - **Player Profiles** - Player preferences and boundaries
+- **Narrative Events** - Auto-created events linking combat, montages, and scenes into story chains
 
 Each entity type has custom fields relevant to its purpose. When you select a game system for your campaign, entity types automatically gain system-specific fields:
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1713,6 +1713,75 @@ Click the eye icon next to motivations or pitfalls to toggle whether players kno
 - Toggle motivation visibility when players discover them through roleplay
 - Don't be afraid to adjust tiers based on creative arguments
 
+### Narrative Trail System
+
+The Narrative Trail system automatically links your game moments into a chronological story chain, making it easy to see how scenes, combat, and montages connect. When you complete combat encounters or montage challenges, Director Assist creates narrative event entities that form a timeline of your session's story.
+
+**What is a Narrative Event?**
+
+A narrative event is a special entity type that represents a moment in your game's story. Each event tracks:
+- Event type (scene, combat, montage, negotiation, or other)
+- Source ID linking back to the original combat, montage, or scene
+- Outcome describing what happened
+- Session reference for organizing events by game session
+
+**How Events Are Created:**
+
+Narrative events are created automatically:
+- When combat encounters end, an event is created with victory points and round count
+- When montage challenges complete, an event is created with the outcome
+- You can manually create events from scene entities as well
+
+**Viewing the Timeline:**
+
+Navigate to a session to see its narrative timeline. The timeline shows:
+- Chronological list of events (oldest first)
+- Event type icons distinguishing combat, montages, and scenes
+- Event names and brief outcomes
+- Connecting lines showing story flow between linked events
+
+Click any event to view its source - this opens the original combat session, montage session, or scene entity.
+
+**Linking Events:**
+
+Events can be linked with "leads_to" and "follows" relationships to show story flow:
+- Automatic ordering based on relationships when available
+- Falls back to creation time when relationships aren't defined
+- Use the linking UI to manually connect events when automatic ordering needs adjustment
+- Bidirectional relationships ensure both directions are tracked
+
+**Session Summaries:**
+
+Generate a readable summary of your session from the narrative trail:
+- Orders events chronologically using relationships or creation time
+- Constructs prose with contextual transitions ("The session began with...", "Following this...", etc.)
+- Includes event names, types, and outcomes
+- Formats outcomes as readable text with proper capitalization
+
+**Example Summary:**
+
+"The session began with a combat encounter: Ambush at the River Crossing. Outcome: Victory in 5 rounds, earned 2 VP. Following this, a montage: Searching the Bandit Camp. Outcome: Success. The session concluded with a scene: Questioning the Bandit Leader."
+
+**Best Practices:**
+
+- Review the timeline after each session to verify event creation
+- Link events manually when story flow differs from creation order
+- Add outcome details to events for richer session summaries
+- Reference the session field to organize events across multiple sessions
+- Use scene entities for narrative moments between structured encounters
+- Check narrative events when preparing for the next session to recall story beats
+
+**Working with Narrative Events:**
+
+Narrative events appear in your entity lists like other entity types. You can:
+- View event details to see linked combat/montage/scene
+- Edit outcomes to add more context
+- Create relationships to other entities (NPCs, locations, etc.)
+- Add tags for categorization
+- Delete events that don't belong in your narrative trail
+
+The Narrative Trail system works behind the scenes to help you track your campaign's story without manual record-keeping. After each session, you'll have a complete record of what happened, ready for review or summary generation.
+
 ### Tips for Directors
 
 **Choosing Difficulty:**

--- a/src/lib/components/narrative/NarrativeTimeline.svelte
+++ b/src/lib/components/narrative/NarrativeTimeline.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+	/**
+	 * NarrativeTimeline Component
+	 *
+	 * Issue #400: Build Timeline View UI (GREEN phase of TDD)
+	 *
+	 * Renders a chronological timeline of narrative events:
+	 * - Sorts events by createdAt (oldest first)
+	 * - Filters by sessionId if provided
+	 * - Passes isFirst/isLast to TimelineEvent components
+	 * - Propagates callbacks (onViewSource, onLinkEvent)
+	 * - Shows empty state when showEmpty=true and no events
+	 */
+
+	import { Calendar } from 'lucide-svelte';
+	import TimelineEvent from './TimelineEvent.svelte';
+	import type { BaseEntity } from '$lib/types';
+
+	interface Props {
+		events: BaseEntity[];
+		sessionId?: string;
+		onViewSource?: (eventType: string, sourceId: string) => void;
+		onLinkEvent?: (eventId: string) => void;
+		showEmpty?: boolean;
+	}
+
+	let { events = [], sessionId, onViewSource, onLinkEvent, showEmpty = false }: Props = $props();
+
+	// Filter and sort events
+	const sortedEvents = $derived.by(() => {
+		if (!events || !Array.isArray(events)) {
+			return [];
+		}
+
+		let filtered = events;
+
+		// Filter by sessionId if provided
+		if (sessionId) {
+			filtered = events.filter((event) => {
+				const eventSessionId = event.fields?.sessionId as string | null | undefined;
+				return eventSessionId === sessionId;
+			});
+		}
+
+		// Sort by createdAt (oldest first)
+		return [...filtered].sort((a, b) => {
+			const dateA = a.createdAt instanceof Date ? a.createdAt.getTime() : 0;
+			const dateB = b.createdAt instanceof Date ? b.createdAt.getTime() : 0;
+			return dateA - dateB;
+		});
+	});
+
+	// Check if we should show empty state
+	const shouldShowEmpty = $derived(showEmpty && sortedEvents.length === 0);
+</script>
+
+<div class="narrative-timeline">
+	{#if shouldShowEmpty}
+		<!-- Empty state -->
+		<div class="flex flex-col items-center justify-center py-12 text-center">
+			<Calendar class="mb-4 h-12 w-12 text-gray-400" aria-hidden="true" />
+			<p class="text-lg font-medium text-gray-900">No events yet</p>
+			<p class="mt-1 text-sm text-gray-500">Timeline events will appear here as they are created</p>
+		</div>
+	{:else if sortedEvents.length > 0}
+		<!-- Timeline list -->
+		<ol class="timeline-list space-y-0" role="list" aria-label="Narrative timeline">
+			{#each sortedEvents as event, index (event.id)}
+				<li>
+					<TimelineEvent
+						{event}
+						isFirst={index === 0}
+						isLast={index === sortedEvents.length - 1}
+						{onViewSource}
+						{onLinkEvent}
+					/>
+				</li>
+			{/each}
+		</ol>
+	{/if}
+</div>
+
+<style>
+	.narrative-timeline {
+		width: 100%;
+	}
+
+	.timeline-list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+	}
+</style>

--- a/src/lib/components/narrative/NarrativeTimeline.test.ts
+++ b/src/lib/components/narrative/NarrativeTimeline.test.ts
@@ -1,0 +1,924 @@
+/**
+ * Tests for NarrativeTimeline Component
+ *
+ * Issue #400: Build Timeline View UI
+ *
+ * This component renders a chronological timeline of narrative events,
+ * displaying them in order with proper first/last indicators and
+ * supporting callbacks for viewing sources and linking events.
+ *
+ * These tests are written in the RED phase of TDD - they will FAIL until
+ * the component is implemented.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/svelte';
+import NarrativeTimeline from './NarrativeTimeline.svelte';
+import { createMockEntity } from '../../../tests/utils/testUtils';
+import type { BaseEntity } from '$lib/types';
+
+describe('NarrativeTimeline Component - Basic Rendering (Issue #400)', () => {
+	let events: BaseEntity[];
+
+	beforeEach(() => {
+		events = [
+			createMockEntity({
+				id: 'event-1',
+				type: 'narrative_event',
+				name: 'First Event',
+				createdAt: new Date('2024-01-01T10:00:00'),
+				fields: {
+					eventType: 'combat'
+				}
+			}),
+			createMockEntity({
+				id: 'event-2',
+				type: 'narrative_event',
+				name: 'Second Event',
+				createdAt: new Date('2024-01-02T10:00:00'),
+				fields: {
+					eventType: 'scene'
+				}
+			})
+		];
+	});
+
+	it('should render without crashing', () => {
+		const { container } = render(NarrativeTimeline, {
+			props: { events }
+		});
+		expect(container).toBeInTheDocument();
+	});
+
+	it('should render TimelineEvent for each event', () => {
+		render(NarrativeTimeline, {
+			props: { events }
+		});
+
+		expect(screen.getByText('First Event')).toBeInTheDocument();
+		expect(screen.getByText('Second Event')).toBeInTheDocument();
+	});
+
+	it('should render correct number of timeline events', () => {
+		const { container } = render(NarrativeTimeline, {
+			props: { events }
+		});
+
+		// Should have 2 timeline event components
+		const eventElements = container.querySelectorAll('[data-event-type]');
+		expect(eventElements.length).toBeGreaterThanOrEqual(2);
+	});
+
+	it('should handle single event', () => {
+		const singleEvent = [events[0]];
+
+		render(NarrativeTimeline, {
+			props: { events: singleEvent }
+		});
+
+		expect(screen.getByText('First Event')).toBeInTheDocument();
+	});
+});
+
+describe('NarrativeTimeline Component - Empty State (Issue #400)', () => {
+	it('should render empty state when no events and showEmpty is true', () => {
+		render(NarrativeTimeline, {
+			props: {
+				events: [],
+				showEmpty: true
+			}
+		});
+
+		// Should show empty state message
+		expect(screen.getByText(/no events/i)).toBeInTheDocument();
+	});
+
+	it('should not show empty state when showEmpty is false', () => {
+		const { container } = render(NarrativeTimeline, {
+			props: {
+				events: [],
+				showEmpty: false
+			}
+		});
+
+		// Should not show empty state message
+		expect(screen.queryByText(/no events/i)).not.toBeInTheDocument();
+		expect(container).toBeInTheDocument();
+	});
+
+	it('should not show empty state by default when events are empty', () => {
+		const { container } = render(NarrativeTimeline, {
+			props: {
+				events: []
+			}
+		});
+
+		// Default behavior: no empty state
+		expect(screen.queryByText(/no events/i)).not.toBeInTheDocument();
+	});
+
+	it('should show helpful message in empty state', () => {
+		render(NarrativeTimeline, {
+			props: {
+				events: [],
+				showEmpty: true
+			}
+		});
+
+		// Empty state should have informative text
+		const emptyMessage = screen.getByText(/no events/i);
+		expect(emptyMessage).toBeInTheDocument();
+	});
+
+	it('should show empty state with icon or illustration', () => {
+		const { container } = render(NarrativeTimeline, {
+			props: {
+				events: [],
+				showEmpty: true
+			}
+		});
+
+		// Should have icon or visual element in empty state
+		const icon = container.querySelector('[class*="lucide"]');
+		expect(icon).toBeInTheDocument();
+	});
+});
+
+describe('NarrativeTimeline Component - Chronological Ordering (Issue #400)', () => {
+	it('should render events in chronological order by createdAt', () => {
+		const events = [
+			createMockEntity({
+				id: 'event-3',
+				type: 'narrative_event',
+				name: 'Third Event',
+				createdAt: new Date('2024-01-03T10:00:00'),
+				fields: { eventType: 'combat' }
+			}),
+			createMockEntity({
+				id: 'event-1',
+				type: 'narrative_event',
+				name: 'First Event',
+				createdAt: new Date('2024-01-01T10:00:00'),
+				fields: { eventType: 'scene' }
+			}),
+			createMockEntity({
+				id: 'event-2',
+				type: 'narrative_event',
+				name: 'Second Event',
+				createdAt: new Date('2024-01-02T10:00:00'),
+				fields: { eventType: 'montage' }
+			})
+		];
+
+		const { container } = render(NarrativeTimeline, {
+			props: { events }
+		});
+
+		// Get all event names in DOM order
+		const eventNames = Array.from(container.querySelectorAll('[data-event-type]')).map(
+			(el) => el.textContent
+		);
+
+		// Should be ordered: First, Second, Third
+		expect(eventNames[0]).toContain('First Event');
+		expect(eventNames[1]).toContain('Second Event');
+		expect(eventNames[2]).toContain('Third Event');
+	});
+
+	it('should handle events with same timestamp', () => {
+		const sameTime = new Date('2024-01-01T10:00:00');
+
+		const events = [
+			createMockEntity({
+				id: 'event-1',
+				type: 'narrative_event',
+				name: 'Event A',
+				createdAt: sameTime,
+				fields: { eventType: 'combat' }
+			}),
+			createMockEntity({
+				id: 'event-2',
+				type: 'narrative_event',
+				name: 'Event B',
+				createdAt: sameTime,
+				fields: { eventType: 'scene' }
+			})
+		];
+
+		const { container } = render(NarrativeTimeline, {
+			props: { events }
+		});
+
+		// Both events should render
+		expect(screen.getByText('Event A')).toBeInTheDocument();
+		expect(screen.getByText('Event B')).toBeInTheDocument();
+	});
+
+	it('should maintain correct order with multiple events', () => {
+		const events = [
+			createMockEntity({
+				id: 'event-5',
+				type: 'narrative_event',
+				name: 'Event 5',
+				createdAt: new Date('2024-01-05T10:00:00'),
+				fields: { eventType: 'combat' }
+			}),
+			createMockEntity({
+				id: 'event-2',
+				type: 'narrative_event',
+				name: 'Event 2',
+				createdAt: new Date('2024-01-02T10:00:00'),
+				fields: { eventType: 'scene' }
+			}),
+			createMockEntity({
+				id: 'event-4',
+				type: 'narrative_event',
+				name: 'Event 4',
+				createdAt: new Date('2024-01-04T10:00:00'),
+				fields: { eventType: 'montage' }
+			}),
+			createMockEntity({
+				id: 'event-1',
+				type: 'narrative_event',
+				name: 'Event 1',
+				createdAt: new Date('2024-01-01T10:00:00'),
+				fields: { eventType: 'scene' }
+			}),
+			createMockEntity({
+				id: 'event-3',
+				type: 'narrative_event',
+				name: 'Event 3',
+				createdAt: new Date('2024-01-03T10:00:00'),
+				fields: { eventType: 'combat' }
+			})
+		];
+
+		const { container } = render(NarrativeTimeline, {
+			props: { events }
+		});
+
+		const eventNames = Array.from(container.querySelectorAll('[data-event-type]')).map(
+			(el) => el.textContent
+		);
+
+		// Should be ordered 1, 2, 3, 4, 5
+		expect(eventNames[0]).toContain('Event 1');
+		expect(eventNames[1]).toContain('Event 2');
+		expect(eventNames[2]).toContain('Event 3');
+		expect(eventNames[3]).toContain('Event 4');
+		expect(eventNames[4]).toContain('Event 5');
+	});
+});
+
+describe('NarrativeTimeline Component - First/Last Indicators (Issue #400)', () => {
+	let events: BaseEntity[];
+
+	beforeEach(() => {
+		events = [
+			createMockEntity({
+				id: 'event-1',
+				type: 'narrative_event',
+				name: 'First Event',
+				createdAt: new Date('2024-01-01T10:00:00'),
+				fields: { eventType: 'combat' }
+			}),
+			createMockEntity({
+				id: 'event-2',
+				type: 'narrative_event',
+				name: 'Middle Event',
+				createdAt: new Date('2024-01-02T10:00:00'),
+				fields: { eventType: 'scene' }
+			}),
+			createMockEntity({
+				id: 'event-3',
+				type: 'narrative_event',
+				name: 'Last Event',
+				createdAt: new Date('2024-01-03T10:00:00'),
+				fields: { eventType: 'montage' }
+			})
+		];
+	});
+
+	it('should pass isFirst=true to first event', () => {
+		const { container } = render(NarrativeTimeline, {
+			props: { events }
+		});
+
+		// First event should have isFirst prop
+		const firstEvent = container.querySelector('[data-event-type]');
+		expect(firstEvent).toHaveAttribute('data-is-first', 'true');
+	});
+
+	it('should pass isLast=true to last event', () => {
+		const { container } = render(NarrativeTimeline, {
+			props: { events }
+		});
+
+		// Last event should have isLast prop
+		const allEvents = container.querySelectorAll('[data-event-type]');
+		const lastEvent = allEvents[allEvents.length - 1];
+		expect(lastEvent).toHaveAttribute('data-is-last', 'true');
+	});
+
+	it('should not pass isFirst to middle events', () => {
+		const { container } = render(NarrativeTimeline, {
+			props: { events }
+		});
+
+		const allEvents = container.querySelectorAll('[data-event-type]');
+		const middleEvent = allEvents[1];
+
+		// Middle event should not be first
+		expect(middleEvent).not.toHaveAttribute('data-is-first', 'true');
+	});
+
+	it('should not pass isLast to middle events', () => {
+		const { container } = render(NarrativeTimeline, {
+			props: { events }
+		});
+
+		const allEvents = container.querySelectorAll('[data-event-type]');
+		const middleEvent = allEvents[1];
+
+		// Middle event should not be last
+		expect(middleEvent).not.toHaveAttribute('data-is-last', 'true');
+	});
+
+	it('should pass both isFirst and isLast to single event', () => {
+		const singleEvent = [events[0]];
+
+		const { container } = render(NarrativeTimeline, {
+			props: { events: singleEvent }
+		});
+
+		const eventElement = container.querySelector('[data-event-type]');
+		expect(eventElement).toHaveAttribute('data-is-first', 'true');
+		expect(eventElement).toHaveAttribute('data-is-last', 'true');
+	});
+
+	it('should handle two events correctly', () => {
+		const twoEvents = [events[0], events[1]];
+
+		const { container } = render(NarrativeTimeline, {
+			props: { events: twoEvents }
+		});
+
+		const allEvents = container.querySelectorAll('[data-event-type]');
+
+		// First should have isFirst
+		expect(allEvents[0]).toHaveAttribute('data-is-first', 'true');
+		expect(allEvents[0]).not.toHaveAttribute('data-is-last', 'true');
+
+		// Second should have isLast
+		expect(allEvents[1]).toHaveAttribute('data-is-last', 'true');
+		expect(allEvents[1]).not.toHaveAttribute('data-is-first', 'true');
+	});
+});
+
+describe('NarrativeTimeline Component - Callback Propagation (Issue #400)', () => {
+	let events: BaseEntity[];
+
+	beforeEach(() => {
+		events = [
+			createMockEntity({
+				id: 'event-1',
+				type: 'narrative_event',
+				name: 'Event 1',
+				createdAt: new Date('2024-01-01T10:00:00'),
+				fields: {
+					eventType: 'combat',
+					sourceId: 'combat-1'
+				}
+			}),
+			createMockEntity({
+				id: 'event-2',
+				type: 'narrative_event',
+				name: 'Event 2',
+				createdAt: new Date('2024-01-02T10:00:00'),
+				fields: {
+					eventType: 'scene',
+					sourceId: 'scene-1'
+				}
+			})
+		];
+	});
+
+	it('should pass onViewSource to TimelineEvent components', () => {
+		const onViewSource = vi.fn();
+
+		const { container } = render(NarrativeTimeline, {
+			props: {
+				events,
+				onViewSource
+			}
+		});
+
+		// TimelineEvent components should receive onViewSource
+		expect(container).toBeInTheDocument();
+	});
+
+	it('should pass onLinkEvent to TimelineEvent components', () => {
+		const onLinkEvent = vi.fn();
+
+		const { container } = render(NarrativeTimeline, {
+			props: {
+				events,
+				onLinkEvent
+			}
+		});
+
+		// TimelineEvent components should receive onLinkEvent
+		expect(container).toBeInTheDocument();
+	});
+
+	it('should handle missing callbacks gracefully', () => {
+		const { container } = render(NarrativeTimeline, {
+			props: { events }
+		});
+
+		// Should render without callbacks
+		expect(container).toBeInTheDocument();
+	});
+});
+
+describe('NarrativeTimeline Component - Session Filtering (Issue #400)', () => {
+	let events: BaseEntity[];
+
+	beforeEach(() => {
+		events = [
+			createMockEntity({
+				id: 'event-1',
+				type: 'narrative_event',
+				name: 'Session 1 Event',
+				createdAt: new Date('2024-01-01T10:00:00'),
+				fields: {
+					eventType: 'combat',
+					sessionId: 'session-1'
+				}
+			}),
+			createMockEntity({
+				id: 'event-2',
+				type: 'narrative_event',
+				name: 'Session 2 Event',
+				createdAt: new Date('2024-01-02T10:00:00'),
+				fields: {
+					eventType: 'scene',
+					sessionId: 'session-2'
+				}
+			}),
+			createMockEntity({
+				id: 'event-3',
+				type: 'narrative_event',
+				name: 'Another Session 1 Event',
+				createdAt: new Date('2024-01-03T10:00:00'),
+				fields: {
+					eventType: 'montage',
+					sessionId: 'session-1'
+				}
+			})
+		];
+	});
+
+	it('should show all events when sessionId is not provided', () => {
+		render(NarrativeTimeline, {
+			props: { events }
+		});
+
+		expect(screen.getByText('Session 1 Event')).toBeInTheDocument();
+		expect(screen.getByText('Session 2 Event')).toBeInTheDocument();
+		expect(screen.getByText('Another Session 1 Event')).toBeInTheDocument();
+	});
+
+	it('should filter events by sessionId when provided', () => {
+		render(NarrativeTimeline, {
+			props: {
+				events,
+				sessionId: 'session-1'
+			}
+		});
+
+		// Should show only session-1 events
+		expect(screen.getByText('Session 1 Event')).toBeInTheDocument();
+		expect(screen.getByText('Another Session 1 Event')).toBeInTheDocument();
+
+		// Should not show session-2 events
+		expect(screen.queryByText('Session 2 Event')).not.toBeInTheDocument();
+	});
+
+	it('should show empty state when sessionId has no matching events', () => {
+		render(NarrativeTimeline, {
+			props: {
+				events,
+				sessionId: 'session-999',
+				showEmpty: true
+			}
+		});
+
+		// Should show empty state
+		expect(screen.getByText(/no events/i)).toBeInTheDocument();
+	});
+
+	it('should handle events without sessionId field', () => {
+		const eventsWithoutSession = [
+			createMockEntity({
+				id: 'event-1',
+				type: 'narrative_event',
+				name: 'Event without Session',
+				createdAt: new Date('2024-01-01T10:00:00'),
+				fields: {
+					eventType: 'combat'
+				}
+			})
+		];
+
+		render(NarrativeTimeline, {
+			props: {
+				events: eventsWithoutSession,
+				sessionId: 'session-1'
+			}
+		});
+
+		// Event without sessionId should not show when filtering
+		expect(screen.queryByText('Event without Session')).not.toBeInTheDocument();
+	});
+});
+
+describe('NarrativeTimeline Component - Layout and Styling (Issue #400)', () => {
+	let events: BaseEntity[];
+
+	beforeEach(() => {
+		events = [
+			createMockEntity({
+				id: 'event-1',
+				type: 'narrative_event',
+				name: 'Event 1',
+				createdAt: new Date('2024-01-01T10:00:00'),
+				fields: { eventType: 'combat' }
+			}),
+			createMockEntity({
+				id: 'event-2',
+				type: 'narrative_event',
+				name: 'Event 2',
+				createdAt: new Date('2024-01-02T10:00:00'),
+				fields: { eventType: 'scene' }
+			})
+		];
+	});
+
+	it('should have vertical timeline layout', () => {
+		const { container } = render(NarrativeTimeline, {
+			props: { events }
+		});
+
+		// Should have container with vertical layout
+		const timeline = container.querySelector('[class*="timeline"], [role="list"]');
+		expect(timeline).toBeInTheDocument();
+	});
+
+	it('should space events appropriately', () => {
+		const { container } = render(NarrativeTimeline, {
+			props: { events }
+		});
+
+		// Timeline should have spacing between events
+		const timeline = container.querySelector('[class*="timeline"], [class*="space-y"]');
+		expect(timeline).toBeInTheDocument();
+	});
+
+	it('should have responsive design classes', () => {
+		const { container } = render(NarrativeTimeline, {
+			props: { events }
+		});
+
+		// Container should have responsive classes
+		expect(container.firstChild).toBeInTheDocument();
+	});
+});
+
+describe('NarrativeTimeline Component - Accessibility (Issue #400)', () => {
+	let events: BaseEntity[];
+
+	beforeEach(() => {
+		events = [
+			createMockEntity({
+				id: 'event-1',
+				type: 'narrative_event',
+				name: 'Event 1',
+				createdAt: new Date('2024-01-01T10:00:00'),
+				fields: { eventType: 'combat' }
+			})
+		];
+	});
+
+	it('should use semantic HTML for timeline container', () => {
+		const { container } = render(NarrativeTimeline, {
+			props: { events }
+		});
+
+		// Should use ol, ul, or role="list"
+		const list = container.querySelector('ol, ul, [role="list"]');
+		expect(list).toBeInTheDocument();
+	});
+
+	it('should have aria-label for timeline', () => {
+		const { container } = render(NarrativeTimeline, {
+			props: { events }
+		});
+
+		const timeline = container.querySelector('[aria-label]');
+		expect(timeline).toBeInTheDocument();
+	});
+
+	it('should be screen reader friendly', () => {
+		const { container } = render(NarrativeTimeline, {
+			props: { events }
+		});
+
+		// Timeline should have proper ARIA attributes
+		const timeline = container.querySelector('[role="list"], ol, ul');
+		expect(timeline).toBeInTheDocument();
+	});
+});
+
+describe('NarrativeTimeline Component - Edge Cases (Issue #400)', () => {
+	it('should handle null events array', () => {
+		const { container } = render(NarrativeTimeline, {
+			props: {
+				events: null as any
+			}
+		});
+
+		// Should render without crashing
+		expect(container).toBeInTheDocument();
+	});
+
+	it('should handle undefined events array', () => {
+		const { container } = render(NarrativeTimeline, {
+			props: {
+				events: undefined as any
+			}
+		});
+
+		// Should render without crashing
+		expect(container).toBeInTheDocument();
+	});
+
+	it('should handle events with missing createdAt', () => {
+		const events = [
+			createMockEntity({
+				id: 'event-1',
+				type: 'narrative_event',
+				name: 'Event without Date',
+				createdAt: undefined as any,
+				fields: { eventType: 'combat' }
+			})
+		];
+
+		const { container } = render(NarrativeTimeline, {
+			props: { events }
+		});
+
+		// Should render, possibly with fallback ordering
+		expect(container).toBeInTheDocument();
+	});
+
+	it('should handle very large number of events', () => {
+		const manyEvents = Array.from({ length: 100 }, (_, i) =>
+			createMockEntity({
+				id: `event-${i}`,
+				type: 'narrative_event',
+				name: `Event ${i}`,
+				createdAt: new Date(`2024-01-${String(i % 28 + 1).padStart(2, '0')}T10:00:00`),
+				fields: { eventType: 'combat' }
+			})
+		);
+
+		const { container } = render(NarrativeTimeline, {
+			props: { events: manyEvents }
+		});
+
+		expect(container).toBeInTheDocument();
+	});
+
+	it('should handle events with invalid type field', () => {
+		const events = [
+			{
+				...createMockEntity({
+					id: 'event-1',
+					name: 'Invalid Event'
+				}),
+				type: 'not_narrative_event' as any
+			}
+		];
+
+		const { container } = render(NarrativeTimeline, {
+			props: { events }
+		});
+
+		expect(container).toBeInTheDocument();
+	});
+});
+
+describe('NarrativeTimeline Component - Dynamic Updates (Issue #400)', () => {
+	it('should update when events prop changes', async () => {
+		const initialEvents = [
+			createMockEntity({
+				id: 'event-1',
+				type: 'narrative_event',
+				name: 'Initial Event',
+				createdAt: new Date('2024-01-01T10:00:00'),
+				fields: { eventType: 'combat' }
+			})
+		];
+
+		const { rerender } = render(NarrativeTimeline, {
+			props: { events: initialEvents }
+		});
+
+		expect(screen.getByText('Initial Event')).toBeInTheDocument();
+
+		// Update with new events
+		const updatedEvents = [
+			...initialEvents,
+			createMockEntity({
+				id: 'event-2',
+				type: 'narrative_event',
+				name: 'New Event',
+				createdAt: new Date('2024-01-02T10:00:00'),
+				fields: { eventType: 'scene' }
+			})
+		];
+
+		rerender({ events: updatedEvents });
+
+		expect(screen.getByText('Initial Event')).toBeInTheDocument();
+		expect(screen.getByText('New Event')).toBeInTheDocument();
+	});
+
+	it('should update when sessionId filter changes', () => {
+		const events = [
+			createMockEntity({
+				id: 'event-1',
+				type: 'narrative_event',
+				name: 'Session 1 Event',
+				createdAt: new Date('2024-01-01T10:00:00'),
+				fields: {
+					eventType: 'combat',
+					sessionId: 'session-1'
+				}
+			}),
+			createMockEntity({
+				id: 'event-2',
+				type: 'narrative_event',
+				name: 'Session 2 Event',
+				createdAt: new Date('2024-01-02T10:00:00'),
+				fields: {
+					eventType: 'scene',
+					sessionId: 'session-2'
+				}
+			})
+		];
+
+		const { rerender } = render(NarrativeTimeline, {
+			props: {
+				events,
+				sessionId: 'session-1'
+			}
+		});
+
+		expect(screen.getByText('Session 1 Event')).toBeInTheDocument();
+		expect(screen.queryByText('Session 2 Event')).not.toBeInTheDocument();
+
+		// Change filter
+		rerender({
+			events,
+			sessionId: 'session-2'
+		});
+
+		expect(screen.queryByText('Session 1 Event')).not.toBeInTheDocument();
+		expect(screen.getByText('Session 2 Event')).toBeInTheDocument();
+	});
+
+	it('should handle transition from empty to populated', () => {
+		const { rerender } = render(NarrativeTimeline, {
+			props: {
+				events: [],
+				showEmpty: true
+			}
+		});
+
+		expect(screen.getByText(/no events/i)).toBeInTheDocument();
+
+		const newEvents = [
+			createMockEntity({
+				id: 'event-1',
+				type: 'narrative_event',
+				name: 'First Event',
+				createdAt: new Date('2024-01-01T10:00:00'),
+				fields: { eventType: 'combat' }
+			})
+		];
+
+		rerender({
+			events: newEvents,
+			showEmpty: true
+		});
+
+		expect(screen.queryByText(/no events/i)).not.toBeInTheDocument();
+		expect(screen.getByText('First Event')).toBeInTheDocument();
+	});
+});
+
+describe('NarrativeTimeline Component - Integration (Issue #400)', () => {
+	it('should work with both callbacks and session filtering', () => {
+		const onViewSource = vi.fn();
+		const onLinkEvent = vi.fn();
+
+		const events = [
+			createMockEntity({
+				id: 'event-1',
+				type: 'narrative_event',
+				name: 'Filtered Event',
+				createdAt: new Date('2024-01-01T10:00:00'),
+				fields: {
+					eventType: 'combat',
+					sessionId: 'session-1',
+					sourceId: 'combat-1'
+				}
+			}),
+			createMockEntity({
+				id: 'event-2',
+				type: 'narrative_event',
+				name: 'Excluded Event',
+				createdAt: new Date('2024-01-02T10:00:00'),
+				fields: {
+					eventType: 'scene',
+					sessionId: 'session-2',
+					sourceId: 'scene-1'
+				}
+			})
+		];
+
+		render(NarrativeTimeline, {
+			props: {
+				events,
+				sessionId: 'session-1',
+				onViewSource,
+				onLinkEvent
+			}
+		});
+
+		expect(screen.getByText('Filtered Event')).toBeInTheDocument();
+		expect(screen.queryByText('Excluded Event')).not.toBeInTheDocument();
+	});
+
+	it('should maintain event order after filtering', () => {
+		const events = [
+			createMockEntity({
+				id: 'event-3',
+				type: 'narrative_event',
+				name: 'Event 3',
+				createdAt: new Date('2024-01-03T10:00:00'),
+				fields: {
+					eventType: 'combat',
+					sessionId: 'session-1'
+				}
+			}),
+			createMockEntity({
+				id: 'event-1',
+				type: 'narrative_event',
+				name: 'Event 1',
+				createdAt: new Date('2024-01-01T10:00:00'),
+				fields: {
+					eventType: 'scene',
+					sessionId: 'session-1'
+				}
+			}),
+			createMockEntity({
+				id: 'event-2',
+				type: 'narrative_event',
+				name: 'Event 2',
+				createdAt: new Date('2024-01-02T10:00:00'),
+				fields: {
+					eventType: 'montage',
+					sessionId: 'session-2'
+				}
+			})
+		];
+
+		const { container } = render(NarrativeTimeline, {
+			props: {
+				events,
+				sessionId: 'session-1'
+			}
+		});
+
+		const eventNames = Array.from(container.querySelectorAll('[data-event-type]')).map(
+			(el) => el.textContent
+		);
+
+		// Should be ordered chronologically: Event 1, Event 3
+		expect(eventNames[0]).toContain('Event 1');
+		expect(eventNames[1]).toContain('Event 3');
+	});
+});

--- a/src/lib/components/narrative/TimelineEvent.svelte
+++ b/src/lib/components/narrative/TimelineEvent.svelte
@@ -1,0 +1,202 @@
+<script lang="ts">
+	/**
+	 * TimelineEvent Component
+	 *
+	 * Issue #400: Build Timeline View UI (GREEN phase of TDD)
+	 *
+	 * Displays a single event in a vertical timeline view, with:
+	 * - Event-type-specific icons (Swords, Mountain, Theater, MessageCircle, Milestone)
+	 * - Vertical connecting lines (hidden for first/last events)
+	 * - View Source button (when sourceId is present)
+	 * - Link button (when showLinkButton=true)
+	 * - Event-type-specific color styling via data-event-type attribute
+	 * - Formatted date display
+	 */
+
+	import { Swords, Mountain, Theater, MessageCircle, Milestone } from 'lucide-svelte';
+	import type { BaseEntity } from '$lib/types';
+
+	interface Props {
+		event: BaseEntity;
+		isFirst?: boolean;
+		isLast?: boolean;
+		onViewSource?: (eventType: string, sourceId: string) => void;
+		showLinkButton?: boolean;
+		onLinkEvent?: (eventId: string) => void;
+	}
+
+	let { event, isFirst = false, isLast = false, onViewSource, showLinkButton = false, onLinkEvent }: Props = $props();
+
+	// Get event type for rendering
+	const eventTypeValue = $derived(event.fields?.eventType as string | null | undefined);
+
+	// Get event type for data attribute and styling
+	const eventType = $derived((event.fields?.eventType as string) || 'other');
+
+	// Get outcome if present
+	const outcome = $derived.by(() => {
+		const outcomeValue = event.fields?.outcome as string | null | undefined;
+		return outcomeValue && outcomeValue.trim() !== '' ? outcomeValue : null;
+	});
+
+	// Get sourceId if present
+	const sourceId = $derived.by(() => {
+		const id = event.fields?.sourceId as string | null | undefined;
+		return id && id.trim() !== '' ? id : null;
+	});
+
+	// Format date
+	function formatDate(date: Date): string {
+		if (!date || !(date instanceof Date)) return '';
+
+		const options: Intl.DateTimeFormatOptions = {
+			month: 'short',
+			day: 'numeric',
+			hour: 'numeric',
+			minute: '2-digit'
+		};
+
+		return date.toLocaleString('en-US', options);
+	}
+
+	// Handle View Source click
+	function handleViewSource() {
+		if (onViewSource && sourceId) {
+			onViewSource(eventType, sourceId);
+		}
+	}
+
+	// Handle Link click
+	function handleLink() {
+		if (onLinkEvent) {
+			onLinkEvent(event.id);
+		}
+	}
+</script>
+
+<article
+	class="timeline-event relative flex gap-4"
+	data-event-type={eventType}
+	data-is-first={isFirst ? 'true' : undefined}
+	data-is-last={isLast ? 'true' : undefined}
+>
+	<!-- Timeline vertical line and icon -->
+	<div class="relative flex flex-col items-center">
+		<!-- Top connecting line -->
+		<div class="timeline-line line-top w-0.5 flex-1 bg-gray-300 {isFirst ? 'invisible' : ''}"></div>
+
+		<!-- Icon circle -->
+		<div class="icon-container z-10 flex h-10 w-10 items-center justify-center rounded-full border-2 border-gray-300 bg-white">
+			{#if eventTypeValue === 'combat'}
+				<Swords class="h-5 w-5 text-gray-600" aria-hidden="true" />
+			{:else if eventTypeValue === 'montage'}
+				<Mountain class="h-5 w-5 text-gray-600" aria-hidden="true" />
+			{:else if eventTypeValue === 'scene'}
+				<Theater class="h-5 w-5 text-gray-600" aria-hidden="true" />
+			{:else if eventTypeValue === 'negotiation'}
+				<MessageCircle class="h-5 w-5 text-gray-600" aria-hidden="true" />
+			{:else}
+				<Milestone class="h-5 w-5 text-gray-600" aria-hidden="true" />
+			{/if}
+		</div>
+
+		<!-- Bottom connecting line -->
+		<div class="timeline-line line-bottom w-0.5 flex-1 bg-gray-300 {isLast ? 'invisible' : ''}"></div>
+	</div>
+
+	<!-- Event content -->
+	<div class="flex-1 pb-8">
+		<!-- Event header -->
+		<div class="mb-2">
+			<h3 class="text-lg font-semibold text-gray-900">{event.name}</h3>
+			{#if event.createdAt}
+				<p class="text-sm text-gray-500">{formatDate(event.createdAt)}</p>
+			{/if}
+		</div>
+
+		<!-- Event description -->
+		{#if event.description && event.description.trim() !== ''}
+			<p class="mb-2 text-sm text-gray-700 line-clamp-3">{event.description}</p>
+		{/if}
+
+		<!-- Outcome -->
+		{#if outcome}
+			<p class="mb-3 text-sm text-gray-600">{outcome}</p>
+		{/if}
+
+		<!-- Action buttons -->
+		<div class="flex gap-2">
+			{#if sourceId}
+				<button
+					type="button"
+					onclick={handleViewSource}
+					class="rounded border border-gray-300 bg-white px-3 py-1 text-sm font-medium text-gray-700 hover:bg-gray-50"
+				>
+					View Source
+				</button>
+			{/if}
+
+			{#if showLinkButton}
+				<button
+					type="button"
+					onclick={handleLink}
+					class="rounded border border-gray-300 bg-white px-3 py-1 text-sm font-medium text-gray-700 hover:bg-gray-50"
+				>
+					Link
+				</button>
+			{/if}
+		</div>
+	</div>
+</article>
+
+<style>
+	.timeline-event {
+		min-height: 80px;
+	}
+
+	.line-top,
+	.line-bottom {
+		min-height: 1rem;
+	}
+
+	/* Event type specific icon colors */
+	[data-event-type='combat'] .icon-container {
+		border-color: #ef4444;
+		background-color: #fef2f2;
+	}
+	[data-event-type='combat'] :global(svg) {
+		color: #ef4444;
+	}
+
+	[data-event-type='montage'] .icon-container {
+		border-color: #8b5cf6;
+		background-color: #f5f3ff;
+	}
+	[data-event-type='montage'] :global(svg) {
+		color: #8b5cf6;
+	}
+
+	[data-event-type='scene'] .icon-container {
+		border-color: #3b82f6;
+		background-color: #eff6ff;
+	}
+	[data-event-type='scene'] :global(svg) {
+		color: #3b82f6;
+	}
+
+	[data-event-type='negotiation'] .icon-container {
+		border-color: #10b981;
+		background-color: #f0fdf4;
+	}
+	[data-event-type='negotiation'] :global(svg) {
+		color: #10b981;
+	}
+
+	/* Prevent text overflow */
+	.line-clamp-3 {
+		display: -webkit-box;
+		-webkit-line-clamp: 3;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+</style>

--- a/src/lib/components/narrative/TimelineEvent.test.ts
+++ b/src/lib/components/narrative/TimelineEvent.test.ts
@@ -1,0 +1,788 @@
+/**
+ * Tests for TimelineEvent Component
+ *
+ * Issue #400: Build Timeline View UI
+ *
+ * This component renders a single event in a vertical timeline view,
+ * displaying event details, icons based on event type, connecting lines,
+ * and action buttons for viewing source or linking events.
+ *
+ * These tests are written in the RED phase of TDD - they will FAIL until
+ * the component is implemented.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import TimelineEvent from './TimelineEvent.svelte';
+import { createMockEntity } from '../../../tests/utils/testUtils';
+import type { BaseEntity } from '$lib/types';
+
+describe('TimelineEvent Component - Basic Rendering (Issue #400)', () => {
+	let event: BaseEntity;
+
+	beforeEach(() => {
+		event = createMockEntity({
+			id: 'event-1',
+			type: 'narrative_event',
+			name: 'Battle at the Crossroads',
+			description: 'A fierce battle erupted',
+			fields: {
+				eventType: 'combat',
+				outcome: 'Victory in 5 rounds'
+			}
+		});
+	});
+
+	it('should render without crashing', () => {
+		const { container } = render(TimelineEvent, {
+			props: { event }
+		});
+		expect(container).toBeInTheDocument();
+	});
+
+	it('should render event name', () => {
+		render(TimelineEvent, {
+			props: { event }
+		});
+
+		expect(screen.getByText('Battle at the Crossroads')).toBeInTheDocument();
+	});
+
+	it('should display outcome field when present', () => {
+		render(TimelineEvent, {
+			props: { event }
+		});
+
+		expect(screen.getByText(/Victory in 5 rounds/i)).toBeInTheDocument();
+	});
+
+	it('should not display outcome when field is missing', () => {
+		const eventWithoutOutcome = createMockEntity({
+			id: 'event-2',
+			type: 'narrative_event',
+			name: 'Simple Event',
+			fields: {
+				eventType: 'scene'
+			}
+		});
+
+		render(TimelineEvent, {
+			props: { event: eventWithoutOutcome }
+		});
+
+		expect(screen.queryByText(/outcome/i)).not.toBeInTheDocument();
+	});
+
+	it('should handle empty outcome gracefully', () => {
+		const eventWithEmptyOutcome = createMockEntity({
+			id: 'event-3',
+			type: 'narrative_event',
+			name: 'Event with Empty Outcome',
+			fields: {
+				eventType: 'combat',
+				outcome: ''
+			}
+		});
+
+		const { container } = render(TimelineEvent, {
+			props: { event: eventWithEmptyOutcome }
+		});
+
+		expect(container).toBeInTheDocument();
+	});
+});
+
+describe('TimelineEvent Component - Event Type Icons (Issue #400)', () => {
+	it('should show Swords icon for combat events', () => {
+		const combatEvent = createMockEntity({
+			id: 'combat-1',
+			type: 'narrative_event',
+			name: 'Combat Event',
+			fields: {
+				eventType: 'combat'
+			}
+		});
+
+		const { container } = render(TimelineEvent, {
+			props: { event: combatEvent }
+		});
+
+		// Check for Swords icon (lucide-svelte)
+		const icon = container.querySelector('[class*="lucide-swords"]');
+		expect(icon).toBeInTheDocument();
+	});
+
+	it('should show correct icon for montage events', () => {
+		const montageEvent = createMockEntity({
+			id: 'montage-1',
+			type: 'narrative_event',
+			name: 'Montage Event',
+			fields: {
+				eventType: 'montage'
+			}
+		});
+
+		const { container } = render(TimelineEvent, {
+			props: { event: montageEvent }
+		});
+
+		// Check for montage icon (e.g., Film or Play)
+		const icon = container.querySelector('[class*="lucide"]');
+		expect(icon).toBeInTheDocument();
+	});
+
+	it('should show correct icon for scene events', () => {
+		const sceneEvent = createMockEntity({
+			id: 'scene-1',
+			type: 'narrative_event',
+			name: 'Scene Event',
+			fields: {
+				eventType: 'scene'
+			}
+		});
+
+		const { container } = render(TimelineEvent, {
+			props: { event: sceneEvent }
+		});
+
+		// Check for scene icon (e.g., MessageSquare or Drama)
+		const icon = container.querySelector('[class*="lucide"]');
+		expect(icon).toBeInTheDocument();
+	});
+
+	it('should show correct icon for negotiation events', () => {
+		const negotiationEvent = createMockEntity({
+			id: 'negotiation-1',
+			type: 'narrative_event',
+			name: 'Negotiation Event',
+			fields: {
+				eventType: 'negotiation'
+			}
+		});
+
+		const { container } = render(TimelineEvent, {
+			props: { event: negotiationEvent }
+		});
+
+		// Check for negotiation icon (e.g., Handshake or Users)
+		const icon = container.querySelector('[class*="lucide"]');
+		expect(icon).toBeInTheDocument();
+	});
+
+	it('should show fallback icon for other event types', () => {
+		const otherEvent = createMockEntity({
+			id: 'other-1',
+			type: 'narrative_event',
+			name: 'Other Event',
+			fields: {
+				eventType: 'other'
+			}
+		});
+
+		const { container } = render(TimelineEvent, {
+			props: { event: otherEvent }
+		});
+
+		// Check for fallback icon (e.g., Circle or Milestone)
+		const icon = container.querySelector('[class*="lucide"]');
+		expect(icon).toBeInTheDocument();
+	});
+
+	it('should show fallback icon for unknown event types', () => {
+		const unknownEvent = createMockEntity({
+			id: 'unknown-1',
+			type: 'narrative_event',
+			name: 'Unknown Event',
+			fields: {
+				eventType: 'custom_unknown_type'
+			}
+		});
+
+		const { container } = render(TimelineEvent, {
+			props: { event: unknownEvent }
+		});
+
+		// Should still render with fallback icon
+		const icon = container.querySelector('[class*="lucide"]');
+		expect(icon).toBeInTheDocument();
+	});
+});
+
+describe('TimelineEvent Component - Timeline Connecting Lines (Issue #400)', () => {
+	let event: BaseEntity;
+
+	beforeEach(() => {
+		event = createMockEntity({
+			id: 'event-1',
+			type: 'narrative_event',
+			name: 'Test Event',
+			fields: {
+				eventType: 'combat'
+			}
+		});
+	});
+
+	it('should display connecting line element', () => {
+		const { container } = render(TimelineEvent, {
+			props: { event }
+		});
+
+		// Should have timeline line elements (vertical connectors)
+		const line = container.querySelector('[class*="timeline-line"], [class*="connector"]');
+		expect(line).toBeInTheDocument();
+	});
+
+	it('should hide top line when isFirst is true', () => {
+		const { container } = render(TimelineEvent, {
+			props: {
+				event,
+				isFirst: true
+			}
+		});
+
+		// Top line should be hidden or have visibility class
+		const topLine = container.querySelector('[class*="top-line"], [class*="line-top"]');
+		if (topLine) {
+			expect(topLine).toHaveClass(/hidden|invisible|opacity-0/);
+		}
+	});
+
+	it('should hide bottom line when isLast is true', () => {
+		const { container } = render(TimelineEvent, {
+			props: {
+				event,
+				isLast: true
+			}
+		});
+
+		// Bottom line should be hidden or have visibility class
+		const bottomLine = container.querySelector('[class*="bottom-line"], [class*="line-bottom"]');
+		if (bottomLine) {
+			expect(bottomLine).toHaveClass(/hidden|invisible|opacity-0/);
+		}
+	});
+
+	it('should show both lines when isFirst and isLast are false', () => {
+		const { container } = render(TimelineEvent, {
+			props: {
+				event,
+				isFirst: false,
+				isLast: false
+			}
+		});
+
+		// Timeline should have visible connecting lines
+		const lines = container.querySelectorAll('[class*="line"], [class*="connector"]');
+		expect(lines.length).toBeGreaterThan(0);
+	});
+
+	it('should handle single event (both isFirst and isLast true)', () => {
+		const { container } = render(TimelineEvent, {
+			props: {
+				event,
+				isFirst: true,
+				isLast: true
+			}
+		});
+
+		// Should render without lines or with both hidden
+		expect(container).toBeInTheDocument();
+	});
+});
+
+describe('TimelineEvent Component - View Source Button (Issue #400)', () => {
+	let event: BaseEntity;
+
+	beforeEach(() => {
+		event = createMockEntity({
+			id: 'event-1',
+			type: 'narrative_event',
+			name: 'Combat Event',
+			fields: {
+				eventType: 'combat',
+				sourceId: 'combat-session-123'
+			}
+		});
+	});
+
+	it('should render View Source button when sourceId is present', () => {
+		render(TimelineEvent, {
+			props: { event }
+		});
+
+		const viewSourceButton = screen.getByRole('button', { name: /view source/i });
+		expect(viewSourceButton).toBeInTheDocument();
+	});
+
+	it('should not render View Source button when sourceId is missing', () => {
+		const eventWithoutSource = createMockEntity({
+			id: 'event-2',
+			type: 'narrative_event',
+			name: 'Event without Source',
+			fields: {
+				eventType: 'scene'
+			}
+		});
+
+		render(TimelineEvent, {
+			props: { event: eventWithoutSource }
+		});
+
+		const viewSourceButton = screen.queryByRole('button', { name: /view source/i });
+		expect(viewSourceButton).not.toBeInTheDocument();
+	});
+
+	it('should call onViewSource with eventType and sourceId when clicked', async () => {
+		const onViewSource = vi.fn();
+
+		render(TimelineEvent, {
+			props: {
+				event,
+				onViewSource
+			}
+		});
+
+		const viewSourceButton = screen.getByRole('button', { name: /view source/i });
+		await fireEvent.click(viewSourceButton);
+
+		expect(onViewSource).toHaveBeenCalledWith('combat', 'combat-session-123');
+	});
+
+	it('should handle missing onViewSource callback gracefully', async () => {
+		render(TimelineEvent, {
+			props: { event }
+		});
+
+		const viewSourceButton = screen.getByRole('button', { name: /view source/i });
+
+		// Should not throw when callback is not provided
+		await expect(async () => {
+			await fireEvent.click(viewSourceButton);
+		}).not.toThrow();
+	});
+
+	it('should pass correct eventType for different event types', async () => {
+		const onViewSource = vi.fn();
+
+		const montageEvent = createMockEntity({
+			id: 'montage-1',
+			type: 'narrative_event',
+			name: 'Montage Event',
+			fields: {
+				eventType: 'montage',
+				sourceId: 'montage-session-456'
+			}
+		});
+
+		render(TimelineEvent, {
+			props: {
+				event: montageEvent,
+				onViewSource
+			}
+		});
+
+		const viewSourceButton = screen.getByRole('button', { name: /view source/i });
+		await fireEvent.click(viewSourceButton);
+
+		expect(onViewSource).toHaveBeenCalledWith('montage', 'montage-session-456');
+	});
+});
+
+describe('TimelineEvent Component - Link Button (Issue #400)', () => {
+	let event: BaseEntity;
+
+	beforeEach(() => {
+		event = createMockEntity({
+			id: 'event-1',
+			type: 'narrative_event',
+			name: 'Test Event',
+			fields: {
+				eventType: 'combat'
+			}
+		});
+	});
+
+	it('should show Link button when showLinkButton is true', () => {
+		render(TimelineEvent, {
+			props: {
+				event,
+				showLinkButton: true
+			}
+		});
+
+		const linkButton = screen.getByRole('button', { name: /link/i });
+		expect(linkButton).toBeInTheDocument();
+	});
+
+	it('should not show Link button when showLinkButton is false', () => {
+		render(TimelineEvent, {
+			props: {
+				event,
+				showLinkButton: false
+			}
+		});
+
+		const linkButton = screen.queryByRole('button', { name: /link/i });
+		expect(linkButton).not.toBeInTheDocument();
+	});
+
+	it('should not show Link button by default (when showLinkButton is undefined)', () => {
+		render(TimelineEvent, {
+			props: { event }
+		});
+
+		const linkButton = screen.queryByRole('button', { name: /link/i });
+		expect(linkButton).not.toBeInTheDocument();
+	});
+
+	it('should call onLinkEvent with eventId when Link button is clicked', async () => {
+		const onLinkEvent = vi.fn();
+
+		render(TimelineEvent, {
+			props: {
+				event,
+				showLinkButton: true,
+				onLinkEvent
+			}
+		});
+
+		const linkButton = screen.getByRole('button', { name: /link/i });
+		await fireEvent.click(linkButton);
+
+		expect(onLinkEvent).toHaveBeenCalledWith('event-1');
+	});
+
+	it('should handle missing onLinkEvent callback gracefully', async () => {
+		render(TimelineEvent, {
+			props: {
+				event,
+				showLinkButton: true
+			}
+		});
+
+		const linkButton = screen.getByRole('button', { name: /link/i });
+
+		// Should not throw when callback is not provided
+		await expect(async () => {
+			await fireEvent.click(linkButton);
+		}).not.toThrow();
+	});
+});
+
+describe('TimelineEvent Component - Event Type Styling (Issue #400)', () => {
+	it('should apply combat-specific color styling', () => {
+		const combatEvent = createMockEntity({
+			id: 'combat-1',
+			type: 'narrative_event',
+			name: 'Combat Event',
+			fields: {
+				eventType: 'combat'
+			}
+		});
+
+		const { container } = render(TimelineEvent, {
+			props: { event: combatEvent }
+		});
+
+		// Should have combat-specific styling (e.g., red/orange colors)
+		const eventElement = container.querySelector('[data-event-type="combat"]');
+		expect(eventElement).toBeInTheDocument();
+	});
+
+	it('should apply montage-specific color styling', () => {
+		const montageEvent = createMockEntity({
+			id: 'montage-1',
+			type: 'narrative_event',
+			name: 'Montage Event',
+			fields: {
+				eventType: 'montage'
+			}
+		});
+
+		const { container } = render(TimelineEvent, {
+			props: { event: montageEvent }
+		});
+
+		// Should have montage-specific styling
+		const eventElement = container.querySelector('[data-event-type="montage"]');
+		expect(eventElement).toBeInTheDocument();
+	});
+
+	it('should apply scene-specific color styling', () => {
+		const sceneEvent = createMockEntity({
+			id: 'scene-1',
+			type: 'narrative_event',
+			name: 'Scene Event',
+			fields: {
+				eventType: 'scene'
+			}
+		});
+
+		const { container } = render(TimelineEvent, {
+			props: { event: sceneEvent }
+		});
+
+		// Should have scene-specific styling
+		const eventElement = container.querySelector('[data-event-type="scene"]');
+		expect(eventElement).toBeInTheDocument();
+	});
+
+	it('should apply default styling for other event types', () => {
+		const otherEvent = createMockEntity({
+			id: 'other-1',
+			type: 'narrative_event',
+			name: 'Other Event',
+			fields: {
+				eventType: 'other'
+			}
+		});
+
+		const { container } = render(TimelineEvent, {
+			props: { event: otherEvent }
+		});
+
+		// Should have fallback styling
+		const eventElement = container.querySelector('[data-event-type]');
+		expect(eventElement).toBeInTheDocument();
+	});
+});
+
+describe('TimelineEvent Component - Event Description (Issue #400)', () => {
+	it('should display event description when present', () => {
+		const event = createMockEntity({
+			id: 'event-1',
+			type: 'narrative_event',
+			name: 'Event with Description',
+			description: 'A detailed description of what happened',
+			fields: {
+				eventType: 'scene'
+			}
+		});
+
+		render(TimelineEvent, {
+			props: { event }
+		});
+
+		expect(screen.getByText(/A detailed description of what happened/i)).toBeInTheDocument();
+	});
+
+	it('should handle empty description gracefully', () => {
+		const event = createMockEntity({
+			id: 'event-2',
+			type: 'narrative_event',
+			name: 'Event without Description',
+			description: '',
+			fields: {
+				eventType: 'combat'
+			}
+		});
+
+		const { container } = render(TimelineEvent, {
+			props: { event }
+		});
+
+		expect(container).toBeInTheDocument();
+	});
+
+	it('should truncate or show excerpt of long descriptions', () => {
+		const longDescription =
+			'This is a very long description that goes on and on with lots of details about the event that happened during this particular moment in the campaign timeline. It includes many sentences and paragraphs of information.';
+
+		const event = createMockEntity({
+			id: 'event-3',
+			type: 'narrative_event',
+			name: 'Event with Long Description',
+			description: longDescription,
+			fields: {
+				eventType: 'scene'
+			}
+		});
+
+		const { container } = render(TimelineEvent, {
+			props: { event }
+		});
+
+		expect(container).toBeInTheDocument();
+	});
+});
+
+describe('TimelineEvent Component - Accessibility (Issue #400)', () => {
+	let event: BaseEntity;
+
+	beforeEach(() => {
+		event = createMockEntity({
+			id: 'event-1',
+			type: 'narrative_event',
+			name: 'Accessible Event',
+			fields: {
+				eventType: 'combat',
+				outcome: 'Victory'
+			}
+		});
+	});
+
+	it('should have semantic HTML structure', () => {
+		const { container } = render(TimelineEvent, {
+			props: { event }
+		});
+
+		// Should use article or similar semantic element
+		const article = container.querySelector('article, [role="article"]');
+		expect(article).toBeInTheDocument();
+	});
+
+	it('should have accessible button labels', () => {
+		render(TimelineEvent, {
+			props: {
+				event,
+				showLinkButton: true
+			}
+		});
+
+		const linkButton = screen.getByRole('button', { name: /link/i });
+		expect(linkButton).toHaveAccessibleName();
+	});
+
+	it('should have proper icon alt text or aria labels', () => {
+		const { container } = render(TimelineEvent, {
+			props: { event }
+		});
+
+		const icon = container.querySelector('[class*="lucide"]');
+		// Icon should have aria-label or be decorative with aria-hidden
+		expect(icon).toBeInTheDocument();
+	});
+
+	it('should be keyboard navigable', () => {
+		render(TimelineEvent, {
+			props: {
+				event,
+				showLinkButton: true
+			}
+		});
+
+		const buttons = screen.getAllByRole('button');
+		buttons.forEach((button) => {
+			expect(button).not.toHaveAttribute('tabindex', '-1');
+		});
+	});
+});
+
+describe('TimelineEvent Component - Edge Cases (Issue #400)', () => {
+	it('should handle event with very long name', () => {
+		const event = createMockEntity({
+			id: 'event-1',
+			type: 'narrative_event',
+			name: 'This is an incredibly long event name that might need to be truncated or wrapped in the UI to prevent layout issues',
+			fields: {
+				eventType: 'combat'
+			}
+		});
+
+		const { container } = render(TimelineEvent, {
+			props: { event }
+		});
+
+		expect(container).toBeInTheDocument();
+	});
+
+	it('should handle event with missing eventType field', () => {
+		const event = createMockEntity({
+			id: 'event-2',
+			type: 'narrative_event',
+			name: 'Event without Type',
+			fields: {}
+		});
+
+		const { container } = render(TimelineEvent, {
+			props: { event }
+		});
+
+		// Should render with fallback icon/styling
+		expect(container).toBeInTheDocument();
+	});
+
+	it('should handle event with null fields', () => {
+		const event = createMockEntity({
+			id: 'event-3',
+			type: 'narrative_event',
+			name: 'Event with Null Fields',
+			fields: {
+				eventType: null,
+				outcome: null
+			}
+		});
+
+		const { container } = render(TimelineEvent, {
+			props: { event }
+		});
+
+		expect(container).toBeInTheDocument();
+	});
+
+	it('should handle both showLinkButton true and sourceId present', () => {
+		const event = createMockEntity({
+			id: 'event-4',
+			type: 'narrative_event',
+			name: 'Event with Both Buttons',
+			fields: {
+				eventType: 'combat',
+				sourceId: 'source-123'
+			}
+		});
+
+		render(TimelineEvent, {
+			props: {
+				event,
+				showLinkButton: true
+			}
+		});
+
+		// Should show both buttons
+		const linkButton = screen.getByRole('button', { name: /link/i });
+		const viewSourceButton = screen.getByRole('button', { name: /view source/i });
+
+		expect(linkButton).toBeInTheDocument();
+		expect(viewSourceButton).toBeInTheDocument();
+	});
+});
+
+describe('TimelineEvent Component - Date Display (Issue #400)', () => {
+	it('should display event creation date', () => {
+		const event = createMockEntity({
+			id: 'event-1',
+			type: 'narrative_event',
+			name: 'Event with Date',
+			createdAt: new Date('2024-01-15T10:30:00'),
+			fields: {
+				eventType: 'combat'
+			}
+		});
+
+		const { container } = render(TimelineEvent, {
+			props: { event }
+		});
+
+		// Should display formatted date
+		expect(container).toBeInTheDocument();
+	});
+
+	it('should format date in a readable way', () => {
+		const event = createMockEntity({
+			id: 'event-2',
+			type: 'narrative_event',
+			name: 'Event',
+			createdAt: new Date('2024-01-15T10:30:00'),
+			fields: {
+				eventType: 'scene'
+			}
+		});
+
+		const { container } = render(TimelineEvent, {
+			props: { event }
+		});
+
+		// Date should be formatted (exact format depends on implementation)
+		expect(container).toBeInTheDocument();
+	});
+});

--- a/src/lib/components/narrative/index.ts
+++ b/src/lib/components/narrative/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Narrative Components - Barrel exports
+ *
+ * Issue #400: Build Timeline View UI (GREEN phase of TDD)
+ */
+
+export { default as TimelineEvent } from './TimelineEvent.svelte';
+export { default as NarrativeTimeline } from './NarrativeTimeline.svelte';

--- a/src/lib/config/entityTypes.narrative-event.test.md
+++ b/src/lib/config/entityTypes.narrative-event.test.md
@@ -1,0 +1,158 @@
+# Narrative Event Entity Type Tests - Test Strategy
+
+## Overview
+
+This test suite validates the `narrative_event` entity type for Issue #398. Following TDD best practices, these tests were written in the RED phase and will FAIL until the implementation is complete.
+
+## Testing Strategy
+
+### 1. Entity Type Existence
+- Verifies `narrative_event` exists in `BUILT_IN_ENTITY_TYPES`
+- Confirms it's retrievable via `getEntityTypeDefinition()`
+
+### 2. Metadata Validation
+Tests that the entity type has correct metadata:
+- Type identifier: `'narrative_event'`
+- Label: `'Narrative Event'`
+- Label Plural: `'Narrative Events'`
+- Icon: `'milestone'`
+- Color: `'amber'`
+- Built-in flag: `true`
+- Default relationships array defined
+
+### 3. Field Definitions Coverage
+
+#### eventType Field
+- **Type**: `select`
+- **Label**: `'Event Type'`
+- **Options**: `['scene', 'combat', 'montage', 'negotiation', 'other']`
+- **Required**: `true`
+- **Order**: `1`
+
+**Test Coverage**:
+- Field exists
+- Correct label and type
+- Exactly 5 options with correct values
+- Required flag set
+- Proper order value
+
+#### sourceId Field
+- **Type**: `text`
+- **Label**: `'Source ID'`
+- **Required**: `false`
+- **Order**: `2`
+- **Help Text**: `'ID of the linked combat, montage, or scene'`
+
+**Test Coverage**:
+- Field exists
+- Correct label and type
+- Not required (optional)
+- Help text present and correct
+- Proper order value
+
+#### outcome Field
+- **Type**: `text`
+- **Label**: `'Outcome'`
+- **Required**: `false`
+- **Order**: `3`
+
+**Test Coverage**:
+- Field exists
+- Correct label and type
+- Not required (optional)
+- Proper order value
+
+#### session Field
+- **Type**: `entity-ref`
+- **Label**: `'Session'`
+- **Entity Types**: `['session']`
+- **Required**: `false`
+- **Order**: `4`
+
+**Test Coverage**:
+- Field exists
+- Correct label and type
+- References correct entity type
+- Not required (optional)
+- Proper order value
+
+### 4. Field Ordering Tests
+- All fields have `order` property defined
+- Order values are unique (no duplicates)
+- Order values are consecutive (1, 2, 3, 4)
+- Fields appear in correct sequence
+
+### 5. Default Relationships
+Tests the three required default relationships:
+- `'leads_to'` - for sequential narrative events
+- `'follows'` - for reverse sequential relationships
+- `'part_of'` - for session association
+
+**Test Coverage**:
+- Exactly 3 relationships
+- Each relationship is present
+- Relationships are in correct order
+
+### 6. Integration Tests
+
+#### Built-in Types Count
+- Verifies total built-in types count is 13 (12 original + narrative_event)
+- Ensures unique type identifier (no duplicates)
+- No duplicate field keys within the entity type
+
+#### Default Type Order
+- `narrative_event` is included in `getDefaultEntityTypeOrder()`
+- Appears exactly once in the default order
+- Total default order count is 13
+
+### 7. Type Validation
+- All fields use valid field types from the FieldType union
+- Required field configuration is correct (only eventType is required)
+- Type identifier is valid for TypeScript EntityType union
+
+## Expected Test Results (RED Phase)
+
+All 49 tests should FAIL with the following patterns:
+
+1. **Existence tests**: `undefined` returned (entity type doesn't exist yet)
+2. **Metadata tests**: Properties are `undefined`
+3. **Field tests**: Fields not found in definitions
+4. **Order tests**: Empty array causes failures
+5. **Relationship tests**: Array is `undefined` or empty
+6. **Integration tests**: Count mismatches (12 vs expected 13)
+
+## Test Philosophy
+
+Following the test strategy for entity types established in the codebase:
+
+1. **Comprehensive Coverage**: Test all aspects of the entity type definition
+2. **Granular Assertions**: Each test verifies one specific aspect
+3. **Clear Intent**: Test names describe expected behavior
+4. **Behavioral Testing**: Focus on the interface, not implementation
+5. **Deterministic**: Tests are isolated and repeatable
+
+## Next Steps (GREEN Phase)
+
+After these tests pass, the implementation should:
+
+1. Add `narrative_event` to `BUILT_IN_ENTITY_TYPES` array in `entityTypes.ts`
+2. Add `'narrative_event'` to `EntityType` union in `entities.ts`
+3. Update `getDefaultEntityTypeOrder()` to include `'narrative_event'`
+
+The tests will guide the implementation to ensure all requirements are met.
+
+## Test Coverage
+
+- **Total Tests**: 54
+- **Failing Tests (expected)**: 49
+- **Passing Tests**: 5 (type-agnostic utility tests)
+
+Coverage includes:
+- ✅ Type existence and retrieval
+- ✅ Metadata completeness
+- ✅ All 4 field definitions with full property validation
+- ✅ Field ordering and uniqueness
+- ✅ Default relationships (3 total)
+- ✅ Integration with existing entity type system
+- ✅ Default order inclusion
+- ✅ Type validation

--- a/src/lib/config/entityTypes.narrative-event.test.ts
+++ b/src/lib/config/entityTypes.narrative-event.test.ts
@@ -1,0 +1,424 @@
+/**
+ * Tests for Narrative Event Entity Type Definition (Issue #398)
+ *
+ * This is the RED phase of TDD - tests written to FAIL initially.
+ * These tests validate the Narrative Event entity type structure:
+ * - Type exists in BUILT_IN_ENTITY_TYPES
+ * - Has correct metadata (label, icon, color, etc.)
+ * - Has all required field definitions
+ * - Field types and options are correct
+ * - Included in getDefaultEntityTypeOrder()
+ *
+ * Implementation will be added in the GREEN phase to make these tests pass.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+	BUILT_IN_ENTITY_TYPES,
+	getEntityTypeDefinition,
+	getDefaultEntityTypeOrder
+} from './entityTypes';
+import type { EntityTypeDefinition, FieldDefinition } from '$lib/types';
+
+describe('Narrative Event Entity Type Definition (Issue #398)', () => {
+	let narrativeEventType: EntityTypeDefinition | undefined;
+
+	// Helper to get the narrative_event type definition
+	function getNarrativeEventType(): EntityTypeDefinition | undefined {
+		return BUILT_IN_ENTITY_TYPES.find((t) => t.type === 'narrative_event');
+	}
+
+	describe('Narrative Event Type Existence', () => {
+		it('should exist in BUILT_IN_ENTITY_TYPES', () => {
+			narrativeEventType = getNarrativeEventType();
+			expect(narrativeEventType).toBeDefined();
+		});
+
+		it('should be retrievable via getEntityTypeDefinition', () => {
+			const narrativeEvent = getEntityTypeDefinition('narrative_event');
+			expect(narrativeEvent).toBeDefined();
+			expect(narrativeEvent?.type).toBe('narrative_event');
+		});
+	});
+
+	describe('Narrative Event Type Metadata', () => {
+		it('should have correct type identifier', () => {
+			narrativeEventType = getNarrativeEventType();
+			expect(narrativeEventType?.type).toBe('narrative_event');
+		});
+
+		it('should have singular label "Narrative Event"', () => {
+			narrativeEventType = getNarrativeEventType();
+			expect(narrativeEventType?.label).toBe('Narrative Event');
+		});
+
+		it('should have plural label "Narrative Events"', () => {
+			narrativeEventType = getNarrativeEventType();
+			expect(narrativeEventType?.labelPlural).toBe('Narrative Events');
+		});
+
+		it('should have icon "milestone"', () => {
+			narrativeEventType = getNarrativeEventType();
+			expect(narrativeEventType?.icon).toBe('milestone');
+		});
+
+		it('should have color "amber"', () => {
+			narrativeEventType = getNarrativeEventType();
+			expect(narrativeEventType?.color).toBe('amber');
+		});
+
+		it('should be marked as built-in', () => {
+			narrativeEventType = getNarrativeEventType();
+			expect(narrativeEventType?.isBuiltIn).toBe(true);
+		});
+
+		it('should have default relationships defined', () => {
+			narrativeEventType = getNarrativeEventType();
+			expect(narrativeEventType?.defaultRelationships).toBeDefined();
+			expect(Array.isArray(narrativeEventType?.defaultRelationships)).toBe(true);
+		});
+	});
+
+	describe('Narrative Event Field Definitions', () => {
+		it('should have field definitions array', () => {
+			narrativeEventType = getNarrativeEventType();
+			expect(narrativeEventType?.fieldDefinitions).toBeDefined();
+			expect(Array.isArray(narrativeEventType?.fieldDefinitions)).toBe(true);
+		});
+
+		it('should have exactly 4 field definitions', () => {
+			narrativeEventType = getNarrativeEventType();
+			expect(narrativeEventType?.fieldDefinitions.length).toBe(4);
+		});
+
+		describe('eventType Field', () => {
+			let field: FieldDefinition | undefined;
+
+			it('should have eventType field', () => {
+				narrativeEventType = getNarrativeEventType();
+				field = narrativeEventType?.fieldDefinitions.find((f) => f.key === 'eventType');
+				expect(field).toBeDefined();
+			});
+
+			it('should have correct label "Event Type"', () => {
+				narrativeEventType = getNarrativeEventType();
+				field = narrativeEventType?.fieldDefinitions.find((f) => f.key === 'eventType');
+				expect(field?.label).toBe('Event Type');
+			});
+
+			it('should be a select field', () => {
+				narrativeEventType = getNarrativeEventType();
+				field = narrativeEventType?.fieldDefinitions.find((f) => f.key === 'eventType');
+				expect(field?.type).toBe('select');
+			});
+
+			it('should have exactly 5 options', () => {
+				narrativeEventType = getNarrativeEventType();
+				field = narrativeEventType?.fieldDefinitions.find((f) => f.key === 'eventType');
+				expect(field?.options?.length).toBe(5);
+			});
+
+			it('should have correct event type options', () => {
+				narrativeEventType = getNarrativeEventType();
+				field = narrativeEventType?.fieldDefinitions.find((f) => f.key === 'eventType');
+				expect(field?.options).toEqual(['scene', 'combat', 'montage', 'negotiation', 'other']);
+			});
+
+			it('should be required', () => {
+				narrativeEventType = getNarrativeEventType();
+				field = narrativeEventType?.fieldDefinitions.find((f) => f.key === 'eventType');
+				expect(field?.required).toBe(true);
+			});
+
+			it('should have order 1', () => {
+				narrativeEventType = getNarrativeEventType();
+				field = narrativeEventType?.fieldDefinitions.find((f) => f.key === 'eventType');
+				expect(field?.order).toBe(1);
+			});
+		});
+
+		describe('sourceId Field', () => {
+			let field: FieldDefinition | undefined;
+
+			it('should have sourceId field', () => {
+				narrativeEventType = getNarrativeEventType();
+				field = narrativeEventType?.fieldDefinitions.find((f) => f.key === 'sourceId');
+				expect(field).toBeDefined();
+			});
+
+			it('should have correct label "Source ID"', () => {
+				narrativeEventType = getNarrativeEventType();
+				field = narrativeEventType?.fieldDefinitions.find((f) => f.key === 'sourceId');
+				expect(field?.label).toBe('Source ID');
+			});
+
+			it('should be a text field', () => {
+				narrativeEventType = getNarrativeEventType();
+				field = narrativeEventType?.fieldDefinitions.find((f) => f.key === 'sourceId');
+				expect(field?.type).toBe('text');
+			});
+
+			it('should not be required', () => {
+				narrativeEventType = getNarrativeEventType();
+				field = narrativeEventType?.fieldDefinitions.find((f) => f.key === 'sourceId');
+				expect(field?.required).toBe(false);
+			});
+
+			it('should have order 2', () => {
+				narrativeEventType = getNarrativeEventType();
+				field = narrativeEventType?.fieldDefinitions.find((f) => f.key === 'sourceId');
+				expect(field?.order).toBe(2);
+			});
+
+			it('should have helpText explaining the field purpose', () => {
+				narrativeEventType = getNarrativeEventType();
+				field = narrativeEventType?.fieldDefinitions.find((f) => f.key === 'sourceId');
+				expect(field?.helpText).toBeDefined();
+				expect(field?.helpText).toBe('ID of the linked combat, montage, or scene');
+			});
+		});
+
+		describe('outcome Field', () => {
+			let field: FieldDefinition | undefined;
+
+			it('should have outcome field', () => {
+				narrativeEventType = getNarrativeEventType();
+				field = narrativeEventType?.fieldDefinitions.find((f) => f.key === 'outcome');
+				expect(field).toBeDefined();
+			});
+
+			it('should have correct label "Outcome"', () => {
+				narrativeEventType = getNarrativeEventType();
+				field = narrativeEventType?.fieldDefinitions.find((f) => f.key === 'outcome');
+				expect(field?.label).toBe('Outcome');
+			});
+
+			it('should be a text field', () => {
+				narrativeEventType = getNarrativeEventType();
+				field = narrativeEventType?.fieldDefinitions.find((f) => f.key === 'outcome');
+				expect(field?.type).toBe('text');
+			});
+
+			it('should not be required', () => {
+				narrativeEventType = getNarrativeEventType();
+				field = narrativeEventType?.fieldDefinitions.find((f) => f.key === 'outcome');
+				expect(field?.required).toBe(false);
+			});
+
+			it('should have order 3', () => {
+				narrativeEventType = getNarrativeEventType();
+				field = narrativeEventType?.fieldDefinitions.find((f) => f.key === 'outcome');
+				expect(field?.order).toBe(3);
+			});
+		});
+
+		describe('session Field', () => {
+			let field: FieldDefinition | undefined;
+
+			it('should have session field', () => {
+				narrativeEventType = getNarrativeEventType();
+				field = narrativeEventType?.fieldDefinitions.find((f) => f.key === 'session');
+				expect(field).toBeDefined();
+			});
+
+			it('should have correct label "Session"', () => {
+				narrativeEventType = getNarrativeEventType();
+				field = narrativeEventType?.fieldDefinitions.find((f) => f.key === 'session');
+				expect(field?.label).toBe('Session');
+			});
+
+			it('should be an entity-ref field', () => {
+				narrativeEventType = getNarrativeEventType();
+				field = narrativeEventType?.fieldDefinitions.find((f) => f.key === 'session');
+				expect(field?.type).toBe('entity-ref');
+			});
+
+			it('should reference session entity type', () => {
+				narrativeEventType = getNarrativeEventType();
+				field = narrativeEventType?.fieldDefinitions.find((f) => f.key === 'session');
+				expect(field?.entityTypes).toEqual(['session']);
+			});
+
+			it('should not be required', () => {
+				narrativeEventType = getNarrativeEventType();
+				field = narrativeEventType?.fieldDefinitions.find((f) => f.key === 'session');
+				expect(field?.required).toBe(false);
+			});
+
+			it('should have order 4', () => {
+				narrativeEventType = getNarrativeEventType();
+				field = narrativeEventType?.fieldDefinitions.find((f) => f.key === 'session');
+				expect(field?.order).toBe(4);
+			});
+		});
+	});
+
+	describe('Narrative Event Field Ordering', () => {
+		it('should have ordered fields', () => {
+			narrativeEventType = getNarrativeEventType();
+			const fields = narrativeEventType?.fieldDefinitions ?? [];
+
+			// Check that all fields have an order property
+			fields.forEach((field) => {
+				expect(field.order).toBeDefined();
+				expect(typeof field.order).toBe('number');
+			});
+		});
+
+		it('should have unique order values', () => {
+			narrativeEventType = getNarrativeEventType();
+			const fields = narrativeEventType?.fieldDefinitions ?? [];
+			const orderValues = fields.map((f) => f.order);
+			const uniqueOrders = new Set(orderValues);
+
+			expect(uniqueOrders.size).toBe(orderValues.length);
+		});
+
+		it('should have consecutive order values starting from 1', () => {
+			narrativeEventType = getNarrativeEventType();
+			const fields = narrativeEventType?.fieldDefinitions ?? [];
+			const orderValues = fields.map((f) => f.order).sort((a, b) => a - b);
+
+			expect(orderValues).toEqual([1, 2, 3, 4]);
+		});
+
+		it('should have fields in correct order: eventType, sourceId, outcome, session', () => {
+			narrativeEventType = getNarrativeEventType();
+			const fields = narrativeEventType?.fieldDefinitions ?? [];
+			const sortedFields = [...fields].sort((a, b) => a.order - b.order);
+
+			expect(sortedFields[0].key).toBe('eventType');
+			expect(sortedFields[1].key).toBe('sourceId');
+			expect(sortedFields[2].key).toBe('outcome');
+			expect(sortedFields[3].key).toBe('session');
+		});
+	});
+
+	describe('Narrative Event Default Relationships', () => {
+		it('should have exactly 3 default relationships', () => {
+			narrativeEventType = getNarrativeEventType();
+			expect(narrativeEventType?.defaultRelationships.length).toBe(3);
+		});
+
+		it('should include "leads_to" relationship', () => {
+			narrativeEventType = getNarrativeEventType();
+			expect(narrativeEventType?.defaultRelationships).toContain('leads_to');
+		});
+
+		it('should include "follows" relationship', () => {
+			narrativeEventType = getNarrativeEventType();
+			expect(narrativeEventType?.defaultRelationships).toContain('follows');
+		});
+
+		it('should include "part_of" relationship for session', () => {
+			narrativeEventType = getNarrativeEventType();
+			expect(narrativeEventType?.defaultRelationships).toContain('part_of');
+		});
+
+		it('should have all three relationships in correct order', () => {
+			narrativeEventType = getNarrativeEventType();
+			expect(narrativeEventType?.defaultRelationships).toEqual(['leads_to', 'follows', 'part_of']);
+		});
+	});
+
+	describe('Narrative Event Integration', () => {
+		it('should be included in total count of built-in types', () => {
+			const builtInTypes = BUILT_IN_ENTITY_TYPES.filter((t) => t.isBuiltIn);
+			// Should be 13 built-in types (12 original + narrative_event)
+			expect(builtInTypes.length).toBe(13);
+		});
+
+		it('should have unique type identifier', () => {
+			const typeIds = BUILT_IN_ENTITY_TYPES.map((t) => t.type);
+			const narrativeEventOccurrences = typeIds.filter((id) => id === 'narrative_event').length;
+			expect(narrativeEventOccurrences).toBe(1);
+		});
+
+		it('should not have duplicate field keys', () => {
+			narrativeEventType = getNarrativeEventType();
+			const fieldKeys = narrativeEventType?.fieldDefinitions.map((f) => f.key) ?? [];
+			const uniqueKeys = new Set(fieldKeys);
+
+			expect(uniqueKeys.size).toBe(fieldKeys.length);
+		});
+	});
+
+	describe('Narrative Event in Default Entity Type Order', () => {
+		it('should be included in getDefaultEntityTypeOrder()', () => {
+			const defaultOrder = getDefaultEntityTypeOrder();
+			expect(defaultOrder).toContain('narrative_event');
+		});
+
+		it('should appear in default order array', () => {
+			const defaultOrder = getDefaultEntityTypeOrder();
+			const narrativeEventIndex = defaultOrder.indexOf('narrative_event');
+			expect(narrativeEventIndex).toBeGreaterThanOrEqual(0);
+		});
+
+		it('should be included exactly once in default order', () => {
+			const defaultOrder = getDefaultEntityTypeOrder();
+			const occurrences = defaultOrder.filter((type) => type === 'narrative_event').length;
+			expect(occurrences).toBe(1);
+		});
+
+		it('should increase total default order count to 13', () => {
+			const defaultOrder = getDefaultEntityTypeOrder();
+			// Should have 13 types now: 12 original + narrative_event
+			expect(defaultOrder.length).toBe(13);
+		});
+	});
+
+	describe('Narrative Event Field Type Validation', () => {
+		it('should have all fields with valid field types', () => {
+			narrativeEventType = getNarrativeEventType();
+			const fields = narrativeEventType?.fieldDefinitions ?? [];
+
+			const validFieldTypes = [
+				'text',
+				'textarea',
+				'richtext',
+				'number',
+				'boolean',
+				'select',
+				'multi-select',
+				'tags',
+				'entity-ref',
+				'entity-refs',
+				'date',
+				'url',
+				'image',
+				'computed',
+				'dice',
+				'resource',
+				'duration'
+			];
+
+			fields.forEach((field) => {
+				expect(validFieldTypes).toContain(field.type);
+			});
+		});
+
+		it('should have correct required field configuration', () => {
+			narrativeEventType = getNarrativeEventType();
+			const fields = narrativeEventType?.fieldDefinitions ?? [];
+
+			// eventType is required
+			const eventTypeField = fields.find((f) => f.key === 'eventType');
+			expect(eventTypeField?.required).toBe(true);
+
+			// All other fields are optional
+			const optionalFields = fields.filter((f) => f.key !== 'eventType');
+			optionalFields.forEach((field) => {
+				expect(field.required).toBe(false);
+			});
+		});
+	});
+
+	describe('Narrative Event Entity Type Union', () => {
+		it('should be a valid EntityType in TypeScript union', () => {
+			// This test validates that 'narrative_event' will be added to the EntityType union
+			// The type system will validate this during compilation
+			const type: string = 'narrative_event';
+			expect(type).toBe('narrative_event');
+		});
+	});
+});

--- a/src/lib/config/entityTypes.test.ts
+++ b/src/lib/config/entityTypes.test.ts
@@ -929,9 +929,9 @@ describe('entityTypes - Ordering Functions', () => {
 				});
 			});
 
-			it('should return exactly 12 built-in types', () => {
+			it('should return exactly 13 built-in types', () => {
 				const order = getDefaultEntityTypeOrder();
-				expect(order.length).toBe(12);
+				expect(order.length).toBe(13);
 			});
 		});
 
@@ -962,13 +962,13 @@ describe('entityTypes - Ordering Functions', () => {
 					'location',
 					'faction',
 					'item',
-					'encounter',
 					'session',
 					'scene',
 					'deity',
 					'timeline_event',
 					'world_rule',
-					'player_profile'
+					'player_profile',
+					'narrative_event'
 				];
 
 				expectedTypes.forEach((type) => {
@@ -1006,11 +1006,6 @@ describe('entityTypes - Ordering Functions', () => {
 				expect(order).toContain('item');
 			});
 
-			it('should include encounter type', () => {
-				const order = getDefaultEntityTypeOrder();
-				expect(order).toContain('encounter');
-			});
-
 			it('should include session type', () => {
 				const order = getDefaultEntityTypeOrder();
 				expect(order).toContain('session');
@@ -1039,6 +1034,11 @@ describe('entityTypes - Ordering Functions', () => {
 			it('should include player_profile type', () => {
 				const order = getDefaultEntityTypeOrder();
 				expect(order).toContain('player_profile');
+			});
+
+			it('should include narrative_event type', () => {
+				const order = getDefaultEntityTypeOrder();
+				expect(order).toContain('narrative_event');
 			});
 		});
 
@@ -1108,7 +1108,7 @@ describe('entityTypes - Ordering Functions', () => {
 			it('should include all built-in types when no custom order', () => {
 				const ordered = getOrderedEntityTypes([], [], null);
 
-				expect(ordered.length).toBe(12);
+				expect(ordered.length).toBe(13);
 
 				const types = ordered.map((t) => t.type);
 				expect(types).toContain('campaign');
@@ -1163,11 +1163,11 @@ describe('entityTypes - Ordering Functions', () => {
 			});
 
 			it('should respect exact ordering from custom order', () => {
-				const customOrder = ['faction', 'item', 'encounter'];
+				const customOrder = ['faction', 'item', 'session'];
 				const ordered = getOrderedEntityTypes([], [], customOrder);
 
 				const orderedTypes = ordered.slice(0, 3).map((t) => t.type);
-				expect(orderedTypes).toEqual(['faction', 'item', 'encounter']);
+				expect(orderedTypes).toEqual(['faction', 'item', 'session']);
 			});
 
 			it('should handle single type in custom order', () => {
@@ -1176,7 +1176,7 @@ describe('entityTypes - Ordering Functions', () => {
 
 				// First type should be campaign, others in default order
 				expect(ordered[0].type).toBe('campaign');
-				expect(ordered.length).toBe(12); // All types still included
+				expect(ordered.length).toBe(13); // All types still included
 			});
 		});
 
@@ -1191,7 +1191,7 @@ describe('entityTypes - Ordering Functions', () => {
 				expect(ordered[2].type).toBe('npc');
 
 				// Remaining types should be appended
-				expect(ordered.length).toBe(12);
+				expect(ordered.length).toBe(13);
 
 				const typesInOrder = ordered.map((t) => t.type);
 				expect(typesInOrder.slice(0, 3)).toEqual(['campaign', 'character', 'npc']);
@@ -1206,7 +1206,7 @@ describe('entityTypes - Ordering Functions', () => {
 				const customOrder = ['campaign'];
 				const ordered = getOrderedEntityTypes([], [], customOrder);
 
-				expect(ordered.length).toBe(12);
+				expect(ordered.length).toBe(13);
 
 				const types = ordered.map((t) => t.type);
 				BUILT_IN_ENTITY_TYPES.forEach((builtInType) => {
@@ -1218,7 +1218,7 @@ describe('entityTypes - Ordering Functions', () => {
 				const customOrder: string[] = [];
 				const ordered = getOrderedEntityTypes([], [], customOrder);
 
-				expect(ordered.length).toBe(12);
+				expect(ordered.length).toBe(13);
 				expect(ordered[0].type).toBe('campaign');
 			});
 		});
@@ -1261,7 +1261,7 @@ describe('entityTypes - Ordering Functions', () => {
 				const ordered = getOrderedEntityTypes([], [], customOrder);
 
 				// Should return all built-in types in default order
-				expect(ordered.length).toBe(12);
+				expect(ordered.length).toBe(13);
 				expect(ordered[0].type).toBe('campaign');
 			});
 		});
@@ -1344,7 +1344,7 @@ describe('entityTypes - Ordering Functions', () => {
 
 				const types = ordered.map((t) => t.type);
 				expect(types).not.toContain('custom_creature');
-				expect(types.length).toBe(12); // Only built-in types
+				expect(types.length).toBe(13); // Only built-in types
 			});
 		});
 
@@ -1423,7 +1423,7 @@ describe('entityTypes - Ordering Functions', () => {
 				const longOrder = [...BUILT_IN_ENTITY_TYPES.map((t) => t.type)].reverse();
 				const ordered = getOrderedEntityTypes([], [], longOrder);
 
-				expect(ordered.length).toBe(12);
+				expect(ordered.length).toBe(13);
 			});
 
 			it('should handle custom order with duplicates', () => {

--- a/src/lib/config/entityTypes.ts
+++ b/src/lib/config/entityTypes.ts
@@ -823,6 +823,48 @@ export const BUILT_IN_ENTITY_TYPES: EntityTypeDefinition[] = [
 			}
 		],
 		defaultRelationships: ['contains', 'features']
+	},
+	{
+		type: 'narrative_event',
+		label: 'Narrative Event',
+		labelPlural: 'Narrative Events',
+		icon: 'milestone',
+		color: 'amber',
+		isBuiltIn: true,
+		fieldDefinitions: [
+			{
+				key: 'eventType',
+				label: 'Event Type',
+				type: 'select',
+				options: ['scene', 'combat', 'montage', 'negotiation', 'other'],
+				required: true,
+				order: 1
+			},
+			{
+				key: 'sourceId',
+				label: 'Source ID',
+				type: 'text',
+				required: false,
+				order: 2,
+				helpText: 'ID of the linked combat, montage, or scene'
+			},
+			{
+				key: 'outcome',
+				label: 'Outcome',
+				type: 'text',
+				required: false,
+				order: 3
+			},
+			{
+				key: 'session',
+				label: 'Session',
+				type: 'entity-ref',
+				entityTypes: ['session'],
+				required: false,
+				order: 4
+			}
+		],
+		defaultRelationships: ['leads_to', 'follows', 'part_of']
 	}
 ];
 
@@ -1035,7 +1077,8 @@ export function getDefaultEntityTypeOrder(): string[] {
 		'deity',
 		'timeline_event',
 		'world_rule',
-		'player_profile'
+		'player_profile',
+		'narrative_event'
 	];
 }
 

--- a/src/lib/db/repositories/narrativeEventIntegration.test.ts
+++ b/src/lib/db/repositories/narrativeEventIntegration.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Integration Tests for Narrative Event Service with Repositories
+ *
+ * Issue #399: Verify that combat and montage sessions automatically create
+ * narrative events when they complete.
+ *
+ * These tests verify the full integration:
+ * - Combat completion creates narrative event
+ * - Montage completion creates narrative event
+ * - Montage auto-completion creates narrative event
+ * - Failures don't block session completion
+ */
+
+import { describe, it, expect, beforeEach, afterEach, beforeAll } from 'vitest';
+import { combatRepository } from './combatRepository';
+import { montageRepository } from './montageRepository';
+import { entityRepository } from './entityRepository';
+import { db } from '../index';
+
+describe('Narrative Event Integration', () => {
+	beforeAll(async () => {
+		await db.open();
+	});
+
+	beforeEach(async () => {
+		// Clear all data before each test
+		await db.combatSessions.clear();
+		await db.montageSessions.clear();
+		await db.entities.clear();
+	});
+
+	afterEach(async () => {
+		// Clean up after each test
+		await db.combatSessions.clear();
+		await db.montageSessions.clear();
+		await db.entities.clear();
+	});
+
+	describe('Combat Integration', () => {
+		it('should create narrative event when combat ends', async () => {
+			// Create and start combat
+			const combat = await combatRepository.create({
+				name: 'Dragon Battle',
+				description: 'Epic battle with an ancient red dragon'
+			});
+			await combatRepository.startCombat(combat.id);
+
+			// Get initial entity count
+			const entitiesBeforeCompletion = await db.entities.count();
+
+			// End combat
+			await combatRepository.endCombat(combat.id);
+
+			// Verify narrative event was created
+			const entitiesAfterCompletion = await db.entities.count();
+			expect(entitiesAfterCompletion).toBe(entitiesBeforeCompletion + 1);
+
+			// Find the narrative event
+			const narrativeEvents = await db.entities
+				.filter((e) => e.type === 'narrative_event')
+				.toArray();
+
+			expect(narrativeEvents).toHaveLength(1);
+			expect(narrativeEvents[0].name).toBe('Dragon Battle');
+			expect(narrativeEvents[0].fields?.eventType).toBe('combat');
+			expect(narrativeEvents[0].fields?.sourceId).toBe(combat.id);
+		});
+
+		it('should not throw if narrative event creation fails', async () => {
+			// Create and start combat
+			const combat = await combatRepository.create({
+				name: 'Test Combat'
+			});
+			await combatRepository.startCombat(combat.id);
+
+			// End combat should succeed even if narrative event fails
+			await expect(combatRepository.endCombat(combat.id)).resolves.toBeDefined();
+
+			// Combat should be completed
+			const completedCombat = await combatRepository.getById(combat.id);
+			expect(completedCombat?.status).toBe('completed');
+		});
+	});
+
+	describe('Montage Integration', () => {
+		it('should create narrative event when montage completes', async () => {
+			// Create and start montage
+			const montage = await montageRepository.create({
+				name: 'Wilderness Survival',
+				description: 'Finding shelter and gathering supplies',
+				difficulty: 'moderate',
+				playerCount: 4
+			});
+			await montageRepository.startMontage(montage.id);
+
+			// Get initial entity count
+			const entitiesBeforeCompletion = await db.entities.count();
+
+			// Complete montage
+			await montageRepository.completeMontage(montage.id, 'total_success');
+
+			// Verify narrative event was created
+			const entitiesAfterCompletion = await db.entities.count();
+			expect(entitiesAfterCompletion).toBe(entitiesBeforeCompletion + 1);
+
+			// Find the narrative event
+			const narrativeEvents = await db.entities
+				.filter((e) => e.type === 'narrative_event')
+				.toArray();
+
+			expect(narrativeEvents).toHaveLength(1);
+			expect(narrativeEvents[0].name).toBe('Wilderness Survival');
+			expect(narrativeEvents[0].fields?.eventType).toBe('montage');
+			expect(narrativeEvents[0].fields?.sourceId).toBe(montage.id);
+			expect(narrativeEvents[0].fields?.outcome).toBe('total_success');
+		});
+
+		it('should create narrative event on auto-completion', async () => {
+			// Create and start montage
+			const montage = await montageRepository.create({
+				name: 'Treasure Hunt',
+				difficulty: 'easy',
+				playerCount: 3
+			});
+			await montageRepository.startMontage(montage.id);
+
+			// Record successes until auto-completion (easy with 3 players: successLimit = 3)
+			await montageRepository.recordChallengeResult(montage.id, {
+				result: 'success',
+				description: 'Found the map'
+			});
+			await montageRepository.recordChallengeResult(montage.id, {
+				result: 'success',
+				description: 'Decoded the clues'
+			});
+
+			// Get entity count before final success
+			const entitiesBeforeAutoComplete = await db.entities.count();
+
+			// Final success should trigger auto-completion and narrative event creation
+			const completedMontage = await montageRepository.recordChallengeResult(montage.id, {
+				result: 'success',
+				description: 'Found the treasure'
+			});
+
+			// Verify montage auto-completed
+			expect(completedMontage.status).toBe('completed');
+			expect(completedMontage.outcome).toBe('total_success');
+
+			// Verify narrative event was created
+			const entitiesAfterAutoComplete = await db.entities.count();
+			expect(entitiesAfterAutoComplete).toBe(entitiesBeforeAutoComplete + 1);
+
+			// Find the narrative event
+			const narrativeEvents = await db.entities
+				.filter((e) => e.type === 'narrative_event')
+				.toArray();
+
+			expect(narrativeEvents).toHaveLength(1);
+			expect(narrativeEvents[0].name).toBe('Treasure Hunt');
+		});
+
+		it('should not throw if narrative event creation fails', async () => {
+			// Create and start montage
+			const montage = await montageRepository.create({
+				name: 'Test Montage',
+				difficulty: 'easy',
+				playerCount: 3
+			});
+			await montageRepository.startMontage(montage.id);
+
+			// Complete montage should succeed even if narrative event fails
+			await expect(
+				montageRepository.completeMontage(montage.id, 'partial_success')
+			).resolves.toBeDefined();
+
+			// Montage should be completed
+			const completedMontage = await montageRepository.getById(montage.id);
+			expect(completedMontage?.status).toBe('completed');
+		});
+	});
+
+	describe('Multiple Sessions', () => {
+		it('should create separate narrative events for multiple sessions', async () => {
+			// Create and complete a combat
+			const combat = await combatRepository.create({
+				name: 'Goblin Raid'
+			});
+			await combatRepository.startCombat(combat.id);
+			await combatRepository.endCombat(combat.id);
+
+			// Create and complete a montage
+			const montage = await montageRepository.create({
+				name: 'City Investigation',
+				difficulty: 'moderate',
+				playerCount: 4
+			});
+			await montageRepository.startMontage(montage.id);
+			await montageRepository.completeMontage(montage.id, 'total_success');
+
+			// Should have 2 narrative events
+			const narrativeEvents = await db.entities
+				.filter((e) => e.type === 'narrative_event')
+				.toArray();
+
+			expect(narrativeEvents).toHaveLength(2);
+
+			// Verify both types exist
+			const combatEvent = narrativeEvents.find((e) => e.fields?.eventType === 'combat');
+			const montageEvent = narrativeEvents.find((e) => e.fields?.eventType === 'montage');
+
+			expect(combatEvent).toBeDefined();
+			expect(montageEvent).toBeDefined();
+			expect(combatEvent?.name).toBe('Goblin Raid');
+			expect(montageEvent?.name).toBe('City Investigation');
+		});
+	});
+});

--- a/src/lib/services/narrativeEventService.test.ts
+++ b/src/lib/services/narrativeEventService.test.ts
@@ -1,0 +1,1741 @@
+/**
+ * Tests for Narrative Event Service (TDD RED Phase - Issue #399)
+ *
+ * This service creates narrative event entities from combat sessions,
+ * montage sessions, and scenes, and manages timeline relationships.
+ *
+ * These tests should FAIL initially as the service doesn't exist yet.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+	createFromCombat,
+	createFromMontage,
+	createFromScene,
+	linkEvents
+} from './narrativeEventService';
+import type { CombatSession } from '$lib/types/combat';
+import type { MontageSession } from '$lib/types/montage';
+import type { BaseEntity } from '$lib/types';
+
+// Mock the entity repository
+vi.mock('$lib/db/repositories/entityRepository', () => ({
+	entityRepository: {
+		create: vi.fn(),
+		getById: vi.fn(),
+		addLink: vi.fn()
+	}
+}));
+
+import { entityRepository } from '$lib/db/repositories/entityRepository';
+
+describe('narrativeEventService', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('createFromCombat', () => {
+		describe('Successful Creation', () => {
+			it('should create narrative event with type "narrative_event"', async () => {
+				const combat: CombatSession = {
+					id: 'combat-123',
+					name: 'Battle at the Bridge',
+					description: 'Epic battle against bandits',
+					status: 'completed',
+					currentRound: 5,
+					currentTurn: 0,
+					combatants: [],
+					groups: [],
+					victoryPoints: 3,
+					heroPoints: 2,
+					log: [],
+					createdAt: new Date('2025-01-01'),
+					updatedAt: new Date('2025-01-01')
+				};
+
+				const createdEntity: BaseEntity = {
+					id: 'event-123',
+					type: 'narrative_event',
+					name: 'Battle at the Bridge',
+					description: 'Epic battle against bandits',
+					tags: [],
+					fields: {
+						eventType: 'combat',
+						sourceId: 'combat-123',
+						outcome: 'Victory in 5 rounds, earned 3 VP'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.create).mockResolvedValue(createdEntity);
+
+				const result = await createFromCombat(combat);
+
+				expect(result.type).toBe('narrative_event');
+			});
+
+			it('should set eventType field to "combat"', async () => {
+				const combat: CombatSession = {
+					id: 'combat-456',
+					name: 'Goblin Ambush',
+					status: 'completed',
+					currentRound: 3,
+					currentTurn: 0,
+					combatants: [],
+					groups: [],
+					victoryPoints: 1,
+					heroPoints: 1,
+					log: [],
+					createdAt: new Date(),
+					updatedAt: new Date()
+				};
+
+				const createdEntity: BaseEntity = {
+					id: 'event-456',
+					type: 'narrative_event',
+					name: 'Goblin Ambush',
+					description: '',
+					tags: [],
+					fields: {
+						eventType: 'combat',
+						sourceId: 'combat-456',
+						outcome: 'Victory in 3 rounds, earned 1 VP'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.create).mockResolvedValue(createdEntity);
+
+				const result = await createFromCombat(combat);
+
+				expect(result.fields.eventType).toBe('combat');
+			});
+
+			it('should set sourceId to combat.id', async () => {
+				const combat: CombatSession = {
+					id: 'combat-unique-789',
+					name: 'Dragon Fight',
+					status: 'completed',
+					currentRound: 10,
+					currentTurn: 0,
+					combatants: [],
+					groups: [],
+					victoryPoints: 5,
+					heroPoints: 3,
+					log: [],
+					createdAt: new Date(),
+					updatedAt: new Date()
+				};
+
+				const createdEntity: BaseEntity = {
+					id: 'event-789',
+					type: 'narrative_event',
+					name: 'Dragon Fight',
+					description: '',
+					tags: [],
+					fields: {
+						eventType: 'combat',
+						sourceId: 'combat-unique-789',
+						outcome: 'Victory in 10 rounds, earned 5 VP'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.create).mockResolvedValue(createdEntity);
+
+				const result = await createFromCombat(combat);
+
+				expect(result.fields.sourceId).toBe('combat-unique-789');
+			});
+
+			it('should set outcome with combat summary including rounds and victory points', async () => {
+				const combat: CombatSession = {
+					id: 'combat-summary',
+					name: 'Bandit Showdown',
+					status: 'completed',
+					currentRound: 7,
+					currentTurn: 0,
+					combatants: [],
+					groups: [],
+					victoryPoints: 4,
+					heroPoints: 2,
+					log: [],
+					createdAt: new Date(),
+					updatedAt: new Date()
+				};
+
+				const createdEntity: BaseEntity = {
+					id: 'event-summary',
+					type: 'narrative_event',
+					name: 'Bandit Showdown',
+					description: '',
+					tags: [],
+					fields: {
+						eventType: 'combat',
+						sourceId: 'combat-summary',
+						outcome: 'Victory in 7 rounds, earned 4 VP'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.create).mockResolvedValue(createdEntity);
+
+				const result = await createFromCombat(combat);
+
+				expect(result.fields.outcome).toContain('7 rounds');
+				expect(result.fields.outcome).toContain('4 VP');
+			});
+
+			it('should use combat name as entity name', async () => {
+				const combat: CombatSession = {
+					id: 'combat-name',
+					name: 'The Great Siege',
+					status: 'completed',
+					currentRound: 15,
+					currentTurn: 0,
+					combatants: [],
+					groups: [],
+					victoryPoints: 10,
+					heroPoints: 5,
+					log: [],
+					createdAt: new Date(),
+					updatedAt: new Date()
+				};
+
+				const createdEntity: BaseEntity = {
+					id: 'event-name',
+					type: 'narrative_event',
+					name: 'The Great Siege',
+					description: '',
+					tags: [],
+					fields: {
+						eventType: 'combat',
+						sourceId: 'combat-name',
+						outcome: 'Victory in 15 rounds, earned 10 VP'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.create).mockResolvedValue(createdEntity);
+
+				const result = await createFromCombat(combat);
+
+				expect(result.name).toBe('The Great Siege');
+			});
+
+			it('should use combat description if provided', async () => {
+				const combat: CombatSession = {
+					id: 'combat-desc',
+					name: 'Forest Ambush',
+					description: 'Bandits attacked from the trees',
+					status: 'completed',
+					currentRound: 4,
+					currentTurn: 0,
+					combatants: [],
+					groups: [],
+					victoryPoints: 2,
+					heroPoints: 1,
+					log: [],
+					createdAt: new Date(),
+					updatedAt: new Date()
+				};
+
+				const createdEntity: BaseEntity = {
+					id: 'event-desc',
+					type: 'narrative_event',
+					name: 'Forest Ambush',
+					description: 'Bandits attacked from the trees',
+					tags: [],
+					fields: {
+						eventType: 'combat',
+						sourceId: 'combat-desc',
+						outcome: 'Victory in 4 rounds, earned 2 VP'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.create).mockResolvedValue(createdEntity);
+
+				const result = await createFromCombat(combat);
+
+				expect(result.description).toBe('Bandits attacked from the trees');
+			});
+
+			it('should call entityRepository.create with correct structure', async () => {
+				const combat: CombatSession = {
+					id: 'combat-call-test',
+					name: 'Test Combat',
+					description: 'Test description',
+					status: 'completed',
+					currentRound: 3,
+					currentTurn: 0,
+					combatants: [],
+					groups: [],
+					victoryPoints: 2,
+					heroPoints: 1,
+					log: [],
+					createdAt: new Date(),
+					updatedAt: new Date()
+				};
+
+				const createdEntity: BaseEntity = {
+					id: 'event-call-test',
+					type: 'narrative_event',
+					name: 'Test Combat',
+					description: 'Test description',
+					tags: [],
+					fields: {
+						eventType: 'combat',
+						sourceId: 'combat-call-test',
+						outcome: 'Victory in 3 rounds, earned 2 VP'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.create).mockResolvedValue(createdEntity);
+
+				await createFromCombat(combat);
+
+				expect(entityRepository.create).toHaveBeenCalledWith(
+					expect.objectContaining({
+						type: 'narrative_event',
+						name: 'Test Combat',
+						description: 'Test description',
+						fields: expect.objectContaining({
+							eventType: 'combat',
+							sourceId: 'combat-call-test',
+							outcome: expect.stringContaining('3 rounds')
+						})
+					})
+				);
+			});
+		});
+
+		describe('Error Handling', () => {
+			it('should fail if combat is not completed', async () => {
+				const combat: CombatSession = {
+					id: 'combat-active',
+					name: 'Active Combat',
+					status: 'active',
+					currentRound: 2,
+					currentTurn: 1,
+					combatants: [],
+					groups: [],
+					victoryPoints: 0,
+					heroPoints: 3,
+					log: [],
+					createdAt: new Date(),
+					updatedAt: new Date()
+				};
+
+				await expect(createFromCombat(combat)).rejects.toThrow(
+					'Cannot create narrative event from combat that is not completed'
+				);
+			});
+
+			it('should fail if combat status is "preparing"', async () => {
+				const combat: CombatSession = {
+					id: 'combat-preparing',
+					name: 'Preparing Combat',
+					status: 'preparing',
+					currentRound: 0,
+					currentTurn: 0,
+					combatants: [],
+					groups: [],
+					victoryPoints: 0,
+					heroPoints: 3,
+					log: [],
+					createdAt: new Date(),
+					updatedAt: new Date()
+				};
+
+				await expect(createFromCombat(combat)).rejects.toThrow(
+					'Cannot create narrative event from combat that is not completed'
+				);
+			});
+
+			it('should fail if combat status is "paused"', async () => {
+				const combat: CombatSession = {
+					id: 'combat-paused',
+					name: 'Paused Combat',
+					status: 'paused',
+					currentRound: 3,
+					currentTurn: 2,
+					combatants: [],
+					groups: [],
+					victoryPoints: 1,
+					heroPoints: 2,
+					log: [],
+					createdAt: new Date(),
+					updatedAt: new Date()
+				};
+
+				await expect(createFromCombat(combat)).rejects.toThrow(
+					'Cannot create narrative event from combat that is not completed'
+				);
+			});
+
+			it('should throw error when repository creation fails', async () => {
+				const combat: CombatSession = {
+					id: 'combat-fail',
+					name: 'Failed Combat',
+					status: 'completed',
+					currentRound: 1,
+					currentTurn: 0,
+					combatants: [],
+					groups: [],
+					victoryPoints: 0,
+					heroPoints: 1,
+					log: [],
+					createdAt: new Date(),
+					updatedAt: new Date()
+				};
+
+				vi.mocked(entityRepository.create).mockRejectedValue(
+					new Error('Database error')
+				);
+
+				await expect(createFromCombat(combat)).rejects.toThrow('Database error');
+			});
+		});
+
+		describe('Edge Cases', () => {
+			it('should handle combat with zero victory points', async () => {
+				const combat: CombatSession = {
+					id: 'combat-zero-vp',
+					name: 'No VP Combat',
+					status: 'completed',
+					currentRound: 2,
+					currentTurn: 0,
+					combatants: [],
+					groups: [],
+					victoryPoints: 0,
+					heroPoints: 1,
+					log: [],
+					createdAt: new Date(),
+					updatedAt: new Date()
+				};
+
+				const createdEntity: BaseEntity = {
+					id: 'event-zero-vp',
+					type: 'narrative_event',
+					name: 'No VP Combat',
+					description: '',
+					tags: [],
+					fields: {
+						eventType: 'combat',
+						sourceId: 'combat-zero-vp',
+						outcome: 'Victory in 2 rounds, earned 0 VP'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.create).mockResolvedValue(createdEntity);
+
+				const result = await createFromCombat(combat);
+
+				expect(result.fields.outcome).toContain('0 VP');
+			});
+
+			it('should handle combat with only 1 round', async () => {
+				const combat: CombatSession = {
+					id: 'combat-one-round',
+					name: 'Quick Combat',
+					status: 'completed',
+					currentRound: 1,
+					currentTurn: 0,
+					combatants: [],
+					groups: [],
+					victoryPoints: 1,
+					heroPoints: 1,
+					log: [],
+					createdAt: new Date(),
+					updatedAt: new Date()
+				};
+
+				const createdEntity: BaseEntity = {
+					id: 'event-one-round',
+					type: 'narrative_event',
+					name: 'Quick Combat',
+					description: '',
+					tags: [],
+					fields: {
+						eventType: 'combat',
+						sourceId: 'combat-one-round',
+						outcome: 'Victory in 1 rounds, earned 1 VP'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.create).mockResolvedValue(createdEntity);
+
+				const result = await createFromCombat(combat);
+
+				expect(result.fields.outcome).toContain('1 rounds');
+			});
+
+			it('should handle combat with empty description', async () => {
+				const combat: CombatSession = {
+					id: 'combat-no-desc',
+					name: 'No Description Combat',
+					status: 'completed',
+					currentRound: 3,
+					currentTurn: 0,
+					combatants: [],
+					groups: [],
+					victoryPoints: 2,
+					heroPoints: 1,
+					log: [],
+					createdAt: new Date(),
+					updatedAt: new Date()
+				};
+
+				const createdEntity: BaseEntity = {
+					id: 'event-no-desc',
+					type: 'narrative_event',
+					name: 'No Description Combat',
+					description: '',
+					tags: [],
+					fields: {
+						eventType: 'combat',
+						sourceId: 'combat-no-desc',
+						outcome: 'Victory in 3 rounds, earned 2 VP'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.create).mockResolvedValue(createdEntity);
+
+				const result = await createFromCombat(combat);
+
+				expect(result.description).toBe('');
+			});
+		});
+	});
+
+	describe('createFromMontage', () => {
+		describe('Successful Creation', () => {
+			it('should create narrative event with type "narrative_event"', async () => {
+				const montage: MontageSession = {
+					id: 'montage-123',
+					name: 'Journey to the Capital',
+					description: 'Travel montage through wilderness',
+					status: 'completed',
+					difficulty: 'moderate',
+					playerCount: 4,
+					successLimit: 5,
+					failureLimit: 3,
+					challenges: [],
+					successCount: 5,
+					failureCount: 1,
+					currentRound: 2,
+					outcome: 'total_success',
+					victoryPoints: 2,
+					createdAt: new Date(),
+					updatedAt: new Date()
+				};
+
+				const createdEntity: BaseEntity = {
+					id: 'event-123',
+					type: 'narrative_event',
+					name: 'Journey to the Capital',
+					description: 'Travel montage through wilderness',
+					tags: [],
+					fields: {
+						eventType: 'montage',
+						sourceId: 'montage-123',
+						outcome: 'total_success'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.create).mockResolvedValue(createdEntity);
+
+				const result = await createFromMontage(montage);
+
+				expect(result.type).toBe('narrative_event');
+			});
+
+			it('should set eventType field to "montage"', async () => {
+				const montage: MontageSession = {
+					id: 'montage-456',
+					name: 'Gathering Supplies',
+					status: 'completed',
+					difficulty: 'easy',
+					playerCount: 3,
+					successLimit: 4,
+					failureLimit: 2,
+					challenges: [],
+					successCount: 4,
+					failureCount: 0,
+					currentRound: 1,
+					outcome: 'total_success',
+					victoryPoints: 1,
+					createdAt: new Date(),
+					updatedAt: new Date()
+				};
+
+				const createdEntity: BaseEntity = {
+					id: 'event-456',
+					type: 'narrative_event',
+					name: 'Gathering Supplies',
+					description: '',
+					tags: [],
+					fields: {
+						eventType: 'montage',
+						sourceId: 'montage-456',
+						outcome: 'total_success'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.create).mockResolvedValue(createdEntity);
+
+				const result = await createFromMontage(montage);
+
+				expect(result.fields.eventType).toBe('montage');
+			});
+
+			it('should set sourceId to montage.id', async () => {
+				const montage: MontageSession = {
+					id: 'montage-unique-789',
+					name: 'Crafting Preparations',
+					status: 'completed',
+					difficulty: 'hard',
+					playerCount: 5,
+					successLimit: 6,
+					failureLimit: 4,
+					challenges: [],
+					successCount: 6,
+					failureCount: 2,
+					currentRound: 2,
+					outcome: 'total_success',
+					victoryPoints: 3,
+					createdAt: new Date(),
+					updatedAt: new Date()
+				};
+
+				const createdEntity: BaseEntity = {
+					id: 'event-789',
+					type: 'narrative_event',
+					name: 'Crafting Preparations',
+					description: '',
+					tags: [],
+					fields: {
+						eventType: 'montage',
+						sourceId: 'montage-unique-789',
+						outcome: 'total_success'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.create).mockResolvedValue(createdEntity);
+
+				const result = await createFromMontage(montage);
+
+				expect(result.fields.sourceId).toBe('montage-unique-789');
+			});
+
+			it('should set outcome to montage outcome value', async () => {
+				const montage: MontageSession = {
+					id: 'montage-outcome',
+					name: 'Mountain Crossing',
+					status: 'completed',
+					difficulty: 'hard',
+					playerCount: 4,
+					successLimit: 6,
+					failureLimit: 4,
+					challenges: [],
+					successCount: 4,
+					failureCount: 4,
+					currentRound: 2,
+					outcome: 'partial_success',
+					victoryPoints: 1,
+					createdAt: new Date(),
+					updatedAt: new Date()
+				};
+
+				const createdEntity: BaseEntity = {
+					id: 'event-outcome',
+					type: 'narrative_event',
+					name: 'Mountain Crossing',
+					description: '',
+					tags: [],
+					fields: {
+						eventType: 'montage',
+						sourceId: 'montage-outcome',
+						outcome: 'partial_success'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.create).mockResolvedValue(createdEntity);
+
+				const result = await createFromMontage(montage);
+
+				expect(result.fields.outcome).toBe('partial_success');
+			});
+
+			it('should use montage name as entity name', async () => {
+				const montage: MontageSession = {
+					id: 'montage-name',
+					name: 'Escape from the Dungeon',
+					status: 'completed',
+					difficulty: 'hard',
+					playerCount: 4,
+					successLimit: 6,
+					failureLimit: 4,
+					challenges: [],
+					successCount: 3,
+					failureCount: 4,
+					currentRound: 2,
+					outcome: 'total_failure',
+					victoryPoints: 0,
+					createdAt: new Date(),
+					updatedAt: new Date()
+				};
+
+				const createdEntity: BaseEntity = {
+					id: 'event-name',
+					type: 'narrative_event',
+					name: 'Escape from the Dungeon',
+					description: '',
+					tags: [],
+					fields: {
+						eventType: 'montage',
+						sourceId: 'montage-name',
+						outcome: 'total_failure'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.create).mockResolvedValue(createdEntity);
+
+				const result = await createFromMontage(montage);
+
+				expect(result.name).toBe('Escape from the Dungeon');
+			});
+
+			it('should handle all three outcome types', async () => {
+				const outcomes: Array<'total_success' | 'partial_success' | 'total_failure'> = [
+					'total_success',
+					'partial_success',
+					'total_failure'
+				];
+
+				for (const outcome of outcomes) {
+					const montage: MontageSession = {
+						id: `montage-${outcome}`,
+						name: `Test ${outcome}`,
+						status: 'completed',
+						difficulty: 'moderate',
+						playerCount: 4,
+						successLimit: 5,
+						failureLimit: 3,
+						challenges: [],
+						successCount: outcome === 'total_failure' ? 2 : 5,
+						failureCount: outcome === 'total_failure' ? 3 : 1,
+						currentRound: 2,
+						outcome,
+						victoryPoints: outcome === 'total_success' ? 2 : outcome === 'partial_success' ? 1 : 0,
+						createdAt: new Date(),
+						updatedAt: new Date()
+					};
+
+					const createdEntity: BaseEntity = {
+						id: `event-${outcome}`,
+						type: 'narrative_event',
+						name: `Test ${outcome}`,
+						description: '',
+						tags: [],
+						fields: {
+							eventType: 'montage',
+							sourceId: `montage-${outcome}`,
+							outcome
+						},
+						links: [],
+						notes: '',
+						createdAt: new Date(),
+						updatedAt: new Date(),
+						metadata: {}
+					};
+
+					vi.mocked(entityRepository.create).mockResolvedValue(createdEntity);
+
+					const result = await createFromMontage(montage);
+
+					expect(result.fields.outcome).toBe(outcome);
+				}
+			});
+		});
+
+		describe('Error Handling', () => {
+			it('should fail if montage is not completed', async () => {
+				const montage: MontageSession = {
+					id: 'montage-active',
+					name: 'Active Montage',
+					status: 'active',
+					difficulty: 'moderate',
+					playerCount: 4,
+					successLimit: 5,
+					failureLimit: 3,
+					challenges: [],
+					successCount: 2,
+					failureCount: 1,
+					currentRound: 1,
+					victoryPoints: 0,
+					createdAt: new Date(),
+					updatedAt: new Date()
+				};
+
+				await expect(createFromMontage(montage)).rejects.toThrow(
+					'Cannot create narrative event from montage that is not completed'
+				);
+			});
+
+			it('should fail if montage status is "preparing"', async () => {
+				const montage: MontageSession = {
+					id: 'montage-preparing',
+					name: 'Preparing Montage',
+					status: 'preparing',
+					difficulty: 'moderate',
+					playerCount: 4,
+					successLimit: 5,
+					failureLimit: 3,
+					challenges: [],
+					successCount: 0,
+					failureCount: 0,
+					currentRound: 1,
+					victoryPoints: 0,
+					createdAt: new Date(),
+					updatedAt: new Date()
+				};
+
+				await expect(createFromMontage(montage)).rejects.toThrow(
+					'Cannot create narrative event from montage that is not completed'
+				);
+			});
+
+			it('should throw error when repository creation fails', async () => {
+				const montage: MontageSession = {
+					id: 'montage-fail',
+					name: 'Failed Montage',
+					status: 'completed',
+					difficulty: 'easy',
+					playerCount: 3,
+					successLimit: 4,
+					failureLimit: 2,
+					challenges: [],
+					successCount: 4,
+					failureCount: 0,
+					currentRound: 1,
+					outcome: 'total_success',
+					victoryPoints: 1,
+					createdAt: new Date(),
+					updatedAt: new Date()
+				};
+
+				vi.mocked(entityRepository.create).mockRejectedValue(
+					new Error('Database error')
+				);
+
+				await expect(createFromMontage(montage)).rejects.toThrow('Database error');
+			});
+		});
+
+		describe('Edge Cases', () => {
+			it('should handle montage with description', async () => {
+				const montage: MontageSession = {
+					id: 'montage-desc',
+					name: 'Wilderness Trek',
+					description: 'A perilous journey through uncharted lands',
+					status: 'completed',
+					difficulty: 'moderate',
+					playerCount: 4,
+					successLimit: 5,
+					failureLimit: 3,
+					challenges: [],
+					successCount: 5,
+					failureCount: 1,
+					currentRound: 2,
+					outcome: 'total_success',
+					victoryPoints: 2,
+					createdAt: new Date(),
+					updatedAt: new Date()
+				};
+
+				const createdEntity: BaseEntity = {
+					id: 'event-desc',
+					type: 'narrative_event',
+					name: 'Wilderness Trek',
+					description: 'A perilous journey through uncharted lands',
+					tags: [],
+					fields: {
+						eventType: 'montage',
+						sourceId: 'montage-desc',
+						outcome: 'total_success'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.create).mockResolvedValue(createdEntity);
+
+				const result = await createFromMontage(montage);
+
+				expect(result.description).toBe('A perilous journey through uncharted lands');
+			});
+
+			it('should handle montage with empty description', async () => {
+				const montage: MontageSession = {
+					id: 'montage-no-desc',
+					name: 'Simple Montage',
+					status: 'completed',
+					difficulty: 'easy',
+					playerCount: 3,
+					successLimit: 4,
+					failureLimit: 2,
+					challenges: [],
+					successCount: 4,
+					failureCount: 0,
+					currentRound: 1,
+					outcome: 'total_success',
+					victoryPoints: 1,
+					createdAt: new Date(),
+					updatedAt: new Date()
+				};
+
+				const createdEntity: BaseEntity = {
+					id: 'event-no-desc',
+					type: 'narrative_event',
+					name: 'Simple Montage',
+					description: '',
+					tags: [],
+					fields: {
+						eventType: 'montage',
+						sourceId: 'montage-no-desc',
+						outcome: 'total_success'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.create).mockResolvedValue(createdEntity);
+
+				const result = await createFromMontage(montage);
+
+				expect(result.description).toBe('');
+			});
+		});
+	});
+
+	describe('createFromScene', () => {
+		describe('Successful Creation', () => {
+			it('should create narrative event with type "narrative_event"', async () => {
+				const sceneEntity: BaseEntity = {
+					id: 'scene-123',
+					type: 'scene',
+					name: 'Meeting at the Tavern',
+					description: 'The party meets in a dimly lit tavern',
+					tags: ['roleplay', 'intro'],
+					fields: {},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				const createdEntity: BaseEntity = {
+					id: 'event-123',
+					type: 'narrative_event',
+					name: 'Meeting at the Tavern',
+					description: 'The party meets in a dimly lit tavern',
+					tags: [],
+					fields: {
+						eventType: 'scene',
+						sourceId: 'scene-123'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.getById).mockResolvedValue(sceneEntity);
+				vi.mocked(entityRepository.create).mockResolvedValue(createdEntity);
+
+				const result = await createFromScene('scene-123');
+
+				expect(result.type).toBe('narrative_event');
+			});
+
+			it('should set eventType field to "scene"', async () => {
+				const sceneEntity: BaseEntity = {
+					id: 'scene-456',
+					type: 'scene',
+					name: 'Chase Through the Market',
+					description: 'A thrilling chase scene',
+					tags: ['action'],
+					fields: {},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				const createdEntity: BaseEntity = {
+					id: 'event-456',
+					type: 'narrative_event',
+					name: 'Chase Through the Market',
+					description: 'A thrilling chase scene',
+					tags: [],
+					fields: {
+						eventType: 'scene',
+						sourceId: 'scene-456'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.getById).mockResolvedValue(sceneEntity);
+				vi.mocked(entityRepository.create).mockResolvedValue(createdEntity);
+
+				const result = await createFromScene('scene-456');
+
+				expect(result.fields.eventType).toBe('scene');
+			});
+
+			it('should set sourceId to scene entity id', async () => {
+				const sceneEntity: BaseEntity = {
+					id: 'scene-unique-789',
+					type: 'scene',
+					name: 'Throne Room Confrontation',
+					description: 'The party confronts the king',
+					tags: [],
+					fields: {},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				const createdEntity: BaseEntity = {
+					id: 'event-789',
+					type: 'narrative_event',
+					name: 'Throne Room Confrontation',
+					description: 'The party confronts the king',
+					tags: [],
+					fields: {
+						eventType: 'scene',
+						sourceId: 'scene-unique-789'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.getById).mockResolvedValue(sceneEntity);
+				vi.mocked(entityRepository.create).mockResolvedValue(createdEntity);
+
+				const result = await createFromScene('scene-unique-789');
+
+				expect(result.fields.sourceId).toBe('scene-unique-789');
+			});
+
+			it('should copy name from scene entity', async () => {
+				const sceneEntity: BaseEntity = {
+					id: 'scene-name',
+					type: 'scene',
+					name: 'The Grand Revelation',
+					description: 'The villain reveals their master plan',
+					tags: [],
+					fields: {},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				const createdEntity: BaseEntity = {
+					id: 'event-name',
+					type: 'narrative_event',
+					name: 'The Grand Revelation',
+					description: 'The villain reveals their master plan',
+					tags: [],
+					fields: {
+						eventType: 'scene',
+						sourceId: 'scene-name'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.getById).mockResolvedValue(sceneEntity);
+				vi.mocked(entityRepository.create).mockResolvedValue(createdEntity);
+
+				const result = await createFromScene('scene-name');
+
+				expect(result.name).toBe('The Grand Revelation');
+			});
+
+			it('should copy description from scene entity', async () => {
+				const sceneEntity: BaseEntity = {
+					id: 'scene-desc',
+					type: 'scene',
+					name: 'Library Investigation',
+					description: 'The party searches ancient tomes for clues',
+					tags: ['investigation'],
+					fields: {},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				const createdEntity: BaseEntity = {
+					id: 'event-desc',
+					type: 'narrative_event',
+					name: 'Library Investigation',
+					description: 'The party searches ancient tomes for clues',
+					tags: [],
+					fields: {
+						eventType: 'scene',
+						sourceId: 'scene-desc'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.getById).mockResolvedValue(sceneEntity);
+				vi.mocked(entityRepository.create).mockResolvedValue(createdEntity);
+
+				const result = await createFromScene('scene-desc');
+
+				expect(result.description).toBe('The party searches ancient tomes for clues');
+			});
+
+			it('should call entityRepository.getById with scene id', async () => {
+				const sceneEntity: BaseEntity = {
+					id: 'scene-get-test',
+					type: 'scene',
+					name: 'Test Scene',
+					description: 'Test description',
+					tags: [],
+					fields: {},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				const createdEntity: BaseEntity = {
+					id: 'event-get-test',
+					type: 'narrative_event',
+					name: 'Test Scene',
+					description: 'Test description',
+					tags: [],
+					fields: {
+						eventType: 'scene',
+						sourceId: 'scene-get-test'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.getById).mockResolvedValue(sceneEntity);
+				vi.mocked(entityRepository.create).mockResolvedValue(createdEntity);
+
+				await createFromScene('scene-get-test');
+
+				expect(entityRepository.getById).toHaveBeenCalledWith('scene-get-test');
+			});
+		});
+
+		describe('Error Handling', () => {
+			it('should fail if scene entity does not exist', async () => {
+				vi.mocked(entityRepository.getById).mockResolvedValue(undefined);
+
+				await expect(createFromScene('nonexistent-scene')).rejects.toThrow(
+					'Scene entity not found'
+				);
+			});
+
+			it('should fail if entity is not a scene type', async () => {
+				const notAScene: BaseEntity = {
+					id: 'not-scene',
+					type: 'npc',
+					name: 'A Character',
+					description: 'Not a scene',
+					tags: [],
+					fields: {},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.getById).mockResolvedValue(notAScene);
+
+				await expect(createFromScene('not-scene')).rejects.toThrow(
+					'Entity is not a scene type'
+				);
+			});
+
+			it('should throw error when repository creation fails', async () => {
+				const sceneEntity: BaseEntity = {
+					id: 'scene-fail',
+					type: 'scene',
+					name: 'Failed Scene',
+					description: 'Test',
+					tags: [],
+					fields: {},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.getById).mockResolvedValue(sceneEntity);
+				vi.mocked(entityRepository.create).mockRejectedValue(
+					new Error('Database error')
+				);
+
+				await expect(createFromScene('scene-fail')).rejects.toThrow('Database error');
+			});
+		});
+
+		describe('Edge Cases', () => {
+			it('should handle scene with empty description', async () => {
+				const sceneEntity: BaseEntity = {
+					id: 'scene-no-desc',
+					type: 'scene',
+					name: 'Simple Scene',
+					description: '',
+					tags: [],
+					fields: {},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				const createdEntity: BaseEntity = {
+					id: 'event-no-desc',
+					type: 'narrative_event',
+					name: 'Simple Scene',
+					description: '',
+					tags: [],
+					fields: {
+						eventType: 'scene',
+						sourceId: 'scene-no-desc'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.getById).mockResolvedValue(sceneEntity);
+				vi.mocked(entityRepository.create).mockResolvedValue(createdEntity);
+
+				const result = await createFromScene('scene-no-desc');
+
+				expect(result.description).toBe('');
+			});
+
+			it('should handle scene with tags', async () => {
+				const sceneEntity: BaseEntity = {
+					id: 'scene-tags',
+					type: 'scene',
+					name: 'Tagged Scene',
+					description: 'Scene with tags',
+					tags: ['combat', 'roleplay', 'important'],
+					fields: {},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				const createdEntity: BaseEntity = {
+					id: 'event-tags',
+					type: 'narrative_event',
+					name: 'Tagged Scene',
+					description: 'Scene with tags',
+					tags: [],
+					fields: {
+						eventType: 'scene',
+						sourceId: 'scene-tags'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.getById).mockResolvedValue(sceneEntity);
+				vi.mocked(entityRepository.create).mockResolvedValue(createdEntity);
+
+				const result = await createFromScene('scene-tags');
+
+				expect(result).toBeDefined();
+			});
+		});
+	});
+
+	describe('linkEvents', () => {
+		describe('Successful Linking', () => {
+			it('should create bidirectional "leads_to" and "follows" relationships', async () => {
+				const event1: BaseEntity = {
+					id: 'event-1',
+					type: 'narrative_event',
+					name: 'Event 1',
+					description: 'First event',
+					tags: [],
+					fields: { eventType: 'scene' },
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				const event2: BaseEntity = {
+					id: 'event-2',
+					type: 'narrative_event',
+					name: 'Event 2',
+					description: 'Second event',
+					tags: [],
+					fields: { eventType: 'combat' },
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.getById)
+					.mockResolvedValueOnce(event1)
+					.mockResolvedValueOnce(event2);
+
+				await linkEvents('event-1', 'event-2');
+
+				expect(entityRepository.addLink).toHaveBeenCalledWith(
+					'event-1',
+					'event-2',
+					'leads_to',
+					true,
+					undefined,
+					undefined,
+					undefined,
+					'follows',
+					undefined
+				);
+			});
+
+			it('should verify both entities exist before linking', async () => {
+				const event1: BaseEntity = {
+					id: 'event-check-1',
+					type: 'narrative_event',
+					name: 'Event Check 1',
+					description: 'First check',
+					tags: [],
+					fields: { eventType: 'montage' },
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				const event2: BaseEntity = {
+					id: 'event-check-2',
+					type: 'narrative_event',
+					name: 'Event Check 2',
+					description: 'Second check',
+					tags: [],
+					fields: { eventType: 'scene' },
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.getById)
+					.mockResolvedValueOnce(event1)
+					.mockResolvedValueOnce(event2);
+
+				await linkEvents('event-check-1', 'event-check-2');
+
+				expect(entityRepository.getById).toHaveBeenCalledWith('event-check-1');
+				expect(entityRepository.getById).toHaveBeenCalledWith('event-check-2');
+			});
+
+			it('should handle linking different event types', async () => {
+				const combatEvent: BaseEntity = {
+					id: 'combat-event',
+					type: 'narrative_event',
+					name: 'Combat Event',
+					description: 'A battle',
+					tags: [],
+					fields: { eventType: 'combat' },
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				const montageEvent: BaseEntity = {
+					id: 'montage-event',
+					type: 'narrative_event',
+					name: 'Montage Event',
+					description: 'A journey',
+					tags: [],
+					fields: { eventType: 'montage' },
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.getById)
+					.mockResolvedValueOnce(combatEvent)
+					.mockResolvedValueOnce(montageEvent);
+
+				await linkEvents('combat-event', 'montage-event');
+
+				expect(entityRepository.addLink).toHaveBeenCalled();
+			});
+		});
+
+		describe('Error Handling', () => {
+			it('should fail if source entity does not exist', async () => {
+				vi.mocked(entityRepository.getById).mockResolvedValue(undefined);
+
+				await expect(linkEvents('nonexistent-1', 'event-2')).rejects.toThrow(
+					'Source entity not found'
+				);
+			});
+
+			it('should fail if target entity does not exist', async () => {
+				const event1: BaseEntity = {
+					id: 'event-exists',
+					type: 'narrative_event',
+					name: 'Existing Event',
+					description: 'Test',
+					tags: [],
+					fields: { eventType: 'scene' },
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.getById)
+					.mockResolvedValueOnce(event1)
+					.mockResolvedValueOnce(undefined);
+
+				await expect(linkEvents('event-exists', 'nonexistent-2')).rejects.toThrow(
+					'Target entity not found'
+				);
+			});
+
+			it('should fail if source entity is not narrative_event type', async () => {
+				const notEvent: BaseEntity = {
+					id: 'not-event',
+					type: 'npc',
+					name: 'An NPC',
+					description: 'Not an event',
+					tags: [],
+					fields: {},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				const event2: BaseEntity = {
+					id: 'event-2',
+					type: 'narrative_event',
+					name: 'Event 2',
+					description: 'Valid event',
+					tags: [],
+					fields: { eventType: 'scene' },
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.getById)
+					.mockResolvedValueOnce(notEvent)
+					.mockResolvedValueOnce(event2);
+
+				await expect(linkEvents('not-event', 'event-2')).rejects.toThrow(
+					'Source entity is not a narrative_event type'
+				);
+			});
+
+			it('should fail if target entity is not narrative_event type', async () => {
+				const event1: BaseEntity = {
+					id: 'event-1',
+					type: 'narrative_event',
+					name: 'Event 1',
+					description: 'Valid event',
+					tags: [],
+					fields: { eventType: 'combat' },
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				const notEvent: BaseEntity = {
+					id: 'not-event-target',
+					type: 'location',
+					name: 'A Location',
+					description: 'Not an event',
+					tags: [],
+					fields: {},
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.getById)
+					.mockResolvedValueOnce(event1)
+					.mockResolvedValueOnce(notEvent);
+
+				await expect(linkEvents('event-1', 'not-event-target')).rejects.toThrow(
+					'Target entity is not a narrative_event type'
+				);
+			});
+
+			it('should throw error when addLink fails', async () => {
+				const event1: BaseEntity = {
+					id: 'event-fail-1',
+					type: 'narrative_event',
+					name: 'Event Fail 1',
+					description: 'Test',
+					tags: [],
+					fields: { eventType: 'scene' },
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				const event2: BaseEntity = {
+					id: 'event-fail-2',
+					type: 'narrative_event',
+					name: 'Event Fail 2',
+					description: 'Test',
+					tags: [],
+					fields: { eventType: 'combat' },
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.getById)
+					.mockResolvedValueOnce(event1)
+					.mockResolvedValueOnce(event2);
+
+				vi.mocked(entityRepository.addLink).mockRejectedValueOnce(
+					new Error('Link already exists')
+				);
+
+				await expect(linkEvents('event-fail-1', 'event-fail-2')).rejects.toThrow(
+					'Link already exists'
+				);
+			});
+		});
+
+		describe('Edge Cases', () => {
+			it('should handle linking event to itself', async () => {
+				const event: BaseEntity = {
+					id: 'event-self',
+					type: 'narrative_event',
+					name: 'Self Event',
+					description: 'Links to itself',
+					tags: [],
+					fields: { eventType: 'other' },
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.getById).mockResolvedValue(event);
+
+				await linkEvents('event-self', 'event-self');
+
+				expect(entityRepository.addLink).toHaveBeenCalledWith(
+					'event-self',
+					'event-self',
+					'leads_to',
+					true,
+					undefined,
+					undefined,
+					undefined,
+					'follows',
+					undefined
+				);
+			});
+
+			it('should preserve relationship direction (from -> to)', async () => {
+				const eventA: BaseEntity = {
+					id: 'event-a',
+					type: 'narrative_event',
+					name: 'Event A',
+					description: 'First chronologically',
+					tags: [],
+					fields: { eventType: 'scene' },
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				const eventB: BaseEntity = {
+					id: 'event-b',
+					type: 'narrative_event',
+					name: 'Event B',
+					description: 'Second chronologically',
+					tags: [],
+					fields: { eventType: 'combat' },
+					links: [],
+					notes: '',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					metadata: {}
+				};
+
+				vi.mocked(entityRepository.getById)
+					.mockResolvedValueOnce(eventA)
+					.mockResolvedValueOnce(eventB);
+
+				await linkEvents('event-a', 'event-b');
+
+				// Verify that A leads_to B (not B leads_to A)
+				expect(entityRepository.addLink).toHaveBeenCalledWith(
+					'event-a',
+					'event-b',
+					'leads_to',
+					true,
+					undefined,
+					undefined,
+					undefined,
+					'follows',
+					undefined
+				);
+			});
+		});
+	});
+});

--- a/src/lib/services/narrativeEventService.ts
+++ b/src/lib/services/narrativeEventService.ts
@@ -1,0 +1,167 @@
+/**
+ * Narrative Event Service (Issue #399)
+ *
+ * Creates narrative event entities from combat sessions, montage sessions,
+ * and scenes, and manages timeline relationships between events.
+ */
+
+import { entityRepository } from '$lib/db/repositories/entityRepository';
+import type { CombatSession } from '$lib/types/combat';
+import type { MontageSession } from '$lib/types/montage';
+import type { BaseEntity, NewEntity } from '$lib/types';
+
+/**
+ * Create a narrative event from a completed combat session.
+ *
+ * @param combat - The combat session to convert into a narrative event
+ * @returns The created narrative event entity
+ * @throws Error if combat is not completed or repository creation fails
+ */
+export async function createFromCombat(combat: CombatSession): Promise<BaseEntity> {
+	// Validate combat status
+	if (combat.status !== 'completed') {
+		throw new Error('Cannot create narrative event from combat that is not completed');
+	}
+
+	// Build outcome summary
+	const outcome = `Victory in ${combat.currentRound} rounds, earned ${combat.victoryPoints} VP`;
+
+	// Create NewEntity for narrative event
+	const newEntity: NewEntity = {
+		type: 'narrative_event',
+		name: combat.name,
+		description: combat.description || '',
+		tags: [],
+		fields: {
+			eventType: 'combat',
+			sourceId: combat.id,
+			outcome
+		},
+		links: [],
+		notes: '',
+		metadata: {}
+	};
+
+	// Persist and return
+	return await entityRepository.create(newEntity);
+}
+
+/**
+ * Create a narrative event from a completed montage session.
+ *
+ * @param montage - The montage session to convert into a narrative event
+ * @returns The created narrative event entity
+ * @throws Error if montage is not completed or repository creation fails
+ */
+export async function createFromMontage(montage: MontageSession): Promise<BaseEntity> {
+	// Validate montage status
+	if (montage.status !== 'completed') {
+		throw new Error('Cannot create narrative event from montage that is not completed');
+	}
+
+	// Create NewEntity for narrative event
+	const newEntity: NewEntity = {
+		type: 'narrative_event',
+		name: montage.name,
+		description: montage.description || '',
+		tags: [],
+		fields: {
+			eventType: 'montage',
+			sourceId: montage.id,
+			outcome: montage.outcome
+		},
+		links: [],
+		notes: '',
+		metadata: {}
+	};
+
+	// Persist and return
+	return await entityRepository.create(newEntity);
+}
+
+/**
+ * Create a narrative event from a scene entity.
+ *
+ * @param sceneId - The ID of the scene entity to convert
+ * @returns The created narrative event entity
+ * @throws Error if scene not found, not a scene type, or repository creation fails
+ */
+export async function createFromScene(sceneId: string): Promise<BaseEntity> {
+	// Fetch scene entity
+	const scene = await entityRepository.getById(sceneId);
+
+	// Validate scene exists
+	if (!scene) {
+		throw new Error('Scene entity not found');
+	}
+
+	// Validate scene type
+	if (scene.type !== 'scene') {
+		throw new Error('Entity is not a scene type');
+	}
+
+	// Create NewEntity for narrative event
+	const newEntity: NewEntity = {
+		type: 'narrative_event',
+		name: scene.name,
+		description: scene.description,
+		tags: [],
+		fields: {
+			eventType: 'scene',
+			sourceId: sceneId
+		},
+		links: [],
+		notes: '',
+		metadata: {}
+	};
+
+	// Persist and return
+	return await entityRepository.create(newEntity);
+}
+
+/**
+ * Link two narrative events with a temporal relationship.
+ * Creates a bidirectional "leads_to" / "follows" relationship.
+ *
+ * @param fromId - ID of the earlier narrative event
+ * @param toId - ID of the later narrative event
+ * @throws Error if entities not found, wrong type, or link creation fails
+ */
+export async function linkEvents(fromId: string, toId: string): Promise<void> {
+	// Fetch both entities
+	const fromEntity = await entityRepository.getById(fromId);
+	const toEntity = await entityRepository.getById(toId);
+
+	// Validate source entity exists
+	if (!fromEntity) {
+		throw new Error('Source entity not found');
+	}
+
+	// Validate target entity exists
+	if (!toEntity) {
+		throw new Error('Target entity not found');
+	}
+
+	// Validate source entity type
+	if (fromEntity.type !== 'narrative_event') {
+		throw new Error('Source entity is not a narrative_event type');
+	}
+
+	// Validate target entity type
+	if (toEntity.type !== 'narrative_event') {
+		throw new Error('Target entity is not a narrative_event type');
+	}
+
+	// Create bidirectional link with leads_to/follows relationship
+	await entityRepository.addLink(
+		fromId,
+		toId,
+		'leads_to',
+		true, // bidirectional
+		undefined, // notes
+		undefined, // strength
+		undefined, // metadata
+		'follows', // reverseRelationship
+		undefined // playerVisible
+	);
+}

--- a/src/lib/services/sessionSummaryService.test.ts
+++ b/src/lib/services/sessionSummaryService.test.ts
@@ -1,0 +1,1274 @@
+/**
+ * Tests for Session Summary Service (TDD RED Phase - Issue #401)
+ *
+ * This service generates narrative summaries from session trails,
+ * constructing ordered sequences of narrative events into readable text.
+ *
+ * These tests should FAIL initially as the service doesn't exist yet.
+ *
+ * Coverage:
+ * - Retrieving ordered narrative event trails for sessions
+ * - Filtering by session field and narrative_event type
+ * - Ordering events chronologically (creation time or leads_to/follows)
+ * - Generating formatted narrative summaries
+ * - Handling empty sessions and missing data
+ * - Error handling for non-existent sessions
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { getTrailForSession, generateSummary } from './sessionSummaryService';
+import type { BaseEntity } from '$lib/types';
+
+// Mock the entity repository
+vi.mock('$lib/db/repositories/entityRepository', () => ({
+	entityRepository: {
+		getById: vi.fn()
+	}
+}));
+
+// Mock Dexie for database queries
+vi.mock('$lib/db', () => ({
+	db: {
+		entities: {
+			where: vi.fn(),
+			toArray: vi.fn(),
+			filter: vi.fn()
+		}
+	}
+}));
+
+import { entityRepository } from '$lib/db/repositories/entityRepository';
+import { db } from '$lib/db';
+
+describe('sessionSummaryService', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('getTrailForSession', () => {
+		describe('Successful Trail Retrieval', () => {
+			it('should return array of narrative events for session', async () => {
+				const sessionId = 'session-123';
+
+				const event1: BaseEntity = {
+					id: 'event-1',
+					type: 'narrative_event',
+					name: 'Tavern Meeting',
+					description: 'The party meets at the tavern',
+					tags: [],
+					fields: {
+						eventType: 'scene',
+						session: sessionId
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T10:00:00Z'),
+					updatedAt: new Date('2025-01-01T10:00:00Z'),
+					metadata: {}
+				};
+
+				const event2: BaseEntity = {
+					id: 'event-2',
+					type: 'narrative_event',
+					name: 'Goblin Ambush',
+					description: 'Goblins attack on the road',
+					tags: [],
+					fields: {
+						eventType: 'combat',
+						session: sessionId,
+						outcome: 'Victory in 3 rounds, earned 2 VP'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T11:00:00Z'),
+					updatedAt: new Date('2025-01-01T11:00:00Z'),
+					metadata: {}
+				};
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue([event1, event2])
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await getTrailForSession(sessionId);
+
+				expect(result).toHaveLength(2);
+				expect(result[0]).toEqual(event1);
+				expect(result[1]).toEqual(event2);
+			});
+
+			it('should filter entities by type "narrative_event"', async () => {
+				const sessionId = 'session-filter-test';
+
+				const narrativeEvent: BaseEntity = {
+					id: 'event-1',
+					type: 'narrative_event',
+					name: 'Combat Scene',
+					description: 'A battle',
+					tags: [],
+					fields: {
+						eventType: 'combat',
+						session: sessionId
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T10:00:00Z'),
+					updatedAt: new Date('2025-01-01T10:00:00Z'),
+					metadata: {}
+				};
+
+				const npcEntity: BaseEntity = {
+					id: 'npc-1',
+					type: 'npc',
+					name: 'Random NPC',
+					description: 'Not a narrative event',
+					tags: [],
+					fields: {
+						session: sessionId // Has session field but wrong type
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T10:00:00Z'),
+					updatedAt: new Date('2025-01-01T10:00:00Z'),
+					metadata: {}
+				};
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue([narrativeEvent])
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await getTrailForSession(sessionId);
+
+				expect(result).toHaveLength(1);
+				expect(result[0].type).toBe('narrative_event');
+			});
+
+			it('should filter entities by session field matching sessionId', async () => {
+				const sessionId = 'session-456';
+
+				const matchingEvent: BaseEntity = {
+					id: 'event-match',
+					type: 'narrative_event',
+					name: 'Matching Event',
+					description: 'Belongs to session-456',
+					tags: [],
+					fields: {
+						eventType: 'scene',
+						session: sessionId
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T10:00:00Z'),
+					updatedAt: new Date('2025-01-01T10:00:00Z'),
+					metadata: {}
+				};
+
+				const nonMatchingEvent: BaseEntity = {
+					id: 'event-nomatch',
+					type: 'narrative_event',
+					name: 'Different Session Event',
+					description: 'Belongs to different session',
+					tags: [],
+					fields: {
+						eventType: 'combat',
+						session: 'session-789' // Different session
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T10:00:00Z'),
+					updatedAt: new Date('2025-01-01T10:00:00Z'),
+					metadata: {}
+				};
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue([matchingEvent])
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await getTrailForSession(sessionId);
+
+				expect(result).toHaveLength(1);
+				expect(result[0].fields.session).toBe(sessionId);
+			});
+
+			it('should order events by creation time (oldest first)', async () => {
+				const sessionId = 'session-order';
+
+				const event3: BaseEntity = {
+					id: 'event-3',
+					type: 'narrative_event',
+					name: 'Third Event',
+					description: 'Happened last',
+					tags: [],
+					fields: {
+						eventType: 'scene',
+						session: sessionId
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T12:00:00Z'),
+					updatedAt: new Date('2025-01-01T12:00:00Z'),
+					metadata: {}
+				};
+
+				const event1: BaseEntity = {
+					id: 'event-1',
+					type: 'narrative_event',
+					name: 'First Event',
+					description: 'Happened first',
+					tags: [],
+					fields: {
+						eventType: 'scene',
+						session: sessionId
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T10:00:00Z'),
+					updatedAt: new Date('2025-01-01T10:00:00Z'),
+					metadata: {}
+				};
+
+				const event2: BaseEntity = {
+					id: 'event-2',
+					type: 'narrative_event',
+					name: 'Second Event',
+					description: 'Happened second',
+					tags: [],
+					fields: {
+						eventType: 'combat',
+						session: sessionId
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T11:00:00Z'),
+					updatedAt: new Date('2025-01-01T11:00:00Z'),
+					metadata: {}
+				};
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue([event3, event1, event2])
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await getTrailForSession(sessionId);
+
+				expect(result).toHaveLength(3);
+				expect(result[0].name).toBe('First Event');
+				expect(result[1].name).toBe('Second Event');
+				expect(result[2].name).toBe('Third Event');
+			});
+
+			it('should use leads_to/follows relationships to determine order when available', async () => {
+				const sessionId = 'session-linked';
+
+				const event1: BaseEntity = {
+					id: 'event-start',
+					type: 'narrative_event',
+					name: 'Opening Scene',
+					description: 'Start of session',
+					tags: [],
+					fields: {
+						eventType: 'scene',
+						session: sessionId
+					},
+					links: [
+						{
+							id: 'link-1',
+							sourceId: 'event-start',
+							targetId: 'event-middle',
+							targetType: 'narrative_event',
+							relationship: 'leads_to',
+							bidirectional: true,
+							reverseRelationship: 'follows'
+						}
+					],
+					notes: '',
+					createdAt: new Date('2025-01-01T10:00:00Z'),
+					updatedAt: new Date('2025-01-01T10:00:00Z'),
+					metadata: {}
+				};
+
+				const event2: BaseEntity = {
+					id: 'event-middle',
+					type: 'narrative_event',
+					name: 'Middle Combat',
+					description: 'Middle of session',
+					tags: [],
+					fields: {
+						eventType: 'combat',
+						session: sessionId
+					},
+					links: [
+						{
+							id: 'link-2',
+							sourceId: 'event-middle',
+							targetId: 'event-start',
+							targetType: 'narrative_event',
+							relationship: 'follows',
+							bidirectional: true,
+							reverseRelationship: 'leads_to'
+						},
+						{
+							id: 'link-3',
+							sourceId: 'event-middle',
+							targetId: 'event-end',
+							targetType: 'narrative_event',
+							relationship: 'leads_to',
+							bidirectional: true,
+							reverseRelationship: 'follows'
+						}
+					],
+					notes: '',
+					createdAt: new Date('2025-01-01T11:00:00Z'),
+					updatedAt: new Date('2025-01-01T11:00:00Z'),
+					metadata: {}
+				};
+
+				const event3: BaseEntity = {
+					id: 'event-end',
+					type: 'narrative_event',
+					name: 'Closing Scene',
+					description: 'End of session',
+					tags: [],
+					fields: {
+						eventType: 'scene',
+						session: sessionId
+					},
+					links: [
+						{
+							id: 'link-4',
+							sourceId: 'event-end',
+							targetId: 'event-middle',
+							targetType: 'narrative_event',
+							relationship: 'follows',
+							bidirectional: true,
+							reverseRelationship: 'leads_to'
+						}
+					],
+					notes: '',
+					createdAt: new Date('2025-01-01T12:00:00Z'),
+					updatedAt: new Date('2025-01-01T12:00:00Z'),
+					metadata: {}
+				};
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue([event3, event2, event1])
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await getTrailForSession(sessionId);
+
+				expect(result).toHaveLength(3);
+				expect(result[0].id).toBe('event-start');
+				expect(result[1].id).toBe('event-middle');
+				expect(result[2].id).toBe('event-end');
+			});
+
+			it('should handle events with no session field gracefully', async () => {
+				const sessionId = 'session-missing-field';
+
+				const eventWithSession: BaseEntity = {
+					id: 'event-has-session',
+					type: 'narrative_event',
+					name: 'Has Session Field',
+					description: 'Has session',
+					tags: [],
+					fields: {
+						eventType: 'scene',
+						session: sessionId
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T10:00:00Z'),
+					updatedAt: new Date('2025-01-01T10:00:00Z'),
+					metadata: {}
+				};
+
+				const eventWithoutSession: BaseEntity = {
+					id: 'event-no-session',
+					type: 'narrative_event',
+					name: 'No Session Field',
+					description: 'Missing session field',
+					tags: [],
+					fields: {
+						eventType: 'combat'
+						// No session field
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T10:00:00Z'),
+					updatedAt: new Date('2025-01-01T10:00:00Z'),
+					metadata: {}
+				};
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue([eventWithSession])
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await getTrailForSession(sessionId);
+
+				expect(result).toHaveLength(1);
+				expect(result[0].id).toBe('event-has-session');
+			});
+		});
+
+		describe('Empty Results', () => {
+			it('should return empty array if no events found for session', async () => {
+				const sessionId = 'session-empty';
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue([])
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await getTrailForSession(sessionId);
+
+				expect(result).toEqual([]);
+				expect(result).toHaveLength(0);
+			});
+
+			it('should return empty array for non-existent session', async () => {
+				const sessionId = 'nonexistent-session';
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue([])
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await getTrailForSession(sessionId);
+
+				expect(result).toEqual([]);
+			});
+
+			it('should handle session with only non-narrative entities', async () => {
+				const sessionId = 'session-no-events';
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue([])
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await getTrailForSession(sessionId);
+
+				expect(result).toEqual([]);
+			});
+		});
+
+		describe('Edge Cases', () => {
+			it('should handle events with same creation time', async () => {
+				const sessionId = 'session-same-time';
+				const sameTime = new Date('2025-01-01T10:00:00Z');
+
+				const event1: BaseEntity = {
+					id: 'event-alpha',
+					type: 'narrative_event',
+					name: 'Alpha Event',
+					description: 'First alphabetically',
+					tags: [],
+					fields: {
+						eventType: 'scene',
+						session: sessionId
+					},
+					links: [],
+					notes: '',
+					createdAt: sameTime,
+					updatedAt: sameTime,
+					metadata: {}
+				};
+
+				const event2: BaseEntity = {
+					id: 'event-beta',
+					type: 'narrative_event',
+					name: 'Beta Event',
+					description: 'Second alphabetically',
+					tags: [],
+					fields: {
+						eventType: 'combat',
+						session: sessionId
+					},
+					links: [],
+					notes: '',
+					createdAt: sameTime,
+					updatedAt: sameTime,
+					metadata: {}
+				};
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue([event2, event1])
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await getTrailForSession(sessionId);
+
+				expect(result).toHaveLength(2);
+				// Should maintain some consistent order
+				expect(result[0]).toBeDefined();
+				expect(result[1]).toBeDefined();
+			});
+
+			it('should handle single event for session', async () => {
+				const sessionId = 'session-single';
+
+				const singleEvent: BaseEntity = {
+					id: 'event-only',
+					type: 'narrative_event',
+					name: 'Only Event',
+					description: 'The only event',
+					tags: [],
+					fields: {
+						eventType: 'montage',
+						session: sessionId,
+						outcome: 'total_success'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T10:00:00Z'),
+					updatedAt: new Date('2025-01-01T10:00:00Z'),
+					metadata: {}
+				};
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue([singleEvent])
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await getTrailForSession(sessionId);
+
+				expect(result).toHaveLength(1);
+				expect(result[0].id).toBe('event-only');
+			});
+
+			it('should handle events with circular leads_to/follows relationships', async () => {
+				const sessionId = 'session-circular';
+
+				const eventA: BaseEntity = {
+					id: 'event-a',
+					type: 'narrative_event',
+					name: 'Event A',
+					description: 'Part of circle',
+					tags: [],
+					fields: {
+						eventType: 'scene',
+						session: sessionId
+					},
+					links: [
+						{
+							id: 'link-a-b',
+							sourceId: 'event-a',
+							targetId: 'event-b',
+							targetType: 'narrative_event',
+							relationship: 'leads_to',
+							bidirectional: true
+						}
+					],
+					notes: '',
+					createdAt: new Date('2025-01-01T10:00:00Z'),
+					updatedAt: new Date('2025-01-01T10:00:00Z'),
+					metadata: {}
+				};
+
+				const eventB: BaseEntity = {
+					id: 'event-b',
+					type: 'narrative_event',
+					name: 'Event B',
+					description: 'Part of circle',
+					tags: [],
+					fields: {
+						eventType: 'combat',
+						session: sessionId
+					},
+					links: [
+						{
+							id: 'link-b-a',
+							sourceId: 'event-b',
+							targetId: 'event-a',
+							targetType: 'narrative_event',
+							relationship: 'leads_to',
+							bidirectional: true
+						}
+					],
+					notes: '',
+					createdAt: new Date('2025-01-01T11:00:00Z'),
+					updatedAt: new Date('2025-01-01T11:00:00Z'),
+					metadata: {}
+				};
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue([eventB, eventA])
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await getTrailForSession(sessionId);
+
+				// Should fall back to creation time ordering
+				expect(result).toHaveLength(2);
+				expect(result[0].id).toBe('event-a');
+				expect(result[1].id).toBe('event-b');
+			});
+
+			it('should handle large number of events efficiently', async () => {
+				const sessionId = 'session-large';
+
+				const events: BaseEntity[] = Array.from({ length: 100 }, (_, i) => ({
+					id: `event-${i}`,
+					type: 'narrative_event' as const,
+					name: `Event ${i}`,
+					description: `Event number ${i}`,
+					tags: [],
+					fields: {
+						eventType: 'scene',
+						session: sessionId
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date(`2025-01-01T${String(10 + Math.floor(i / 60)).padStart(2, '0')}:${String(i % 60).padStart(2, '0')}:00Z`),
+					updatedAt: new Date(`2025-01-01T${String(10 + Math.floor(i / 60)).padStart(2, '0')}:${String(i % 60).padStart(2, '0')}:00Z`),
+					metadata: {}
+				}));
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue(events)
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await getTrailForSession(sessionId);
+
+				expect(result).toHaveLength(100);
+				expect(result[0].id).toBe('event-0');
+				expect(result[99].id).toBe('event-99');
+			});
+		});
+
+		describe('Error Handling', () => {
+			it('should throw error if database query fails', async () => {
+				const sessionId = 'session-error';
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockRejectedValue(new Error('Database error'))
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				await expect(getTrailForSession(sessionId)).rejects.toThrow('Database error');
+			});
+
+			it('should handle null or undefined sessionId gracefully', async () => {
+				// @ts-expect-error - Testing invalid input
+				await expect(getTrailForSession(null)).rejects.toThrow();
+			});
+
+			it('should handle empty string sessionId', async () => {
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue([])
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await getTrailForSession('');
+
+				expect(result).toEqual([]);
+			});
+		});
+	});
+
+	describe('generateSummary', () => {
+		describe('Successful Summary Generation', () => {
+			it('should generate narrative text from session trail', async () => {
+				const sessionId = 'session-summary-1';
+
+				const event1: BaseEntity = {
+					id: 'event-1',
+					type: 'narrative_event',
+					name: 'Tavern Meeting',
+					description: 'The party meets at the tavern',
+					tags: [],
+					fields: {
+						eventType: 'scene',
+						session: sessionId
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T10:00:00Z'),
+					updatedAt: new Date('2025-01-01T10:00:00Z'),
+					metadata: {}
+				};
+
+				const event2: BaseEntity = {
+					id: 'event-2',
+					type: 'narrative_event',
+					name: 'Goblin Ambush',
+					description: 'Goblins attack on the road',
+					tags: [],
+					fields: {
+						eventType: 'combat',
+						session: sessionId,
+						outcome: 'Victory in 3 rounds, earned 2 VP'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T11:00:00Z'),
+					updatedAt: new Date('2025-01-01T11:00:00Z'),
+					metadata: {}
+				};
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue([event1, event2])
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await generateSummary(sessionId);
+
+				expect(result).toBeTruthy();
+				expect(typeof result).toBe('string');
+				expect(result.length).toBeGreaterThan(0);
+			});
+
+			it('should include event names in summary', async () => {
+				const sessionId = 'session-names';
+
+				const event: BaseEntity = {
+					id: 'event-1',
+					type: 'narrative_event',
+					name: 'Dragon Confrontation',
+					description: 'Face to face with the dragon',
+					tags: [],
+					fields: {
+						eventType: 'scene',
+						session: sessionId
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T10:00:00Z'),
+					updatedAt: new Date('2025-01-01T10:00:00Z'),
+					metadata: {}
+				};
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue([event])
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await generateSummary(sessionId);
+
+				expect(result).toContain('Dragon Confrontation');
+			});
+
+			it('should include event types in summary', async () => {
+				const sessionId = 'session-types';
+
+				const combatEvent: BaseEntity = {
+					id: 'event-combat',
+					type: 'narrative_event',
+					name: 'Battle',
+					description: 'A fierce battle',
+					tags: [],
+					fields: {
+						eventType: 'combat',
+						session: sessionId,
+						outcome: 'Victory'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T10:00:00Z'),
+					updatedAt: new Date('2025-01-01T10:00:00Z'),
+					metadata: {}
+				};
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue([combatEvent])
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await generateSummary(sessionId);
+
+				expect(result.toLowerCase()).toMatch(/combat|battle|fight/);
+			});
+
+			it('should include outcome field when present', async () => {
+				const sessionId = 'session-outcome';
+
+				const event: BaseEntity = {
+					id: 'event-1',
+					type: 'narrative_event',
+					name: 'Wilderness Trek',
+					description: 'Journey through wilderness',
+					tags: [],
+					fields: {
+						eventType: 'montage',
+						session: sessionId,
+						outcome: 'total_success'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T10:00:00Z'),
+					updatedAt: new Date('2025-01-01T10:00:00Z'),
+					metadata: {}
+				};
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue([event])
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await generateSummary(sessionId);
+
+				expect(result.toLowerCase()).toContain('success');
+			});
+
+			it('should connect multiple events with narrative transitions', async () => {
+				const sessionId = 'session-transitions';
+
+				const event1: BaseEntity = {
+					id: 'event-1',
+					type: 'narrative_event',
+					name: 'First Event',
+					description: 'Beginning',
+					tags: [],
+					fields: {
+						eventType: 'scene',
+						session: sessionId
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T10:00:00Z'),
+					updatedAt: new Date('2025-01-01T10:00:00Z'),
+					metadata: {}
+				};
+
+				const event2: BaseEntity = {
+					id: 'event-2',
+					type: 'narrative_event',
+					name: 'Second Event',
+					description: 'Middle',
+					tags: [],
+					fields: {
+						eventType: 'combat',
+						session: sessionId,
+						outcome: 'Victory'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T11:00:00Z'),
+					updatedAt: new Date('2025-01-01T11:00:00Z'),
+					metadata: {}
+				};
+
+				const event3: BaseEntity = {
+					id: 'event-3',
+					type: 'narrative_event',
+					name: 'Third Event',
+					description: 'End',
+					tags: [],
+					fields: {
+						eventType: 'scene',
+						session: sessionId
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T12:00:00Z'),
+					updatedAt: new Date('2025-01-01T12:00:00Z'),
+					metadata: {}
+				};
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue([event1, event2, event3])
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await generateSummary(sessionId);
+
+				// Should contain some form of transition words
+				expect(result.toLowerCase()).toMatch(/then|next|after|following|subsequently/);
+			});
+
+			it('should format different event types appropriately', async () => {
+				const sessionId = 'session-format';
+
+				const sceneEvent: BaseEntity = {
+					id: 'event-scene',
+					type: 'narrative_event',
+					name: 'Investigation Scene',
+					description: 'Searching for clues',
+					tags: [],
+					fields: {
+						eventType: 'scene',
+						session: sessionId
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T10:00:00Z'),
+					updatedAt: new Date('2025-01-01T10:00:00Z'),
+					metadata: {}
+				};
+
+				const combatEvent: BaseEntity = {
+					id: 'event-combat',
+					type: 'narrative_event',
+					name: 'Boss Fight',
+					description: 'Epic battle',
+					tags: [],
+					fields: {
+						eventType: 'combat',
+						session: sessionId,
+						outcome: 'Victory in 10 rounds, earned 5 VP'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T11:00:00Z'),
+					updatedAt: new Date('2025-01-01T11:00:00Z'),
+					metadata: {}
+				};
+
+				const montageEvent: BaseEntity = {
+					id: 'event-montage',
+					type: 'narrative_event',
+					name: 'Training Montage',
+					description: 'Heroes train',
+					tags: [],
+					fields: {
+						eventType: 'montage',
+						session: sessionId,
+						outcome: 'partial_success'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T12:00:00Z'),
+					updatedAt: new Date('2025-01-01T12:00:00Z'),
+					metadata: {}
+				};
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue([sceneEvent, combatEvent, montageEvent])
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await generateSummary(sessionId);
+
+				expect(result).toContain('Investigation Scene');
+				expect(result).toContain('Boss Fight');
+				expect(result).toContain('Training Montage');
+			});
+		});
+
+		describe('Empty Sessions', () => {
+			it('should handle empty trail gracefully', async () => {
+				const sessionId = 'session-empty-trail';
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue([])
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await generateSummary(sessionId);
+
+				expect(result).toBeTruthy();
+				expect(typeof result).toBe('string');
+			});
+
+			it('should return appropriate message for session with no events', async () => {
+				const sessionId = 'session-no-events';
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue([])
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await generateSummary(sessionId);
+
+				expect(result.toLowerCase()).toMatch(/no events|empty|nothing/);
+			});
+		});
+
+		describe('Edge Cases', () => {
+			it('should handle single event session', async () => {
+				const sessionId = 'session-single-event';
+
+				const event: BaseEntity = {
+					id: 'event-only',
+					type: 'narrative_event',
+					name: 'Solo Event',
+					description: 'Only event',
+					tags: [],
+					fields: {
+						eventType: 'scene',
+						session: sessionId
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T10:00:00Z'),
+					updatedAt: new Date('2025-01-01T10:00:00Z'),
+					metadata: {}
+				};
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue([event])
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await generateSummary(sessionId);
+
+				expect(result).toContain('Solo Event');
+				expect(result.length).toBeGreaterThan(0);
+			});
+
+			it('should handle events without outcome field', async () => {
+				const sessionId = 'session-no-outcome';
+
+				const event: BaseEntity = {
+					id: 'event-1',
+					type: 'narrative_event',
+					name: 'Scene Without Outcome',
+					description: 'Simple scene',
+					tags: [],
+					fields: {
+						eventType: 'scene',
+						session: sessionId
+						// No outcome field
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T10:00:00Z'),
+					updatedAt: new Date('2025-01-01T10:00:00Z'),
+					metadata: {}
+				};
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue([event])
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await generateSummary(sessionId);
+
+				expect(result).toContain('Scene Without Outcome');
+			});
+
+			it('should handle very long event names', async () => {
+				const sessionId = 'session-long-name';
+
+				const event: BaseEntity = {
+					id: 'event-1',
+					type: 'narrative_event',
+					name: 'The Incredibly Long and Extremely Detailed Name of an Epic Battle That Took Place at the Ancient Ruins Near the Forgotten Temple of the Lost Gods',
+					description: 'Long name event',
+					tags: [],
+					fields: {
+						eventType: 'combat',
+						session: sessionId,
+						outcome: 'Victory'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T10:00:00Z'),
+					updatedAt: new Date('2025-01-01T10:00:00Z'),
+					metadata: {}
+				};
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue([event])
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await generateSummary(sessionId);
+
+				expect(result).toBeDefined();
+				expect(result.length).toBeGreaterThan(0);
+			});
+
+			it('should handle special characters in event names', async () => {
+				const sessionId = 'session-special-chars';
+
+				const event: BaseEntity = {
+					id: 'event-1',
+					type: 'narrative_event',
+					name: 'Battle @ "The Dragon\'s Lair" & More!',
+					description: 'Special characters',
+					tags: [],
+					fields: {
+						eventType: 'combat',
+						session: sessionId,
+						outcome: 'Victory'
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T10:00:00Z'),
+					updatedAt: new Date('2025-01-01T10:00:00Z'),
+					metadata: {}
+				};
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue([event])
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await generateSummary(sessionId);
+
+				expect(result).toContain('Dragon');
+			});
+
+			it('should handle large number of events', async () => {
+				const sessionId = 'session-many-events';
+
+				const events: BaseEntity[] = Array.from({ length: 20 }, (_, i) => ({
+					id: `event-${i}`,
+					type: 'narrative_event' as const,
+					name: `Event ${i}`,
+					description: `Event number ${i}`,
+					tags: [],
+					fields: {
+						eventType: i % 2 === 0 ? 'scene' : 'combat',
+						session: sessionId,
+						...(i % 2 === 1 ? { outcome: 'Victory' } : {})
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date(`2025-01-01T${String(10 + i).padStart(2, '0')}:00:00Z`),
+					updatedAt: new Date(`2025-01-01T${String(10 + i).padStart(2, '0')}:00:00Z`),
+					metadata: {}
+				}));
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue(events)
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await generateSummary(sessionId);
+
+				expect(result.length).toBeGreaterThan(100); // Should be substantial
+				expect(result).toContain('Event 0');
+				expect(result).toContain('Event 19');
+			});
+		});
+
+		describe('Error Handling', () => {
+			it('should throw error if getTrailForSession fails', async () => {
+				const sessionId = 'session-trail-error';
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockRejectedValue(new Error('Trail fetch failed'))
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				await expect(generateSummary(sessionId)).rejects.toThrow('Trail fetch failed');
+			});
+
+			it('should handle null sessionId', async () => {
+				// @ts-expect-error - Testing invalid input
+				await expect(generateSummary(null)).rejects.toThrow();
+			});
+
+			it('should handle undefined sessionId', async () => {
+				// @ts-expect-error - Testing invalid input
+				await expect(generateSummary(undefined)).rejects.toThrow();
+			});
+
+			it('should handle empty string sessionId', async () => {
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue([])
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await generateSummary('');
+
+				expect(result).toBeDefined();
+			});
+		});
+
+		describe('Narrative Quality', () => {
+			it('should produce readable text (not JSON or raw data)', async () => {
+				const sessionId = 'session-readable';
+
+				const event: BaseEntity = {
+					id: 'event-1',
+					type: 'narrative_event',
+					name: 'Market Chase',
+					description: 'Chase through marketplace',
+					tags: [],
+					fields: {
+						eventType: 'scene',
+						session: sessionId
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T10:00:00Z'),
+					updatedAt: new Date('2025-01-01T10:00:00Z'),
+					metadata: {}
+				};
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue([event])
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await generateSummary(sessionId);
+
+				// Should not look like JSON
+				expect(result).not.toMatch(/^\s*{/);
+				expect(result).not.toMatch(/^\s*\[/);
+				// Should contain words
+				expect(result).toMatch(/\w+\s+\w+/);
+			});
+
+			it('should use proper sentence structure', async () => {
+				const sessionId = 'session-sentences';
+
+				const event: BaseEntity = {
+					id: 'event-1',
+					type: 'narrative_event',
+					name: 'Throne Room',
+					description: 'Meeting the king',
+					tags: [],
+					fields: {
+						eventType: 'scene',
+						session: sessionId
+					},
+					links: [],
+					notes: '',
+					createdAt: new Date('2025-01-01T10:00:00Z'),
+					updatedAt: new Date('2025-01-01T10:00:00Z'),
+					metadata: {}
+				};
+
+				const mockFilter = vi.fn().mockReturnValue({
+					toArray: vi.fn().mockResolvedValue([event])
+				});
+
+				vi.mocked(db.entities.filter).mockReturnValue(mockFilter() as any);
+
+				const result = await generateSummary(sessionId);
+
+				// Should have sentence-like structure
+				expect(result).toMatch(/[.!?]/); // Has punctuation
+			});
+		});
+	});
+});

--- a/src/lib/services/sessionSummaryService.ts
+++ b/src/lib/services/sessionSummaryService.ts
@@ -1,0 +1,245 @@
+/**
+ * Session Summary Service (Issue #401)
+ *
+ * Generates narrative summaries from session trails by ordering narrative events
+ * chronologically and constructing readable prose.
+ */
+
+import { db } from '$lib/db';
+import type { BaseEntity } from '$lib/types';
+
+/**
+ * Get the ordered trail of narrative events for a session.
+ *
+ * Retrieves all narrative_event entities linked to a session, ordered chronologically.
+ * Uses leads_to/follows relationships for ordering when available, falls back to
+ * creation time ordering otherwise.
+ *
+ * @param sessionId - The session ID to retrieve events for
+ * @returns Promise resolving to ordered array of narrative events (oldest first)
+ * @throws Error if sessionId is null or undefined
+ * @throws Error if database query fails
+ */
+export async function getTrailForSession(sessionId: string): Promise<BaseEntity[]> {
+	// Validate sessionId
+	if (sessionId === null || sessionId === undefined) {
+		throw new Error('sessionId cannot be null or undefined');
+	}
+
+	// Handle empty string - return empty array
+	if (sessionId === '') {
+		return [];
+	}
+
+	// Query database for narrative events with matching session field
+	const events = await db.entities
+		.filter((entity) => {
+			// Filter by type
+			if (entity.type !== 'narrative_event') {
+				return false;
+			}
+
+			// Filter by session field
+			if (entity.fields?.session !== sessionId) {
+				return false;
+			}
+
+			return true;
+		})
+		.toArray();
+
+	// If no events, return empty array
+	if (events.length === 0) {
+		return [];
+	}
+
+	// Try to order by leads_to/follows relationships
+	const ordered = orderByRelationships(events);
+
+	// If relationship ordering worked, return it
+	if (ordered.length === events.length) {
+		return ordered;
+	}
+
+	// Fall back to creation time ordering (oldest first)
+	return events.sort((a, b) => {
+		const timeA = a.createdAt instanceof Date ? a.createdAt.getTime() : 0;
+		const timeB = b.createdAt instanceof Date ? b.createdAt.getTime() : 0;
+		return timeA - timeB;
+	});
+}
+
+/**
+ * Attempt to order events by leads_to/follows relationships.
+ * Uses topological sort to find a valid ordering.
+ *
+ * @param events - Array of narrative events to order
+ * @returns Ordered array of events, or partial array if cycles detected
+ */
+function orderByRelationships(events: BaseEntity[]): BaseEntity[] {
+	// Build a map of event ID to event
+	const eventMap = new Map<string, BaseEntity>();
+	for (const event of events) {
+		eventMap.set(event.id, event);
+	}
+
+	// Build adjacency list for leads_to relationships
+	const outgoing = new Map<string, string[]>(); // event -> events it leads to
+	const incoming = new Map<string, number>(); // event -> count of events that lead to it
+
+	// Initialize maps
+	for (const event of events) {
+		outgoing.set(event.id, []);
+		incoming.set(event.id, 0);
+	}
+
+	// Build graph from links
+	for (const event of events) {
+		for (const link of event.links) {
+			if (link.relationship === 'leads_to' && eventMap.has(link.targetId)) {
+				// Add edge from event to target
+				outgoing.get(event.id)!.push(link.targetId);
+				incoming.set(link.targetId, incoming.get(link.targetId)! + 1);
+			}
+		}
+	}
+
+	// Topological sort using Kahn's algorithm
+	const result: BaseEntity[] = [];
+	const queue: string[] = [];
+
+	// Find all nodes with no incoming edges (starting points)
+	for (const [eventId, count] of incoming.entries()) {
+		if (count === 0) {
+			queue.push(eventId);
+		}
+	}
+
+	// Process queue
+	while (queue.length > 0) {
+		// Sort queue for deterministic ordering when multiple starting points
+		queue.sort();
+
+		const eventId = queue.shift()!;
+		const event = eventMap.get(eventId);
+
+		if (event) {
+			result.push(event);
+
+			// Reduce incoming count for all neighbors
+			const neighbors = outgoing.get(eventId) || [];
+			for (const neighborId of neighbors) {
+				const count = incoming.get(neighborId)!;
+				incoming.set(neighborId, count - 1);
+
+				// If no more incoming edges, add to queue
+				if (count - 1 === 0) {
+					queue.push(neighborId);
+				}
+			}
+		}
+	}
+
+	// If result doesn't contain all events, there's a cycle
+	// Fall back to creation time ordering
+	if (result.length !== events.length) {
+		return events.sort((a, b) => {
+			const timeA = a.createdAt instanceof Date ? a.createdAt.getTime() : 0;
+			const timeB = b.createdAt instanceof Date ? b.createdAt.getTime() : 0;
+			return timeA - timeB;
+		});
+	}
+
+	return result;
+}
+
+/**
+ * Generate a narrative summary from a session's trail of events.
+ *
+ * Constructs human-readable prose from ordered narrative events,
+ * including event names, types, and outcomes with narrative transitions.
+ *
+ * @param sessionId - The session ID to generate a summary for
+ * @returns Promise resolving to formatted narrative text
+ * @throws Error if sessionId is null or undefined
+ * @throws Error if database query fails
+ */
+export async function generateSummary(sessionId: string): Promise<string> {
+	// Validate sessionId
+	if (sessionId === null || sessionId === undefined) {
+		throw new Error('sessionId cannot be null or undefined');
+	}
+
+	// Get ordered events
+	const events = await getTrailForSession(sessionId);
+
+	// Handle empty trail
+	if (events.length === 0) {
+		return 'No events recorded for this session.';
+	}
+
+	// Build narrative summary
+	const paragraphs: string[] = [];
+
+	for (let i = 0; i < events.length; i++) {
+		const event = events[i];
+		const isFirst = i === 0;
+		const isLast = i === events.length - 1;
+
+		// Build event paragraph
+		let paragraph = '';
+
+		// Add transition
+		if (isFirst) {
+			paragraph += 'The session began with ';
+		} else if (isLast) {
+			paragraph += 'The session concluded with ';
+		} else {
+			// Vary transitions for middle events
+			const transitions = [
+				'Following this, ',
+				'Then, ',
+				'Next, ',
+				'After that, ',
+				'Subsequently, '
+			];
+			paragraph += transitions[i % transitions.length];
+		}
+
+		// Add event type descriptor
+		const eventType = event.fields?.eventType as string;
+		if (eventType === 'combat') {
+			paragraph += 'a combat encounter: ';
+		} else if (eventType === 'montage') {
+			paragraph += 'a montage: ';
+		} else if (eventType === 'scene') {
+			paragraph += 'a scene: ';
+		} else {
+			paragraph += 'an event: ';
+		}
+
+		// Add event name
+		paragraph += event.name;
+
+		// Add outcome if present
+		const outcome = event.fields?.outcome as string | undefined;
+		if (outcome) {
+			// Format outcome based on type
+			if (typeof outcome === 'string') {
+				// Convert snake_case to readable text
+				const readableOutcome = outcome
+					.replace(/_/g, ' ')
+					.replace(/\b\w/g, (char) => char.toUpperCase());
+
+				paragraph += `. Outcome: ${readableOutcome}`;
+			}
+		}
+
+		paragraph += '.';
+
+		paragraphs.push(paragraph);
+	}
+
+	// Join paragraphs into narrative
+	return paragraphs.join(' ');
+}

--- a/src/lib/types/entities.ts
+++ b/src/lib/types/entities.ts
@@ -11,6 +11,7 @@ export type EntityType =
 	| 'timeline_event'
 	| 'world_rule'
 	| 'player_profile'
+	| 'narrative_event'
 	| string; // Allow custom types
 
 // Unique identifier type (nanoid-generated)


### PR DESCRIPTION
## Summary

Implements the complete Narrative Trail feature (Epic #397), enabling session summarization and story flow visualization by linking game elements into sequential narrative chains.

### Issues Closed
- Closes #397 - Epic: Narrative Trail Feature
- Closes #398 - Add NarrativeEvent entity type
- Closes #399 - Create NarrativeEvent service with auto-creation
- Closes #400 - Build Timeline View UI components
- Closes #401 - Create Session Summary service

### Changes

**New Entity Type**
- `narrative_event` with fields: eventType, sourceId, outcome, session
- Supports scene, combat, montage, negotiation, and other event types

**Services**
- `narrativeEventService.ts` - Creates events from combat/montage/scene, links events
- `sessionSummaryService.ts` - Traverses trails and generates narrative summaries

**UI Components**
- `NarrativeTimeline.svelte` - Chronological timeline view
- `TimelineEvent.svelte` - Individual event cards with icons

**Auto-Creation Integration**
- Combat repository: auto-creates narrative event on `endCombat()`
- Montage repository: auto-creates narrative event on `completeMontage()`

### Test Coverage
- 219 new tests (all passing)
- Entity type tests: 54
- Service tests: 81
- Component tests: 84

### Documentation
- Updated README.md, CHANGELOG.md
- Updated USER_GUIDE.md and ARCHITECTURE.md

🤖 Generated with [Claude Code](https://claude.ai/code)