### PR TITLE
fix(scene): add dark mode text and icon visibility

### DIFF
--- a/src/lib/components/scene/SceneContextPanel.svelte
+++ b/src/lib/components/scene/SceneContextPanel.svelte
@@ -78,7 +78,7 @@ const hasContext = $derived(!!locationRef || (npcRefs && npcRefs.length > 0));
 </script>
 
 <div class="scene-context-panel border border-gray-300 dark:border-gray-600 rounded-lg p-4">
-	<h3 class="text-lg font-semibold mb-3">Scene Context</h3>
+	<h3 class="text-lg font-semibold mb-3 text-gray-900 dark:text-gray-100">Scene Context</h3>
 
 	{#if !hasContext}
 		<p class="text-gray-500 dark:text-gray-400 text-sm">No context information defined</p>
@@ -89,7 +89,7 @@ const hasContext = $derived(!!locationRef || (npcRefs && npcRefs.length > 0));
 				<span class="text-sm font-medium text-gray-600 dark:text-gray-400">Location:</span>
 
 				{#if locationLoading}
-					<p class="text-sm text-gray-500">Loading...</p>
+					<p class="text-sm text-gray-500 dark:text-gray-400">Loading...</p>
 				{:else if location}
 					<button
 						class="ml-2 text-blue-600 dark:text-blue-400 hover:underline"
@@ -110,7 +110,7 @@ const hasContext = $derived(!!locationRef || (npcRefs && npcRefs.length > 0));
 				<span class="text-sm font-medium text-gray-600 dark:text-gray-400">NPCs:</span>
 
 				{#if npcsLoading}
-					<p class="text-sm text-gray-500">Loading...</p>
+					<p class="text-sm text-gray-500 dark:text-gray-400">Loading...</p>
 				{:else if npcs.length > 0}
 					<ul class="list-disc list-inside ml-2 mt-1">
 						{#each npcs as npc}

--- a/src/lib/components/scene/SceneHeader.svelte
+++ b/src/lib/components/scene/SceneHeader.svelte
@@ -44,14 +44,14 @@ function handleComplete() {
 		<div class="flex items-center gap-3">
 			<button
 				type="button"
-				class="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg"
+				class="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg text-gray-700 dark:text-gray-300"
 				onclick={handleBack}
 				aria-label="Back to scene list"
 			>
 				<ArrowLeft size={20} />
 			</button>
 
-			<h1 class="text-2xl font-bold">{sceneName}</h1>
+			<h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">{sceneName}</h1>
 
 			<SceneStatusBadge {status} />
 		</div>
@@ -59,7 +59,7 @@ function handleComplete() {
 		<div class="flex items-center gap-2">
 			<button
 				type="button"
-				class="flex items-center gap-2 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700"
+				class="flex items-center gap-2 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300"
 				onclick={handleEdit}
 			>
 				<Edit size={16} />

--- a/src/lib/components/scene/SceneNoteCapture.svelte
+++ b/src/lib/components/scene/SceneNoteCapture.svelte
@@ -53,7 +53,7 @@ $effect(() => {
 </script>
 
 <div class="scene-note-capture">
-	<label for="scene-notes-{sceneId}" class="block text-sm font-medium mb-2">
+	<label for="scene-notes-{sceneId}" class="block text-sm font-medium mb-2 text-gray-900 dark:text-gray-100">
 		What Happened
 	</label>
 

--- a/src/routes/scene/+page.svelte
+++ b/src/routes/scene/+page.svelte
@@ -72,7 +72,7 @@ $effect(() => {
 
 <div class="scene-list-page container mx-auto p-6">
 	<div class="flex items-center justify-between mb-6">
-		<h1 class="text-3xl font-bold">Scenes</h1>
+		<h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100">Scenes</h1>
 		<button
 			type="button"
 			class="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md"
@@ -138,7 +138,7 @@ $effect(() => {
 				>
 					<div class="flex-1">
 						<div class="flex items-center gap-3 mb-2">
-							<h2 class="text-lg font-semibold">{scene.name}</h2>
+							<h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">{scene.name}</h2>
 							<SceneStatusBadge status={(scene.fields.sceneStatus as 'planned' | 'in_progress' | 'completed') ?? 'planned'} />
 						</div>
 						{#if scene.description}


### PR DESCRIPTION
## Summary

Fixes #420

- Add missing `dark:text-gray-100` to headings on Scene pages
- Add `dark:text-gray-300` to labels, buttons, and icon containers
- Fix back arrow icon visibility by adding text color to parent button
- Add `dark:text-gray-400` to loading text

## Files Changed

- `src/routes/scene/+page.svelte`
- `src/lib/components/scene/SceneHeader.svelte`
- `src/lib/components/scene/SceneContextPanel.svelte`
- `src/lib/components/scene/SceneNoteCapture.svelte`

## Test plan

- [ ] View Scene list page in dark mode - heading and scene names visible
- [ ] View Scene detail page in dark mode - back arrow, scene name, Edit button visible
- [ ] Verify "Scene Context" heading and "What Happened" label visible in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)