### PR TITLE
feat(layout): responsive shell layout with mobile sidebar drawer

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -17,10 +17,16 @@
 	/* Dashboard grid layout */
 	.dashboard-layout {
 		display: grid;
-		grid-template-columns: var(--sidebar-width) 1fr;
+		grid-template-columns: 1fr;
 		grid-template-rows: var(--header-height) 1fr;
-		height: 100vh;
+		height: 100dvh;
 		overflow: hidden;
+	}
+
+	@media (min-width: 1024px) {
+		.dashboard-layout {
+			grid-template-columns: var(--sidebar-width) 1fr;
+		}
 	}
 
 	.dashboard-header {
@@ -29,8 +35,32 @@
 	}
 
 	.dashboard-sidebar {
-		grid-row: 2;
 		@apply overflow-y-auto border-r border-slate-200 dark:border-slate-700;
+	}
+
+	/* Mobile: sidebar is a fixed overlay drawer */
+	@media (max-width: 1023px) {
+		.dashboard-sidebar {
+			position: fixed;
+			top: var(--header-height);
+			left: 0;
+			bottom: 0;
+			width: var(--sidebar-width);
+			z-index: 40;
+			transform: translateX(-100%);
+			transition: transform 0.2s ease-in-out;
+		}
+
+		.dashboard-sidebar.mobile-open {
+			transform: translateX(0);
+		}
+	}
+
+	/* Desktop: sidebar is in-grid */
+	@media (min-width: 1024px) {
+		.dashboard-sidebar {
+			grid-row: 2;
+		}
 	}
 
 	.dashboard-main {
@@ -38,9 +68,24 @@
 		@apply flex overflow-hidden;
 	}
 
+	/* Sidebar backdrop for mobile */
+	.sidebar-backdrop {
+		position: fixed;
+		inset: 0;
+		top: var(--header-height);
+		z-index: 30;
+		background-color: rgba(0, 0, 0, 0.5);
+	}
+
 	/* Panel system */
 	.panel {
-		@apply flex-1 min-w-[320px] overflow-y-auto border-r border-slate-200 dark:border-slate-700 last:border-r-0;
+		@apply flex-1 overflow-y-auto border-r border-slate-200 dark:border-slate-700 last:border-r-0;
+	}
+
+	@media (min-width: 1024px) {
+		.panel {
+			min-width: 320px;
+		}
 	}
 
 	.panel-resizer {

--- a/src/lib/components/layout/Header.svelte
+++ b/src/lib/components/layout/Header.svelte
@@ -42,7 +42,7 @@
 	<div class="flex items-center gap-4">
 		<button
 			class="btn btn-ghost p-2 lg:hidden"
-			onclick={() => uiStore.toggleSidebar()}
+			onclick={() => uiStore.toggleMobileSidebar()}
 			aria-label="Toggle sidebar"
 		>
 			<Menu class="w-5 h-5 text-slate-700 dark:text-slate-300" />

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -13,6 +13,8 @@
 	import type { EntityTypeDefinition } from '$lib/types';
 	import { onMount } from 'svelte';
 
+	let { mobileOpen = false }: { mobileOpen?: boolean } = $props();
+
 	let quickAddOpen = $state(false);
 	let editMode = $state(false);
 	let orderedTypes = $state<EntityTypeDefinition[]>([]);
@@ -98,7 +100,7 @@
 	}
 </script>
 
-<aside class="dashboard-sidebar flex flex-col bg-surface-secondary dark:bg-surface-dark-secondary">
+<aside class="dashboard-sidebar flex flex-col bg-surface-secondary dark:bg-surface-dark-secondary {mobileOpen ? 'mobile-open' : ''}">
 	<!-- Navigation -->
 	<nav class="flex-1 overflow-y-auto p-4">
 		<!-- Home -->

--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -1,6 +1,7 @@
 // UI state store using Svelte 5 runes
 function createUIStore() {
 	let sidebarCollapsed = $state(false);
+	let mobileSidebarOpen = $state(false);
 	let chatPanelOpen = $state(false);
 	let activeModal = $state<string | null>(null);
 	let selectedEntityId = $state<string | null>(null);
@@ -23,6 +24,9 @@ function createUIStore() {
 		get sidebarCollapsed() {
 			return sidebarCollapsed;
 		},
+		get mobileSidebarOpen() {
+			return mobileSidebarOpen;
+		},
 		get chatPanelOpen() {
 			return chatPanelOpen;
 		},
@@ -41,6 +45,14 @@ function createUIStore() {
 
 		toggleSidebar() {
 			sidebarCollapsed = !sidebarCollapsed;
+		},
+
+		toggleMobileSidebar() {
+			mobileSidebarOpen = !mobileSidebarOpen;
+		},
+
+		closeMobileSidebar() {
+			mobileSidebarOpen = false;
 		},
 
 		toggleChatPanel() {

--- a/src/lib/stores/ui.test.ts
+++ b/src/lib/stores/ui.test.ts
@@ -124,8 +124,13 @@ describe('UI Store', () => {
 			expect(uiStore.theme).toBe('system');
 		});
 
+		it('should initialize with mobile sidebar closed', () => {
+			expect(uiStore.mobileSidebarOpen).toBe(false);
+		});
+
 		it('should have all state properties defined', () => {
 			expect(uiStore).toHaveProperty('sidebarCollapsed');
+			expect(uiStore).toHaveProperty('mobileSidebarOpen');
 			expect(uiStore).toHaveProperty('chatPanelOpen');
 			expect(uiStore).toHaveProperty('activeModal');
 			expect(uiStore).toHaveProperty('selectedEntityId');
@@ -168,6 +173,89 @@ describe('UI Store', () => {
 
 			uiStore.toggleSidebar(); // false
 			expect(uiStore.sidebarCollapsed).toBe(false);
+		});
+	});
+
+	describe('Mobile Sidebar State', () => {
+		it('should initialize with mobile sidebar closed', () => {
+			expect(uiStore.mobileSidebarOpen).toBe(false);
+		});
+
+		describe('toggleMobileSidebar()', () => {
+			it('should toggle mobile sidebar from closed to open', () => {
+				expect(uiStore.mobileSidebarOpen).toBe(false);
+
+				uiStore.toggleMobileSidebar();
+
+				expect(uiStore.mobileSidebarOpen).toBe(true);
+			});
+
+			it('should toggle mobile sidebar from open to closed', () => {
+				uiStore.toggleMobileSidebar();
+				expect(uiStore.mobileSidebarOpen).toBe(true);
+
+				uiStore.toggleMobileSidebar();
+
+				expect(uiStore.mobileSidebarOpen).toBe(false);
+			});
+
+			it('should handle multiple toggles', () => {
+				uiStore.toggleMobileSidebar(); // true
+				uiStore.toggleMobileSidebar(); // false
+				uiStore.toggleMobileSidebar(); // true
+
+				expect(uiStore.mobileSidebarOpen).toBe(true);
+			});
+		});
+
+		describe('closeMobileSidebar()', () => {
+			it('should close mobile sidebar when open', () => {
+				uiStore.toggleMobileSidebar();
+				expect(uiStore.mobileSidebarOpen).toBe(true);
+
+				uiStore.closeMobileSidebar();
+
+				expect(uiStore.mobileSidebarOpen).toBe(false);
+			});
+
+			it('should be safe to call when already closed', () => {
+				expect(uiStore.mobileSidebarOpen).toBe(false);
+
+				uiStore.closeMobileSidebar();
+
+				expect(uiStore.mobileSidebarOpen).toBe(false);
+			});
+
+			it('should work after multiple toggles', () => {
+				uiStore.toggleMobileSidebar();
+				uiStore.toggleMobileSidebar();
+				uiStore.toggleMobileSidebar();
+
+				uiStore.closeMobileSidebar();
+
+				expect(uiStore.mobileSidebarOpen).toBe(false);
+			});
+		});
+
+		it('should not affect desktop sidebar state', () => {
+			expect(uiStore.sidebarCollapsed).toBe(false);
+
+			uiStore.toggleMobileSidebar();
+
+			expect(uiStore.sidebarCollapsed).toBe(false);
+			expect(uiStore.mobileSidebarOpen).toBe(true);
+		});
+
+		it('should not affect other state when toggling mobile sidebar', () => {
+			uiStore.openChatPanel();
+			uiStore.openModal('test-modal');
+			uiStore.selectEntity('entity-123');
+
+			uiStore.toggleMobileSidebar();
+
+			expect(uiStore.chatPanelOpen).toBe(true);
+			expect(uiStore.activeModal).toBe('test-modal');
+			expect(uiStore.selectedEntityId).toBe('entity-123');
 		});
 	});
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -20,7 +20,12 @@
 		hasAnyApiKey,
 		shouldShowAiSetupBanner
 	} from '$lib/services';
-	import { goto } from '$app/navigation';
+	import { goto, afterNavigate } from '$app/navigation';
+
+	// Close mobile sidebar on navigation
+	afterNavigate(() => {
+		uiStore.closeMobileSidebar();
+	});
 
 	let { children } = $props();
 	let headerComponent: ReturnType<typeof Header> | undefined = $state();
@@ -117,7 +122,17 @@
 
 <div class="dashboard-layout">
 	<Header bind:this={headerComponent} />
-	<Sidebar />
+	<Sidebar mobileOpen={uiStore.mobileSidebarOpen} />
+
+	<!-- Mobile sidebar backdrop -->
+	{#if uiStore.mobileSidebarOpen}
+		<button
+			class="sidebar-backdrop lg:hidden"
+			onclick={() => uiStore.closeMobileSidebar()}
+			aria-label="Close sidebar"
+		></button>
+	{/if}
+
 	<main class="dashboard-main">
 		<div class="flex-1 overflow-y-auto p-6">
 			<!-- AI setup reminder banner -->


### PR DESCRIPTION
## Summary
- Converts the fixed two-column CSS grid layout to responsive: single column on mobile, two-column at `lg:` (1024px+)
- Sidebar becomes a slide-in overlay drawer on mobile with backdrop, auto-closes on navigation
- Fixes `100vh` to `100dvh` for mobile browser address bar compatibility
- Panel min-width (320px) now only applies on desktop
- Adds `mobileSidebarOpen` state to UI store with toggle/close methods (separate from desktop sidebar state)

Closes #467

## Test plan
- [x] TypeScript check passes (`npm run check` — 0 errors)
- [x] Production build succeeds (`npm run build`)
- [x] All 98 UI store tests pass (88 existing + 10 new)
- [ ] Manual: verify desktop layout unchanged at 1024px+
- [ ] Manual: verify single-column layout below 1024px
- [ ] Manual: hamburger menu opens/closes sidebar drawer with slide animation
- [ ] Manual: backdrop appears behind sidebar, clicking it closes sidebar
- [ ] Manual: navigating to a page auto-closes the sidebar
- [ ] Manual: no vertical overflow on mobile browsers (address bar safe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)