### PR TITLE
fix: resolve 6 TypeScript errors in test files

### DIFF
--- a/src/lib/config/systemGenerationOverrides.test.ts
+++ b/src/lib/config/systemGenerationOverrides.test.ts
@@ -95,8 +95,7 @@ describe('systemGenerationOverrides', () => {
 		});
 
 		it('should return null for unknown system', () => {
-			// @ts-expect-error - Testing invalid input
-			const override = getSystemGenerationOverride('unknown-system', 'npc');
+			const override = getSystemGenerationOverride('unknown-system' as any, 'npc');
 			expect(override).toBeNull();
 		});
 
@@ -481,8 +480,7 @@ describe('systemGenerationOverrides', () => {
 
 	describe('Edge cases', () => {
 		it('should handle invalid system IDs gracefully', () => {
-			// @ts-expect-error - Testing invalid input
-			const override = getSystemGenerationOverride('invalid-system-id', 'npc');
+			const override = getSystemGenerationOverride('invalid-system-id' as any, 'npc');
 			expect(override).toBeNull();
 		});
 
@@ -555,7 +553,7 @@ describe('systemGenerationOverrides', () => {
 			expect(result.typeFields?.find(f => f.key === 'new')).toBeDefined();
 
 			// Original should not be mutated
-			expect(baseWithFields.typeFields.length).toBe(1);
+			expect(baseWithFields.typeFields!.length).toBe(1);
 		});
 	});
 

--- a/src/lib/services/chatService.generationType.test.ts
+++ b/src/lib/services/chatService.generationType.test.ts
@@ -448,8 +448,6 @@ describe('chatService - Generation Type Integration', () => {
 	describe('Error handling with generationType', () => {
 		it('should handle API errors with generationType', async () => {
 			mockMessagesCreate.mockRejectedValue(new Error('API error'));
-			'negotiation',
-			'montage',
 
 			await expect(
 				sendChatMessage('Test', [], true, undefined, 'npc')
@@ -1443,6 +1441,8 @@ describe('chatService - Generation Type Integration', () => {
 					onStream,
 					'combat',
 					{ encounterDifficulty: 'medium' },
+					false,
+					'summary',
 					'draw-steel'
 				);
 


### PR DESCRIPTION
## Summary
- Remove unused `@ts-expect-error` directives in systemGenerationOverrides tests (use `as any` instead)
- Add non-null assertion for `typeFields.length` check
- Remove orphaned string expressions in chatService error handling test
- Fix `sendChatMessage` parameter order (add `sendAllContext`, `contextDetailLevel` before `systemId`)

Fixes type check from 6 errors to 0 errors.

## Test plan
- [x] `svelte-check --threshold error` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)