### PR TITLE
fix(lint): remove unnecessary escape in FieldInput dice regex

### DIFF
--- a/src/lib/components/entity/FieldInput.svelte
+++ b/src/lib/components/entity/FieldInput.svelte
@@ -199,7 +199,7 @@
 	function isValidDice(dice: string): boolean {
 		if (!dice) return true;
 		// Pattern: XdY or XdY+Z or XdY-Z (where X, Y, Z are numbers)
-		const dicePattern = /^\d+d\d+([+\-]\d+)?$/i;
+		const dicePattern = /^\d+d\d+([+-]\d+)?$/i;
 		return dicePattern.test(dice.trim());
 	}
 


### PR DESCRIPTION
## Summary
- Fixes the remaining `no-useless-escape` lint error in `FieldInput.svelte` line 202
- Same issue as #476 but in a different file

## Test plan
- [ ] CI lint step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)