### PR TITLE
feat(v1.7.0): Respite Activity Tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-02-12
+
+### Added
+
+**Respite Activity Tracker - Core Implementation (Issue #408)**
+- RespiteSession, RespiteHero, RespiteActivity, KitSwap type definitions following Draw Steel respite mechanics
+- respiteRepository with full CRUD, lifecycle management (preparing -> active -> completed), hero management, activity tracking, VP conversion, and kit swap recording
+- respiteStore with Svelte 5 runes, live query subscription, and comprehensive derived values
+- Database Version 11 with respiteSessions table
+- Svelte 5 proxy handling (JSON.parse/JSON.stringify before IndexedDB operations)
+- 89 tests covering repository operations, store reactivity, and derived values
+
+**Respite Activity Tracker - UI Components (Issue #409)**
+- RespiteSetup: Create/edit respite form with hero multi-select and recovery tracking
+- HeroRecoveryPanel: Recovery tracking per hero with red/yellow/green color coding
+- RespiteActivityCard: Activity display with type badge (6 types) and status indicator
+- ActivityControls: Add activity form with template quick-select
+- KitSwapTracker: Kit swap recording form and history display
+- VictoryPointsConverter: VP to XP conversion UI with progress bar
+- RespiteRulesReference: Collapsible Draw Steel respite rules panel
+- RespiteProgress: Overview dashboard with hero, activity, VP, and kit swap stats
+- Routes: /respite (list with grid), /respite/new (create), /respite/[id] (3-column active layout)
+- Sidebar navigation with Coffee icon and active respite count badge
+
+**Respite Activity Tracker - Integration (Issue #410)**
+- Campaign and character linking (campaignId, characterIds, linkedSessionIds fields)
+- getByCampaignId() and getByCharacterId() repository queries
+- Narrative event creation from completed respite sessions (createFromRespite)
+- RespiteAnalytics component with VP totals, activity distribution, and completion stats
+- Store analytics: totalVPConverted, totalActivitiesCompleted, activityTypeDistribution
+
+**Respite Activity Tracker - Quality of Life (Issue #412)**
+- 15 predefined activity templates across 5 types (project, crafting, socializing, training, investigation)
+- Template quick-select buttons in ActivityControls for rapid activity creation
+- getTemplatesByType() and getTemplateTypes() helper functions
+- 7 tests covering template configuration and filtering
+
+**Respite Activity Tracker - Documentation (Issue #411)**
+- Updated DRAW_STEEL_GAP_ANALYSIS.md marking respite system as implemented
+- Comprehensive CHANGELOG entries covering all 5 implementation issues
+
+### Changed
+
+**Test Suite Health**
+- 253 test files with 12,225 tests passing
+- 65 skipped tests (unchanged)
+- 2 pre-existing errors (unchanged, in RelateCommand.svelte)
+
 ## [1.6.0] - 2026-02-11
 
 ### Added

--- a/DRAW_STEEL_GAP_ANALYSIS.md
+++ b/DRAW_STEEL_GAP_ANALYSIS.md
@@ -1,0 +1,1332 @@
+# Draw Steel Gap Analysis: Features NOT Yet Implemented or Planned
+
+**Last Updated:** February 2026
+**Project:** Director Assist
+**Status:** Comprehensive analysis of Draw Steel mechanics not yet in the codebase or GitHub issues
+
+---
+
+## Executive Summary
+
+Director Assist has implemented a solid foundation for Draw Steel campaign management with full support for:
+- **Combat tracking** (2d10 initiative, threat levels, hero points, victory points, conditions)
+- **Montage challenges** (difficulty-based success/failure tracking, two-round system)
+- **Negotiations** (interest/patience tracking, 13 motivations, pitfalls, tier-based arguments)
+- **Creature templates** (searchable monster library with roles and abilities)
+- **Entity management** (characters, NPCs, locations, custom types with Draw Steel fields)
+- **Relationship visualization** (matrix and network views)
+
+However, several **significant Draw Steel features** are either partially implemented, planned but not started, or not yet identified. This document catalogs all gaps organized by game mechanic category.
+
+---
+
+## I. CHARACTER CREATION & ADVANCEMENT
+
+### A. Character Sheet Implementation
+
+**Status:** Partially Implemented
+**Current:** Basic entity fields for Draw Steel characters exist (ancestry, class, culture, etc.)
+**Gap:** No dedicated character sheet page designed specifically for Draw Steel heroes
+
+**Missing Features:**
+1. **Comprehensive Draw Steel Character Attributes**
+   - Might, Agility, Reason, Intuition, Presence tracking (5 core attributes)
+   - Attribute rolls (2d10 based on attribute level)
+   - Current implementation only stores these as generic custom fields
+
+2. **Skill System**
+   - Skill list with training levels (Untrained, Trained, Expert, Master)
+   - Skill modifier calculations based on attributes
+   - Specialized training tracking per skill
+   - Current implementation doesn't calculate or track skill DC vs. rolls
+
+3. **Class-Specific Tracking**
+   - Class choice dropdown validation
+   - Subclass-specific features tracking
+   - Kit feature tracking
+   - Heritage/Ancestry trait effects management
+
+4. **Equipment Management**
+   - Weapon tracking with damage types and properties
+   - Armor and AC calculation
+   - Encumbrance tracking
+   - Equipment condition tracking
+
+5. **Experience & Advancement**
+   - XP tracking toward level up
+   - Milestone tracking UI
+   - Level progression calculator
+   - Advancement history
+
+**Why It Matters:**
+Directors need a complete, Draw Steel-accurate character sheet to quickly reference hero stats during play. Current generic entity fields don't provide the focused, tactical information needed.
+
+**Suggested Priority:** MEDIUM-HIGH
+Character sheets would be used constantly at the table and improve the core Director experience.
+
+---
+
+### B. Character Creation Wizard
+
+**Status:** Not Implemented
+**Gap:** No guided character creation process
+
+**Missing Features:**
+1. Step-by-step character creation following Draw Steel rules
+2. Ancestry selection with trait suggestions
+3. Culture/Career combination guidance
+4. Class selection with feature explanations
+5. Attribute generation (standard array vs. rolling)
+6. Starting equipment selection
+7. Background/motivation interview questions
+8. Finishing touches (alignment, bonds, personality)
+
+**Why It Matters:**
+New players often struggle with character creation. A guided wizard that validates Draw Steel rules as they go would be invaluable for onboarding and reducing table setup time.
+
+**Suggested Priority:** LOW-MEDIUM
+Nice-to-have for player onboarding but not essential for Directors running campaigns.
+
+---
+
+## II. COMBAT SYSTEM
+
+### A. Power Roll Integration
+
+**Status:** Partially Implemented
+**Current:** Types and logging structure exist for power rolls (2d10 tier system)
+**Gap:** No UI for rolling and interpreting power rolls in the moment
+
+**Missing Features:**
+1. **Power Roll Interface**
+   - Quick roll button (2d10)
+   - Dice roller widget showing both dice individually
+   - Automatic tier calculation and highlighting
+   - Critical detection (double 10s)
+   - Display of tier effects on combat
+
+2. **Power Roll History**
+   - Session history of all power rolls
+   - Filter by combatant, action type, or result
+   - Statistics on roll success rates
+
+3. **Modifier Application**
+   - Quick modifier input (+/- bonuses)
+   - Save common modifiers
+   - Attribute-based modifier suggestions
+
+**Why It Matters:**
+Power rolls happen dozens of times per combat. A dedicated roller would speed up play and make the 2d10 system feel more integrated into the tool.
+
+**Suggested Priority:** MEDIUM
+Highly useful during active combat sessions but not blocking.
+
+---
+
+### B. Combatant Action Economy
+
+**Status:** Not Implemented
+**Gap:** No tracking of action/maneuver spent per turn
+
+**Missing Features:**
+1. **Action Tracking Per Combatant**
+   - Track actions spent (one per turn for most creatures)
+   - Track maneuvers spent (one per turn for most creatures)
+   - Track reactions (reset per round)
+   - Visual indication of what's been spent
+
+2. **Action Economy Validation**
+   - Prevent spending more than allowed
+   - Warn when spending last action/maneuver
+   - Visual feedback when combatant is "done" for the turn
+
+3. **Custom Action Points**
+   - Support for creatures/abilities with different action economies
+   - Customizable action names (Fury Points, Focus, etc.)
+
+**Why It Matters:**
+Draw Steel's action economy (action + maneuver per turn) is core to combat tactics. Tracking spent actions prevents confusion and speeds up turn resolution.
+
+**Suggested Priority:** MEDIUM-HIGH
+Essential for combat accuracy but could be worked around with manual notes.
+
+---
+
+### C. Turn Summary & Log Export
+
+**Status:** Partially Implemented
+**Current:** Combat log exists but only in-app
+**Gap:** No export or session summary features
+
+**Missing Features:**
+1. **Turn Summary Display**
+   - What each combatant did this turn
+   - Damage dealt/taken summary
+   - Conditions applied/expired
+   - Readable natural language summary
+
+2. **Combat Log Export**
+   - Export log to text/markdown
+   - Export to PDF for sharing
+   - Include combatant stats and final state
+   - Formatted for human reading
+
+3. **Combat Statistics**
+   - Damage dealt per combatant
+   - Damage taken per combatant
+   - Kill/defeat count
+   - Most impactful abilities used
+
+**Why It Matters:**
+Directors often want to recap combat in session notes or share memorable moments. Easy export would tie combats into the narrative trail system better.
+
+**Suggested Priority:** LOW-MEDIUM
+Quality of life improvement but not essential for running combat.
+
+---
+
+### D. Grouped Combatant Actions
+
+**Status:** Partially Implemented
+**Current:** Groups can be created and tracked; they share initiative
+**Gap:** No action selection/management for grouped combatants
+
+**Missing Features:**
+1. **Group Action Interface**
+   - Select actions for all group members at once
+   - Apply same damage/healing to entire group
+   - Add condition to entire group
+   - Collapse/expand group to show/hide members
+
+2. **Individual Member Tracking**
+   - While grouped, still track individual HP/conditions
+   - Allow individual actions/damage within group's turn
+   - Sequential indication (Member 1 of 3, etc.)
+
+**Why It Matters:**
+Groups of identical creatures (goblin squad, zombie horde) are common in Draw Steel. Better UI for managing them would make combat flow smoother.
+
+**Suggested Priority:** MEDIUM
+Useful but groups still function; improvement is UI-focused.
+
+---
+
+### E. Encounter Difficulty Calculator
+
+**Status:** Not Implemented
+**Gap:** No tool to calculate encounter balance
+
+**Missing Features:**
+1. **XP Budget Calculator**
+   - Input hero count and level
+   - Calculate XP budget for encounter
+   - Show XP cost of each creature
+   - Suggest difficulty (Easy, Moderate, Hard, Deadly)
+
+2. **Encounter Templates**
+   - Pre-built encounter templates by difficulty
+   - Creature recommendation suggestions
+   - Number of creatures suggestions
+
+3. **Balance Checker**
+   - Real-time encounter balance assessment
+   - Adjust creature count or swap creatures
+   - Show difficulty curve
+
+**Why It Matters:**
+Many Directors struggle with encounter balance. A calculator would reduce prep time and help create better, more challenging combats.
+
+**Suggested Priority:** MEDIUM
+Useful for prep but not essential for running sessions.
+
+---
+
+## III. NEGOTIATION SYSTEM
+
+### A. Outcome Tracking & Consequences
+
+**Status:** Partially Implemented
+**Current:** Outcomes are calculated and displayed
+**Gap:** No system for tracking consequences or follow-up interactions
+
+**Missing Features:**
+1. **Relationship Impact Tracking**
+   - Automatically update NPC relationship strength based on outcome
+   - Track whether NPC becomes ally, neutral, or hostile
+   - Link negotiation outcome to ongoing NPC interactions
+
+2. **Follow-up Negotiation Support**
+   - Show previous negotiation outcome when creating new one with same NPC
+   - Warn if attempting same arguments that previously failed
+   - Remember which motivations have been used
+
+3. **Faction Reputation Integration**
+   - Track faction reputation changes based on negotiations
+   - Show reputation threshold effects
+   - Multiple faction loyalty tracking
+
+**Why It Matters:**
+Negotiations should have lasting table impact. Tying outcomes to relationships and faction reputation would make negotiations feel consequential.
+
+**Suggested Priority:** MEDIUM
+Requires relationship system enhancement but very rewarding for campaign continuity.
+
+---
+
+### B. Quick Reference & Cheat Sheet
+
+**Status:** Not Implemented
+**Gap:** No in-tool negotiation reference
+
+**Missing Features:**
+1. **Negotiation Rules Summary**
+   - Quick reference for interest/patience mechanics
+   - Argument effect tables (visible in tool, not just in rules)
+   - Outcome descriptions with party perspectives
+
+2. **Motivation/Pitfall Suggestions**
+   - Suggest motivations based on NPC type/description
+   - Suggest pitfalls based on NPC background
+   - Learning tool for new Directors
+
+3. **Argument Effectiveness Hints**
+   - Show which motivation type the NPC cares most about
+   - Highlight if an argument targets already-used motivation
+   - Suggest next best argument
+
+**Why It Matters:**
+New Directors struggle with negotiation mechanics. A quality quick reference would help them master the system.
+
+**Suggested Priority:** LOW-MEDIUM
+Educational/QoL improvement.
+
+---
+
+### C. Extended Negotiation Features
+
+**Status:** Not Planned
+**Gap:** Advanced negotiation mechanics
+
+**Missing Features:**
+1. **Multi-Party Negotiations**
+   - Track multiple NPCs in one negotiation
+   - Different interest/patience per NPC
+   - NPC alliances/opposition
+
+2. **Negotiation Complications**
+   - Surprise obstacles mid-negotiation
+   - Time pressure mechanics
+   - Interruptions or third parties
+
+3. **Negotiation Branching**
+   - Different outcomes lead to different follow-ups
+   - Conditional consequences
+   - Negotiation chains
+
+**Why It Matters:**
+More sophisticated negotiations (multiple parties, complications) add depth to campaigns. Currently not in scope but would be valuable future additions.
+
+**Suggested Priority:** LOW
+Advanced feature for campaign depth.
+
+---
+
+## IV. MONTAGE SYSTEM
+
+### A. Enhanced Challenge Types
+
+**Status:** Partially Implemented
+**Current:** Generic challenges with optional predefined list
+**Gap:** Limited challenge customization and context
+
+**Missing Features:**
+1. **Challenge Templates**
+   - Pre-built montage challenge types by setting/scenario
+   - Common challenges: Finding Shelter, Rally Horse, Forage, Recruit Allies, Gather Information
+   - Suggested skills per challenge
+   - Difficulty indicators
+
+2. **Challenge Context Tracking**
+   - Track which player tackled which challenge
+   - Results affect narrative
+   - Failure consequences suggestions
+
+3. **Montage Complications**
+   - Random event that complicates a challenge
+   - Twist results mid-montage
+   - Failure cascades (one failure affects others)
+
+**Why It Matters:**
+Directors want guidance on what montage challenges to offer. Templates and examples would improve montage quality and variety.
+
+**Suggested Priority:** MEDIUM
+Would enhance montage creation process significantly.
+
+---
+
+### B. Montage Outcome Narrativization
+
+**Status:** Not Implemented
+**Gap:** No tools to turn mechanical outcomes into narrative
+
+**Missing Features:**
+1. **Outcome Description Generator**
+   - AI-powered (Claude integration) descriptions of montage success/failure
+   - Considers challenge types and player actions
+   - Tie to character motivations from entities
+
+2. **Consequence Tracker**
+   - What each outcome means for the story
+   - Resource impact (supplies gained, travel speed, etc.)
+   - Follow-up complications
+
+3. **Montage-to-Scene Bridge**
+   - Automatically create scene entities from montage
+   - Summary of what party accomplished
+   - Link to related entities (locations, NPCs encountered)
+
+**Why It Matters:**
+Montages can feel mechanical. Better tools for narrativizing outcomes would make them feel more integrated into the campaign story.
+
+**Suggested Priority:** MEDIUM
+Quality-of-life improvement that would be very table-friendly.
+
+---
+
+## V. RESPITE & DOWNTIME
+
+### A. Respite Activity System (IMPLEMENTED - v1.7.0, Issues #408-412)
+
+**Status:** IMPLEMENTED (v1.7.0)
+**Scope:** Full respite activity tracker for Draw Steel's downtime mechanics
+
+**What's Implemented:**
+- Core types, database, repository, and store (Issue #408)
+- UI components: RespiteSetup, HeroRecoveryPanel, RespiteActivityCard, ActivityControls, KitSwapTracker, VictoryPointsConverter, RespiteRulesReference, RespiteProgress, RespiteAnalytics
+- Routes: /respite (list), /respite/new (create), /respite/[id] (detail with 3-column active layout)
+- Sidebar navigation with active respite count badge
+- Narrative event integration (createFromRespite)
+- Activity templates with quick-select (15 predefined templates across 5 types)
+- Campaign and character linking support
+- Analytics: VP conversion totals, activity distribution, completion stats
+- 96+ tests covering repository, store, and templates
+
+**Remaining Gaps (Future Enhancement):**
+1. **Resource Tracking During Respite**
+   - Gold spent/earned tracking
+   - Resources consumed tracking
+
+2. **Respite Complications**
+   - Random events during respite
+   - Encounters in town/camp
+
+3. **Respite-to-Active Bridge**
+   - Finish respite, transition to next adventure
+   - Complications become adventure hooks
+
+**Suggested Priority:** LOW (core feature complete, enhancements can follow)
+
+---
+
+## VI. CHARACTER DEVELOPMENT & STORY
+
+### A. Character Bonds & Relationships
+
+**Status:** Partially Implemented
+**Current:** Generic entity relationships exist
+**Gap:** No Draw Steel-specific bonds system
+
+**Missing Features:**
+1. **Draw Steel Bonds System**
+   - Bond types (patron, rival, ally, enemy, romantic, etc.)
+   - Bond impact on gameplay (advantage on helps, disadvantage on hindrances)
+   - Bond development tracker
+   - Bond resolutions
+
+2. **Motivation & Goals Tracking**
+   - Character personal motivations
+   - Campaign goals vs. character goals alignment
+   - Motivation-based story hooks
+   - Resolution tracking
+
+3. **Character Development Arc**
+   - Track how characters change through campaign
+   - Milestone achievements
+   - Character growth points
+   - Betrayals/reconciliations
+
+**Why It Matters:**
+Character bonds drive narrative engagement. A dedicated system would help Directors track character arcs and tie mechanics to story.
+
+**Suggested Priority:** MEDIUM-HIGH
+Would significantly improve campaign narrative quality.
+
+---
+
+### B. Pressure & Bonds Resolution
+
+**Status:** Not Implemented
+**Gap:** No Pressure system tracking
+
+**Missing Features:**
+1. **Pressure Tracker**
+   - Track current pressure on party (0-5 scale or similar)
+   - Pressure sources (enemies getting closer, time running out, etc.)
+   - Pressure effects on gameplay
+   - Pressure resolution mechanics
+
+2. **Bond Resolution Support**
+   - Help Director recognize when bonds should resolve
+   - Suggested consequences for resolution
+   - Tracking impact of resolved bonds
+
+3. **Campaign Tension Management**
+   - Visual indicator of campaign threat level
+   - Suggested escalation paths
+   - Climax readiness tracker
+
+**Why It Matters:**
+Pressure and bonds resolution are Draw Steel's narrative tension mechanics. Supporting them would help Directors create more engaging campaigns.
+
+**Suggested Priority:** MEDIUM
+Advanced feature for campaign pacing and drama.
+
+---
+
+## VII. WORLD BUILDING & LORE
+
+### A. Timeline System
+
+**Status:** Partially Implemented
+**Current:** Timeline Event entity type exists
+**Gap:** No visual timeline or event linking
+
+**Missing Features:**
+1. **Visual Timeline**
+   - Chronological display of events
+   - Filter by type, location, NPC, faction
+   - Zoom in/out by time scale
+   - Color-coded event types
+
+2. **Cause & Effect Tracking**
+   - Link events to their consequences
+   - Show ripple effects through timeline
+   - Suggest consequences for PC actions
+
+3. **Timeline Anchors**
+   - Campaign start date
+   - Known future events (prophecies, planned invasions)
+   - Historical epochs/eras
+
+**Why It Matters:**
+Complex campaigns have interconnected events. A timeline would help Directors track cause/effect and plan revelations.
+
+**Suggested Priority:** MEDIUM
+Nice-to-have for campaign organization.
+
+---
+
+### B. Faction Dynamics System
+
+**Status:** Not Implemented
+**Gap:** Factions are entities but lack mechanical systems
+
+**Missing Features:**
+1. **Faction Resource Tracking**
+   - Power (military, economic, political)
+   - Territory held
+   - Number of members
+   - Goals and priorities
+
+2. **Faction Relationship Web**
+   - Alliances between factions
+   - Rivalries and conflicts
+   - Trade relationships
+   - Hidden enmities
+
+3. **Faction Events & Turns**
+   - Faction action tracker (what each faction is doing)
+   - Initiative-style faction turn order
+   - Faction consequences of PC actions
+   - Faction turn summary
+
+4. **Faction Goals & Intrigues**
+   - Each faction has goals
+   - Intrigues working toward goals
+   - PC can support/oppose faction goals
+   - Influence PC perception of factions
+
+**Why It Matters:**
+Faction dynamics add political depth to campaigns. A tracker would make faction intrigue feel mechanical and consequential.
+
+**Suggested Priority:** MEDIUM
+Good for complex campaigns but not essential.
+
+---
+
+### C. Lore & Secrets Management
+
+**Status:** Partially Implemented
+**Current:** Entities have hidden field/notes system
+**Gap:** No specialized secrets or revelation tracker
+
+**Missing Features:**
+1. **Secret Categories**
+   - Hidden until revealed
+   - Revealed when condition met
+   - Automatic revelation on combat/negotiation/montage
+   - Player-known vs. Director-known
+
+2. **Revelation Tracker**
+   - What secrets have been revealed
+   - When and how they were revealed
+   - Reactions from NPCs/factions
+   - Consequences set off by revelation
+
+3. **Information Availability**
+   - Track what each player character knows
+   - Knowledge checks needed to learn secrets
+   - Misinformation tracking
+   - False leads
+
+**Why It Matters:**
+Managing secrets across a long campaign is complex. Better tools would help Directors maintain mystery and manage reveals.
+
+**Suggested Priority:** MEDIUM
+Quality-of-life improvement for campaign management.
+
+---
+
+## VIII. ENCOUNTER DESIGN & EXPLORATION
+
+### A. Exploration Tracker
+
+**Status:** Not Implemented
+**Gap:** No mechanical support for exploration scenes
+
+**Missing Features:**
+1. **Exploration Scene Setup**
+   - Location setup with exploration challenges
+   - Environmental hazards and obstacles
+   - Search checks and hidden details
+   - Encounter triggers
+
+2. **Active Exploration Tracking**
+   - Track which areas party has explored
+   - Time spent exploring
+   - Resources consumed (light, rope, etc.)
+   - Hazard triggers
+
+3. **Exploration Rewards**
+   - Treasure found
+   - Information discovered
+   - Relationships made
+   - Secrets learned
+
+**Why It Matters:**
+Exploration is less combat-focused than montage but still mechanically important. Tools would help Directors run varied, interesting exploration scenes.
+
+**Suggested Priority:** LOW-MEDIUM
+Useful but less critical than combat/negotiation.
+
+---
+
+### B. Trap & Hazard System
+
+**Status:** Not Implemented
+**Gap:** No dedicated trap/hazard tracking
+
+**Missing Features:**
+1. **Trap Templates**
+   - Pre-built common traps by type
+   - Damage/effect mechanics
+   - DC to spot and disarm
+   - Consequences
+
+2. **Hazard Tracking**
+   - Current status of hazards
+   - Trigger conditions
+   - Damage over time
+   - Mitigation options
+
+3. **Trap Encounter Balance**
+   - Difficulty assessment
+   - Scaling suggestions
+   - Consequences of failure
+
+**Why It Matters:**
+Traps and hazards are common encounter elements. Templates would speed prep and improve encounter variety.
+
+**Suggested Priority:** LOW
+Less critical than core combat/negotiation.
+
+---
+
+## IX. ITEMS & TREASURE
+
+### A. Treasure & Loot Distribution
+
+**Status:** Not Implemented
+**Gap:** No loot tracking or distribution system
+
+**Missing Features:**
+1. **Loot Tracker**
+   - Treasure found in current adventure
+   - Gold, items, artifacts
+   - Distribution history
+   - Outstanding distribution
+
+2. **Character Inventory Integration**
+   - Link items in inventory to character entities
+   - Equip/unequip tracking
+   - Item condition tracking
+   - Weight/encumbrance calculation
+
+3. **Treasure Value Assessment**
+   - Monetary value
+   - Rarity/significance
+   - Curse tracking
+   - Enchantment level
+
+**Why It Matters:**
+Loot tracking is a bread-and-butter mechanic many Directors want. Integration would improve character customization depth.
+
+**Suggested Priority:** LOW-MEDIUM
+Useful but lower priority than core mechanics.
+
+---
+
+### B. Item Properties & Effects
+
+**Status:** Not Implemented
+**Gap:** No mechanical support for item effects
+
+**Missing Features:**
+1. **Equipment Properties**
+   - Damage type
+   - Special properties (magical, cursed, etc.)
+   - Rarity levels
+   - Set bonuses
+
+2. **Item Effects Tracking**
+   - Ongoing effects from items
+   - Daily use limits
+   - Attunement requirements
+   - Curse tracking
+
+3. **Item Identification**
+   - Unknown vs. identified
+   - Identification cost/DC
+   - Partial information
+
+**Why It Matters:**
+Items with special effects are common in Draw Steel. Tracking them properly would improve character customization and encounter design.
+
+**Suggested Priority:** LOW
+Advanced feature for item-focused campaigns.
+
+---
+
+## X. PLAYER MANAGEMENT & TABLE TOOLS
+
+### A. Player Availability & Scheduling
+
+**Status:** Not Implemented
+**Gap:** No player schedule/availability tracking
+
+**Missing Features:**
+1. **Player Profiles**
+   - Character assignment to player
+   - Availability calendar
+   - Scheduling preferences
+   - Rules familiarity level
+
+2. **Session Scheduling**
+   - Session date/time setting
+   - Availability checking
+   - Notification system for scheduled sessions
+   - Absence tracking
+
+3. **Character Absence Handling**
+   - How to handle absent characters in combat
+   - Suggested actions for absent PCs
+   - Retro-catch-up notes
+
+**Why It Matters:**
+Directors with multiple regular players need schedule coordination. Built-in tools would reduce scheduling friction.
+
+**Suggested Priority:** LOW-MEDIUM
+Useful for organized play but not essential for campaign running.
+
+---
+
+### B. Initiative Roller & Dice Integration
+
+**Status:** Partially Implemented
+**Current:** Initiative rolling exists in combat
+**Gap:** No general dice roller or integration with other mechanics
+
+**Missing Features:**
+1. **General Dice Roller**
+   - Roll arbitrary dice (2d10, d20, 4d6, etc.)
+   - Dice pool rolling
+   - Disadvantage/advantage
+   - Kept results tracking
+
+2. **Roll History**
+   - Record all rolls in session
+   - Link rolls to combat/negotiation/montage
+   - Re-roll audit trail
+
+3. **Dice Shortcuts**
+   - Quick buttons for common rolls
+   - Custom dice presets
+   - Roll templates by action type
+
+**Why It Matters:**
+Many mechanics require rolling outside of structured systems (random encounters, improvised checks). A general roller would be useful.
+
+**Suggested Priority:** LOW
+Nice-to-have convenience feature.
+
+---
+
+### C. Session Notes & Recap Generator
+
+**Status:** Partially Implemented
+**Current:** Scene entities and narrative trail exist
+**Gap:** No automatic session recap or notes generator
+
+**Missing Features:**
+1. **Session Recap Generator**
+   - AI-powered (Claude) summary of session events
+   - Key moments highlighted
+   - XP/treasure summary
+   - Plot threads advanced
+
+2. **Notes Templates**
+   - What to record for good session notes
+   - Suggested sections (combat summary, negotiation outcomes, discoveries)
+   - Linked to entities affected
+
+3. **Between-Session Prep**
+   - What happened last session (AI summary)
+   - Plot threads still active
+   - Foreshadowing elements
+   - NPC status updates
+
+**Why It Matters:**
+Session notes are important for campaign continuity. AI-powered recaps would save Director time and improve memory between sessions.
+
+**Suggested Priority:** MEDIUM
+Would be very table-friendly but nice-to-have.
+
+---
+
+## XI. SYSTEM EXPANSION & MULTIPLATFORM
+
+### A. Other Game System Support
+
+**Status:** Planned (Issue #142)
+**Current:** System-agnostic mode exists; Draw Steel is primary focus
+**Gap:** D&D 5e, Pathfinder 2e, and other systems not supported
+
+**Planned:** Issue #142 tracks "Add support for additional TTRPG systems (D&D 5e, Pathfinder 2e)"
+
+**Missing Features:**
+1. **D&D 5e Support**
+   - Full character sheet with ability scores
+   - Proficiencies and expertise
+   - Prepared spells and known spells
+   - Short/long rest mechanics
+
+2. **Pathfinder 2e Support**
+   - Archetype system
+   - Feats and skill feats
+   - Action economy (3 actions per turn)
+   - Conditions and degrees of success
+
+3. **Generic TTRPG Support**
+   - Flexible attributes (any number, any name)
+   - Custom mechanic templates
+
+**Why It Matters:**
+Many Directors run multiple systems. Support would expand the user base significantly.
+
+**Suggested Priority:** MEDIUM
+Planned but appropriate for post-launch expansion.
+
+---
+
+### B. Mobile App / PWA
+
+**Status:** Not Implemented
+**Current:** Responsive web design in progress (Issues #466-473)
+**Gap:** No native mobile app or PWA
+
+**Missing Features:**
+1. **Progressive Web App (PWA)**
+   - Install to home screen
+   - Works offline
+   - Push notifications for session reminders
+   - Sync across devices
+
+2. **Mobile-Optimized Features**
+   - Touch-friendly combat tracker
+   - Quick combatant add
+   - Damage input optimized for touch
+   - Simplified UI for table use
+
+3. **Native Mobile Apps**
+   - iOS app (App Store)
+   - Android app (Google Play)
+   - Offline-first architecture
+   - Cloud sync option
+
+**Why It Matters:**
+Many Directors want to use Director Assist on tablets or phones at the table. A mobile-optimized experience would transform table usability.
+
+**Suggested Priority:** MEDIUM-HIGH
+Planned mobile support (Issues #466-473) but PWA/native apps are future work.
+
+---
+
+### C. Cloud Sync & Multi-Device
+
+**Status:** Partially Planned
+**Current:** Local IndexedDB storage only
+**Gap:** No cloud sync or multi-device synchronization
+
+**Missing Features:**
+1. **Optional Cloud Storage**
+   - Encrypted backup to cloud service
+   - Sync across multiple devices
+   - Conflict resolution
+   - Auto-sync on changes
+
+2. **Collaborative Features**
+   - Real-time combat viewing for remote players
+   - Shared entity editing
+   - Real-time chat integration
+   - Remote player companion app
+
+3. **Version Control**
+   - Campaign version history
+   - Rollback to previous state
+   - Compare campaign versions
+   - Merge changes from multiple devices
+
+**Why It Matters:**
+Cloud sync would enable remote play and multi-device workflow. Appropriate for post-MVP expansion.
+
+**Suggested Priority:** MEDIUM
+Valuable but appropriate for future expansion.
+
+---
+
+## XII. QUALITY OF LIFE & ACCESSIBILITY
+
+### A. Custom Themes & Skins
+
+**Status:** Partially Implemented
+**Current:** Light/dark mode exists
+**Gap:** No custom themes or color customization
+
+**Missing Features:**
+1. **Theme Customization**
+   - Custom color palettes
+   - Font size adjustment
+   - High contrast mode
+   - Dyslexia-friendly font options
+
+2. **Theme Presets**
+   - Campaign-themed color schemes
+   - System-specific themes (Draw Steel colors, etc.)
+   - Saved theme library
+
+**Why It Matters:**
+Accessibility matters, especially for long campaign sessions. Better theme options would improve usability for diverse Directors.
+
+**Suggested Priority:** LOW-MEDIUM
+Good for accessibility but not essential.
+
+---
+
+### B. Keyboard Shortcuts & Commander Mode
+
+**Status:** Partially Implemented
+**Current:** Command palette exists with "/" shortcut
+**Gap:** Limited keyboard shortcuts for combat
+
+**Missing Features:**
+1. **Combat Keyboard Shortcuts**
+   - N = next turn, P = previous turn
+   - D = apply damage, H = apply healing
+   - Q = add condition
+   - Quick number keys for damage amounts
+
+2. **Searchable Action Index**
+   - Find any action by searching
+   - Recently used actions
+   - Customizable shortcuts
+   - Macro support
+
+3. **Hands-Free Mode**
+   - Voice commands (experimental)
+   - Macros for common sequences
+   - One-handed operation for accessibility
+
+**Why It Matters:**
+Combat flows faster with keyboard shortcuts. Full keyboard support would improve experienced Directors' workflow significantly.
+
+**Suggested Priority:** MEDIUM
+Great QoL but not blocking.
+
+---
+
+### C. Print & PDF Export
+
+**Status:** Partially Planned
+**Current:** Some PDF export in settings
+**Gap:** Limited print-friendly formats
+
+**Missing Features:**
+1. **Character Sheet PDF**
+   - Draw Steel-formatted character sheet
+   - Print-ready layout
+   - Fillable form option
+
+2. **Combat Sheet PDF**
+   - Initiative tracker printable
+   - Combatant cards printable
+   - Combat log printable
+
+3. **Campaign Compendium**
+   - All entities as printable reference
+   - Organized by type
+   - Indexed and cross-referenced
+
+**Why It Matters:**
+Some Directors prefer paper backups or printed reference sheets. Exporting would support diverse preferences.
+
+**Suggested Priority:** LOW
+Nice-to-have but lower priority.
+
+---
+
+## XIII. AI & AUTOMATION
+
+### A. Combat Suggestions
+
+**Status:** Not Implemented
+**Gap:** No AI-powered creature tactics or combat suggestions
+
+**Missing Features:**
+1. **Creature Tactical Suggestions**
+   - AI suggests next action for creature based on situation
+   - Considers creature role, abilities, combat status
+   - Suggests damage targets, condition applications
+
+2. **Combat Encounter Flow**
+   - AI-powered encounter pacing suggestions
+   - When to escalate difficulty
+   - Environmental effects suggestions
+
+3. **Damage Calculation Help**
+   - Suggest damage rolls based on creature abilities
+   - Calculate expected damage
+   - Help adjudicate ambiguous situations
+
+**Why It Matters:**
+New Directors struggle with creature tactics. AI suggestions would improve creature behavior and encounter quality.
+
+**Suggested Priority:** LOW-MEDIUM
+Nice-to-have but not essential.
+
+---
+
+### B. Plot Hook Generation
+
+**Status:** Partially Implemented
+**Current:** AI field generation exists
+**Gap:** No specialized plot hook or adventure generation
+
+**Missing Features:**
+1. **Hook Generator**
+   - Generate plot hooks tied to party relationships
+   - Based on character motivations
+   - Based on faction interests
+   - Tie to existing entities
+
+2. **Encounter Generation**
+   - Generate combats based on party level
+   - Generate NPCs for specific roles
+   - Generate locations for specific purposes
+
+3. **Session Prep Assistant**
+   - What to prep for next session
+   - Suggested NPCs to include
+   - Suggested encounters based on plot
+   - Pacing suggestions
+
+**Why It Matters:**
+AI generation exists but could be more specialized for campaign context. Better hooks would help Directors prep faster.
+
+**Suggested Priority:** MEDIUM
+Would be useful but not critical.
+
+---
+
+### C. Grammar & Lore Consistency Checking
+
+**Status:** Not Implemented
+**Gap:** No automated quality checking
+
+**Missing Features:**
+1. **Lore Consistency Checker**
+   - Flag contradictions in entity descriptions
+   - Check date consistency
+   - Verify relationship coherence
+   - Suggest linking related entities
+
+2. **Grammar & Style Checker**
+   - Spell check entity descriptions
+   - Grammar suggestions
+   - Tone consistency
+   - Style matching between entities
+
+3. **Completeness Checker**
+   - Flag incomplete entity entries
+   - Suggest missing relationships
+   - Identify orphaned entities
+   - Recommend additional field fill-in
+
+**Why It Matters:**
+Long campaigns accumulate inconsistencies. Automated checking would catch errors early and improve campaign quality.
+
+**Suggested Priority:** LOW
+Nice-to-have improvement feature.
+
+---
+
+## XIV. INTEGRATION & INTEROPERABILITY
+
+### A. Forge Steel Export Enhancements
+
+**Status:** Partially Implemented
+**Current:** Basic Forge Steel character import exists
+**Gap:** Limited data mapping and no export
+
+**Missing Features:**
+1. **Enhanced Import**
+   - Import all character field data
+   - Map Forge Steel attributes to Draw Steel character sheet
+   - Import equipment
+   - Import complete background
+
+2. **Character Export to Forge Steel**
+   - Export updated character back to Forge Steel format
+   - Roundtrip workflow (edit in Forge Steel or Director Assist)
+   - Version sync
+
+3. **Batch Import**
+   - Import entire party from Forge Steel
+   - Assign to player profiles
+   - Quick setup for established campaigns
+
+**Why It Matters:**
+Forge Steel is the primary character builder. Better integration would streamline player character management.
+
+**Suggested Priority:** MEDIUM
+Useful but foundational features exist.
+
+---
+
+### B. OCF Compliance & Export
+
+**Status:** Partially Implemented
+**Current:** OCF (Open Campaign Format) audit is tracked (Issue #314)
+**Gap:** Full spec compliance and export features
+
+**Missing Features:**
+1. **Full OCF Support**
+   - Complete spec compliance for all data types
+   - Import from OCF files
+   - Export to OCF format
+   - Roundtrip data integrity
+
+2. **Interoperability**
+   - Import campaigns from other OCF-compliant tools
+   - Export to use in other tools
+   - Data portability
+
+3. **Version Management**
+   - OCF version tracking
+   - Migration guides for version updates
+
+**Why It Matters:**
+OCF is the emerging standard for TTRPG data. Compliance would enable ecosystem interoperability.
+
+**Suggested Priority:** MEDIUM
+Good for long-term tool independence and data portability.
+
+---
+
+### C. VTT Integration
+
+**Status:** Not Implemented
+**Gap:** No integration with Virtual Tabletops
+
+**Missing Features:**
+1. **Roll20 Integration**
+   - Export campaign to Roll20 format
+   - Import Roll20 campaigns
+   - Sync character sheets
+
+2. **Foundry Integration**
+   - Export to Foundry VTT format
+   - Creature/NPC import from Foundry
+   - Two-way sync
+
+3. **Fantasy Grounds Integration**
+   - Similar export/import
+   - Data mapping
+
+**Why It Matters:**
+Many Directors use VTTs for remote play. Integration would extend Director Assist utility.
+
+**Suggested Priority:** LOW-MEDIUM
+Valuable for VTT users but not essential for in-person play.
+
+---
+
+## XV. COMMUNITY & CONTENT
+
+### A. Shared Content Library
+
+**Status:** Not Implemented
+**Gap:** No mechanism for sharing user-created content
+
+**Missing Features:**
+1. **Content Marketplace**
+   - Share creature templates with community
+   - Share encounter setups
+   - Share adventure hooks
+   - Community ratings/reviews
+
+2. **Community Packs**
+   - Curated sets of creatures (monster packs)
+   - Encounter libraries by setting
+   - NPC packs
+   - Item libraries
+
+3. **Content Creator Support**
+   - Tools to create and package content
+   - Revenue sharing for creators
+   - Quality assurance process
+
+**Why It Matters:**
+A community content ecosystem would make the tool more valuable and self-sustaining.
+
+**Suggested Priority:** LOW
+Post-MVP expansion, appropriate for long-term growth.
+
+---
+
+### B. Built-In Content
+
+**Status:** Partially Implemented
+**Current:** Some creature templates and example entities
+**Gap:** Limited draw Steel-specific content packs
+
+**Missing Features:**
+1. **Draw Steel Compendium**
+   - Official creature stat blocks
+   - Common NPCs and templates
+   - Published adventure encounters
+   - Treasure tables
+
+2. **Example Content**
+   - Sample campaign setup
+   - Example encounters for each difficulty
+   - Example NPCs and factions
+   - Best practices guide
+
+3. **Setting-Specific Content**
+   - Content for popular Draw Steel settings
+   - Creature lists by setting
+   - Faction templates
+   - Location types
+
+**Why It Matters:**
+New users need example content and reference material. Official content would accelerate adoption.
+
+**Suggested Priority:** MEDIUM
+Good for onboarding but lower priority than core features.
+
+---
+
+## XVI. SUMMARY TABLE
+
+| Feature | Category | Status | Priority | Effort | Impact |
+|---------|----------|--------|----------|--------|--------|
+| **Character Sheet** | Character | Partial | HIGH | Medium | HIGH |
+| **Character Creation Wizard** | Character | None | MEDIUM | Large | MEDIUM |
+| **Power Roll Interface** | Combat | Partial | MEDIUM | Medium | HIGH |
+| **Action Economy Tracking** | Combat | None | HIGH | Medium | HIGH |
+| **Encounter Difficulty Calculator** | Combat | None | MEDIUM | Medium | MEDIUM |
+| **Respite Activity System** | Downtime | Planned | HIGH | Large | HIGH |
+| **Character Bonds System** | Story | None | MEDIUM | Medium | MEDIUM |
+| **Visual Timeline** | World | Partial | MEDIUM | Medium | MEDIUM |
+| **Faction Dynamics** | World | None | MEDIUM | Large | MEDIUM |
+| **Exploration Tracker** | Encounters | None | MEDIUM | Medium | MEDIUM |
+| **Mobile/PWA Support** | Tech | Partial | HIGH | Large | HIGH |
+| **Cloud Sync** | Tech | None | MEDIUM | Large | MEDIUM |
+| **Combat Suggestions** | AI | None | MEDIUM | Medium | MEDIUM |
+| **Forge Steel Export** | Integration | Partial | MEDIUM | Medium | MEDIUM |
+
+---
+
+## RECOMMENDATIONS
+
+### High Priority Gaps (Implement Next)
+1. **Character Sheet Page** - Uses/session; needed for table use
+2. **Action Economy Tracking** - Core combat mechanic
+3. **Power Roll Interface** - Used every combat session
+4. **Respite Activity System** - Already planned; major feature
+5. **Mobile Responsiveness** - Already in progress (Issues #466-473)
+
+### Medium Priority Gaps (Plan for Future)
+1. **Character Bonds & Development** - Improves narrative depth
+2. **Encounter Difficulty Calculator** - Speeds prep
+3. **Enhanced Negotiation Features** - Polish existing system
+4. **Combat Suggestions** - QoL improvement
+5. **Session Recap Generator** - Improves note-taking
+
+### Low Priority Gaps (Consider Later)
+1. **Trap/Hazard Templates** - Useful but less critical
+2. **Loot Distribution** - Useful but simpler workaround exists
+3. **Print/PDF Export** - Nice-to-have convenience
+4. **Community Content** - Post-MVP expansion
+5. **VTT Integration** - For remote players; not in-person essential
+
+### Not Recommended (Probably Out of Scope)
+1. **Multiple TTRPG Systems** - Planned but expansive; do after full Draw Steel
+2. **Native Mobile Apps** - PWA is more practical
+3. **Real-Time Collaboration** - Complex; appropriate for later
+
+---
+
+## CONCLUSION
+
+Director Assist has built an excellent Draw Steel foundation with working combat, montage, and negotiation systems. The planned Respite Activity System (Issues #408-412) is a significant and appropriate next feature.
+
+**The most impactful remaining gaps are:**
+1. **Character Sheet focused UI** - Currently scattered across generic entity fields
+2. **Combat action economy tracking** - Core mechanic not yet supported
+3. **Power roll interface** - Used every session; currently only logging available
+4. **Character bonds/development** - Story integration is weak
+
+These four features would significantly improve both table usability and narrative depth. The technical foundation is solid; these are UX/feature additions rather than architectural changes.
+
+The roadmap is well-prioritized with respite activities planned next. Continue this trajectory while gathering Director feedback from alpha/beta users about what would most improve their sessions.

--- a/docs/RESPITE_SYSTEM.md
+++ b/docs/RESPITE_SYSTEM.md
@@ -1,0 +1,88 @@
+# Respite Activity Tracker - Architecture Overview
+
+## Overview
+
+The Respite Activity Tracker implements Draw Steel's respite mechanics, allowing Directors to manage hero downtime periods of 24+ hours in safe locations. During respites, heroes regain recoveries, convert victory points to XP, swap kits, and undertake downtime activities.
+
+## Architecture
+
+### Data Layer
+
+```
+Types (src/lib/types/respite.ts)
+  └── RespiteSession, RespiteHero, RespiteActivity, KitSwap
+  └── Input types: CreateRespiteInput, UpdateRespiteInput, RecordActivityInput
+
+Repository (src/lib/db/repositories/respiteRepository.ts)
+  └── CRUD: create, getById, getAll, update, delete
+  └── Lifecycle: startRespite, completeRespite
+  └── Heroes: addHero, updateHero, removeHero
+  └── Activities: recordActivity, updateActivity, completeActivity
+  └── VP: convertVictoryPoints
+  └── Kit Swaps: recordKitSwap
+  └── Queries: getByCampaignId, getByCharacterId
+
+Store (src/lib/stores/respite.svelte.ts)
+  └── Svelte 5 runes ($state, $derived)
+  └── Live query subscription via Dexie Observable
+  └── Derived: activeRespites, heroCount, vpRemaining, etc.
+  └── Analytics: totalVPConverted, activityTypeDistribution
+
+Database (src/lib/db/index.ts)
+  └── Version 11: respiteSessions table
+  └── Indexes: id, status, createdAt, updatedAt
+```
+
+### UI Layer
+
+```
+Components (src/lib/components/respite/)
+  ├── RespiteSetup.svelte          - Create/edit form
+  ├── HeroRecoveryPanel.svelte     - Recovery tracking per hero
+  ├── RespiteActivityCard.svelte   - Activity display card
+  ├── ActivityControls.svelte      - Activity creation with templates
+  ├── KitSwapTracker.svelte        - Kit swap recording
+  ├── VictoryPointsConverter.svelte - VP conversion UI
+  ├── RespiteRulesReference.svelte - Collapsible rules panel
+  ├── RespiteProgress.svelte       - Overview dashboard
+  ├── RespiteAnalytics.svelte      - Cross-session analytics
+  └── index.ts                     - Barrel exports
+
+Routes (src/routes/respite/)
+  ├── +page.svelte                 - List view (grid)
+  ├── new/+page.svelte             - Create form
+  └── [id]/+page.svelte            - Detail view (3-column active)
+```
+
+### Integration Layer
+
+```
+Narrative Events (src/lib/services/narrativeEventService.ts)
+  └── createFromRespite() - Auto-creates narrative event on completion
+
+Sidebar (src/lib/components/layout/Sidebar.svelte)
+  └── /respite nav link with Coffee icon
+  └── Active respite count badge
+
+Activity Templates (src/lib/config/respiteTemplates.ts)
+  └── 15 predefined templates across 5 activity types
+  └── Quick-select in ActivityControls
+```
+
+## Lifecycle
+
+```
+preparing → active → completed
+```
+
+1. **Preparing**: Director sets up the respite (name, heroes, VP available)
+2. **Active**: Heroes rest, activities are tracked, VP converted, kits swapped
+3. **Completed**: Summary displayed, narrative event auto-created
+
+## Key Patterns
+
+- **JSON serialization before IndexedDB**: All `db.put()` calls use `JSON.parse(JSON.stringify())` to handle Svelte 5 reactive proxies
+- **Repository + Store separation**: Repository handles data persistence, store handles reactive UI state
+- **Live queries**: Store subscribes to Dexie `liveQuery` for automatic UI updates
+- **Error isolation**: Narrative event creation is wrapped in try/catch to prevent blocking respite completion
+- **Duplicate prevention**: Heroes are checked by case-insensitive name before adding

--- a/docs/testing/RESPITE_TEST_STRATEGY.md
+++ b/docs/testing/RESPITE_TEST_STRATEGY.md
@@ -1,0 +1,88 @@
+# Respite System Test Strategy
+
+## Overview
+
+Test strategy covering all 5 respite implementation issues (#408-#412).
+
+## Test Files
+
+| File | Tests | Coverage |
+|------|-------|----------|
+| `src/lib/db/repositories/respiteRepository.test.ts` | 57 | Repository CRUD, lifecycle, heroes, activities, VP, kit swaps |
+| `src/lib/stores/respite.svelte.test.ts` | 32 | Store reactivity, derived values, operations, error handling |
+| `src/lib/config/respiteTemplates.test.ts` | 7 | Template config, filtering, type coverage |
+
+**Total: 96 tests**
+
+## Repository Tests (57 tests)
+
+### Helper Functions
+- `isValidTransition`: Valid/invalid lifecycle transitions
+- `calculateRemainingVP`: VP math including edge cases
+
+### CRUD Operations
+- Create with defaults, heroes, description
+- GetById (found and not found)
+- Update name, description, VP; timestamp updates; not-found errors
+- Delete
+
+### Lifecycle
+- startRespite: preparing→active, already active error, completed error
+- completeRespite: active→completed with completedAt, not active error
+
+### Hero Management
+- addHero: basic add, duplicate prevention (case-insensitive), heroId link
+- updateHero: recoveries, notes, conditions, not-found error
+- removeHero: basic remove, not-found error
+
+### Activity Management
+- recordActivity: defaults, hero assignment, multiple activities
+- updateActivity: status, name/notes, not-found error
+- completeActivity: with outcome, without outcome
+
+### VP Conversion
+- Convert VP, incremental conversion, over-conversion prevention
+- Zero/negative amount prevention, exact remaining conversion
+
+### Kit Swap Recording
+- Record with reason, without reason, non-existent hero, multiple swaps
+
+## Store Tests (32 tests)
+
+### State and Reactivity
+- Empty initial state
+- Empty derived values
+
+### CRUD
+- createRespite: repository call, error handling
+- selectRespite: set active, handle missing
+- updateRespite: repository call, active sync
+- deleteRespite: repository call, clear active
+
+### Lifecycle
+- startRespite: call, active sync, error
+- completeRespite: call
+
+### Hero/Activity/VP/Kit Swap Operations
+- Delegation to repository with correct arguments
+- Error propagation
+
+### Derived Values
+- heroCount, fullyRestedHeroes, vpRemaining, vpConversionPercent
+- Activities by status (pending, in_progress, completed)
+- kitSwapHistory
+
+## Template Tests (7 tests)
+
+- Templates for all activity types
+- Non-empty name/description
+- At least 3 templates per type
+- getTemplatesByType filtering
+- getTemplateTypes uniqueness
+
+## Test Approach
+
+- **Repository tests**: Use real Dexie + fake-indexeddb for integration-level DB testing
+- **Store tests**: Mock repository, test store logic in isolation
+- **Template tests**: Pure unit tests on config data
+- **UI components**: No component tests in v1.7.0 (follow negotiation pattern for future addition)

--- a/src/lib/components/layout/Sidebar.combat.test.ts
+++ b/src/lib/components/layout/Sidebar.combat.test.ts
@@ -52,6 +52,9 @@ vi.mock('$lib/stores', () => ({
 	},
 	negotiationStore: {
 		activeNegotiations: []
+	},
+	respiteStore: {
+		activeRespites: []
 	}
 }));
 

--- a/src/lib/components/layout/Sidebar.dragdrop.test.ts
+++ b/src/lib/components/layout/Sidebar.dragdrop.test.ts
@@ -44,6 +44,9 @@ vi.mock('$lib/stores', () => ({
 	},
 	negotiationStore: {
 		activeNegotiations: []
+	},
+	respiteStore: {
+		activeRespites: []
 	}
 }));
 

--- a/src/lib/components/layout/Sidebar.integration.test.ts
+++ b/src/lib/components/layout/Sidebar.integration.test.ts
@@ -47,6 +47,9 @@ vi.mock('$lib/stores', () => ({
 	},
 	negotiationStore: {
 		activeNegotiations: []
+	},
+	respiteStore: {
+		activeRespites: []
 	}
 }));
 

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-	import { Plus, Home, ChevronUp, ChevronDown, Pencil, Swords, Theater, MessageCircle, Users, Clapperboard } from 'lucide-svelte';
+	import { Plus, Home, ChevronUp, ChevronDown, Pencil, Swords, Theater, MessageCircle, Users, Clapperboard, Coffee } from 'lucide-svelte';
 	import { page } from '$app/stores';
 	import { getOrderedEntityTypes } from '$lib/config/entityTypes';
-	import { entitiesStore, campaignStore, combatStore, montageStore, negotiationStore } from '$lib/stores';
+	import { entitiesStore, campaignStore, combatStore, montageStore, negotiationStore, respiteStore } from '$lib/stores';
 	import { getIconComponent } from '$lib/utils/icons';
 	import QuickAddModal from './QuickAddModal.svelte';
 	import {
@@ -32,6 +32,11 @@
 	// Get active negotiations count
 	const activeNegotiationsCount = $derived(
 		negotiationStore.activeNegotiations.length
+	);
+
+	// Get active respites count
+	const activeRespitesCount = $derived(
+		respiteStore.activeRespites.length
 	);
 
 	// Initialize ordered types on mount
@@ -180,6 +185,29 @@
 					aria-live="polite"
 				>
 					{activeNegotiationsCount}
+				</span>
+			{/if}
+		</a>
+
+		<!-- Respite -->
+		<a
+			href="/respite"
+			class="flex items-center gap-3 px-3 py-2 rounded-lg mb-2 transition-colors
+				{isActive('/respite')
+				? 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300'
+				: 'hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-700 dark:text-slate-300'}"
+			aria-current={isActive('/respite') ? 'page' : undefined}
+		>
+			<Coffee class="w-5 h-5" data-icon="coffee" />
+			<span class="flex-1 font-medium">Respite</span>
+			{#if activeRespitesCount > 0}
+				<span
+					class="text-xs bg-amber-500 dark:bg-amber-600 text-white px-2 py-0.5 rounded-full"
+					data-testid="active-respite-badge"
+					aria-label="{activeRespitesCount} active respite{activeRespitesCount === 1 ? '' : 's'}"
+					aria-live="polite"
+				>
+					{activeRespitesCount}
 				</span>
 			{/if}
 		</a>

--- a/src/lib/components/respite/ActivityControls.svelte
+++ b/src/lib/components/respite/ActivityControls.svelte
@@ -1,0 +1,165 @@
+<script lang="ts">
+	/**
+	 * ActivityControls Component
+	 *
+	 * Form for adding/editing respite activities.
+	 */
+
+	import type { RespiteActivityType, RecordActivityInput } from '$lib/types/respite';
+	import { getTemplatesByType, type ActivityTemplate } from '$lib/config/respiteTemplates';
+
+	interface Props {
+		onRecord?: (data: RecordActivityInput) => void;
+	}
+
+	let { onRecord }: Props = $props();
+
+	const activityTypes: { value: RespiteActivityType; label: string }[] = [
+		{ value: 'project', label: 'Project' },
+		{ value: 'crafting', label: 'Crafting' },
+		{ value: 'socializing', label: 'Socializing' },
+		{ value: 'training', label: 'Training' },
+		{ value: 'investigation', label: 'Investigation' },
+		{ value: 'other', label: 'Other' }
+	];
+
+	let activityName = $state('');
+	let activityDescription = $state('');
+	let activityType = $state<RespiteActivityType>('project');
+	let activityNotes = $state('');
+	let nameError = $state('');
+
+	// Template quick-select
+	const currentTemplates = $derived(getTemplatesByType(activityType));
+
+	function applyTemplate(template: ActivityTemplate) {
+		activityName = template.name;
+		activityDescription = template.description;
+		activityType = template.type;
+		nameError = '';
+	}
+
+	function validate(): boolean {
+		if (!activityName.trim()) {
+			nameError = 'Activity name is required';
+			return false;
+		}
+		nameError = '';
+		return true;
+	}
+
+	function handleRecord() {
+		if (!validate()) return;
+
+		onRecord?.({
+			name: activityName.trim(),
+			description: activityDescription.trim() || undefined,
+			type: activityType,
+			notes: activityNotes.trim() || undefined
+		});
+
+		// Reset form
+		activityName = '';
+		activityDescription = '';
+		activityType = 'project';
+		activityNotes = '';
+	}
+
+	$effect(() => {
+		if (activityName) nameError = '';
+	});
+</script>
+
+<div class="space-y-4">
+	<!-- Activity Name -->
+	<div>
+		<label for="activity-name" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+			Activity Name <span class="text-red-600">*</span>
+		</label>
+		<input
+			id="activity-name"
+			type="text"
+			bind:value={activityName}
+			required
+			aria-required="true"
+			aria-invalid={!!nameError}
+			placeholder="e.g., Research ancient texts"
+			class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2"
+		/>
+		{#if nameError}
+			<p class="mt-1 text-sm text-red-600">{nameError}</p>
+		{/if}
+	</div>
+
+	<!-- Activity Type -->
+	<div>
+		<label for="activity-type" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+			Activity Type
+		</label>
+		<select
+			id="activity-type"
+			bind:value={activityType}
+			class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2"
+		>
+			{#each activityTypes as type}
+				<option value={type.value}>{type.label}</option>
+			{/each}
+		</select>
+	</div>
+
+	<!-- Template Quick-Select -->
+	{#if currentTemplates.length > 0}
+		<div>
+			<label class="block text-xs text-gray-500 dark:text-gray-400 mb-1">Quick Templates</label>
+			<div class="flex flex-wrap gap-1">
+				{#each currentTemplates as template}
+					<button
+						type="button"
+						onclick={() => applyTemplate(template)}
+						class="text-xs px-2 py-1 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+						title={template.description}
+					>
+						{template.name}
+					</button>
+				{/each}
+			</div>
+		</div>
+	{/if}
+
+	<!-- Description -->
+	<div>
+		<label for="activity-description" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+			Description
+		</label>
+		<textarea
+			id="activity-description"
+			bind:value={activityDescription}
+			rows="2"
+			placeholder="Optional description"
+			class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2"
+		></textarea>
+	</div>
+
+	<!-- Notes -->
+	<div>
+		<label for="activity-notes" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+			Notes
+		</label>
+		<textarea
+			id="activity-notes"
+			bind:value={activityNotes}
+			rows="2"
+			placeholder="Optional notes"
+			class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2"
+		></textarea>
+	</div>
+
+	<!-- Record Button -->
+	<button
+		type="button"
+		onclick={handleRecord}
+		class="w-full rounded-md bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-700"
+	>
+		Add Activity
+	</button>
+</div>

--- a/src/lib/components/respite/HeroRecoveryPanel.svelte
+++ b/src/lib/components/respite/HeroRecoveryPanel.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+	/**
+	 * HeroRecoveryPanel Component
+	 *
+	 * Displays recovery tracking per hero with color-coded status:
+	 * - Red: < 25% recoveries
+	 * - Yellow: 25-75% recoveries
+	 * - Green: > 75% recoveries
+	 */
+
+	import type { RespiteHero } from '$lib/types/respite';
+	import { Heart, Plus, Minus } from 'lucide-svelte';
+
+	interface Props {
+		heroes: RespiteHero[];
+		onUpdateRecovery?: (heroId: string, gained: number) => void;
+	}
+
+	let { heroes, onUpdateRecovery }: Props = $props();
+
+	function getRecoveryColor(hero: RespiteHero): string {
+		const percent = hero.recoveries.current / hero.recoveries.max;
+		if (percent < 0.25) return 'text-red-600 dark:text-red-400';
+		if (percent < 0.75) return 'text-yellow-600 dark:text-yellow-400';
+		return 'text-green-600 dark:text-green-400';
+	}
+
+	function getRecoveryBgColor(hero: RespiteHero): string {
+		const percent = hero.recoveries.current / hero.recoveries.max;
+		if (percent < 0.25) return 'bg-red-500';
+		if (percent < 0.75) return 'bg-yellow-500';
+		return 'bg-green-500';
+	}
+
+	function handleGainRecovery(heroId: string, currentGained: number) {
+		onUpdateRecovery?.(heroId, currentGained + 1);
+	}
+
+	function handleLoseRecovery(heroId: string, currentGained: number) {
+		if (currentGained > 0) {
+			onUpdateRecovery?.(heroId, currentGained - 1);
+		}
+	}
+</script>
+
+<div class="space-y-3">
+	{#if heroes.length === 0}
+		<p class="text-sm text-slate-500 dark:text-slate-400">No heroes in this respite.</p>
+	{:else}
+		{#each heroes as hero (hero.id)}
+			<div
+				class="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4"
+				data-testid="hero-recovery-card"
+			>
+				<div class="flex items-center justify-between mb-2">
+					<div class="flex items-center gap-2">
+						<Heart class="w-4 h-4 {getRecoveryColor(hero)}" />
+						<span class="font-medium text-slate-900 dark:text-white">{hero.name}</span>
+					</div>
+					<span class="text-sm {getRecoveryColor(hero)} font-semibold">
+						{hero.recoveries.current}/{hero.recoveries.max}
+					</span>
+				</div>
+
+				<!-- Recovery Bar -->
+				<div class="w-full bg-slate-200 dark:bg-slate-700 rounded-full h-2.5 mb-2">
+					<div
+						class="{getRecoveryBgColor(hero)} h-2.5 rounded-full transition-all"
+						style="width: {(hero.recoveries.current / hero.recoveries.max) * 100}%"
+						role="progressbar"
+						aria-label="{hero.name} recovery"
+						aria-valuenow={hero.recoveries.current}
+						aria-valuemin={0}
+						aria-valuemax={hero.recoveries.max}
+					></div>
+				</div>
+
+				<!-- Controls -->
+				{#if onUpdateRecovery}
+					<div class="flex items-center justify-between mt-2">
+						<span class="text-xs text-slate-500 dark:text-slate-400">
+							Gained: {hero.recoveries.gained}
+						</span>
+						<div class="flex gap-1">
+							<button
+								type="button"
+								onclick={() => handleLoseRecovery(hero.id, hero.recoveries.gained)}
+								disabled={hero.recoveries.gained <= 0}
+								class="p-1 rounded text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-30"
+								aria-label="Decrease recovery for {hero.name}"
+							>
+								<Minus class="w-4 h-4" />
+							</button>
+							<button
+								type="button"
+								onclick={() => handleGainRecovery(hero.id, hero.recoveries.gained)}
+								disabled={hero.recoveries.current >= hero.recoveries.max}
+								class="p-1 rounded text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-30"
+								aria-label="Increase recovery for {hero.name}"
+							>
+								<Plus class="w-4 h-4" />
+							</button>
+						</div>
+					</div>
+				{/if}
+
+				<!-- Conditions -->
+				{#if hero.conditions && hero.conditions.length > 0}
+					<div class="mt-2 flex flex-wrap gap-1">
+						{#each hero.conditions as condition}
+							<span class="text-xs px-2 py-0.5 rounded-full bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300">
+								{condition}
+							</span>
+						{/each}
+					</div>
+				{/if}
+
+				<!-- Notes -->
+				{#if hero.notes}
+					<p class="mt-2 text-xs text-slate-500 dark:text-slate-400 italic">{hero.notes}</p>
+				{/if}
+			</div>
+		{/each}
+	{/if}
+</div>

--- a/src/lib/components/respite/KitSwapTracker.svelte
+++ b/src/lib/components/respite/KitSwapTracker.svelte
@@ -1,0 +1,133 @@
+<script lang="ts">
+	/**
+	 * KitSwapTracker Component
+	 *
+	 * Records and displays kit swaps during respite.
+	 */
+
+	import type { KitSwap, RespiteHero } from '$lib/types/respite';
+	import { ArrowRight } from 'lucide-svelte';
+
+	interface Props {
+		kitSwaps: KitSwap[];
+		heroes: RespiteHero[];
+		onSwap?: (swap: { heroId: string; from: string; to: string; reason?: string }) => void;
+	}
+
+	let { kitSwaps, heroes, onSwap }: Props = $props();
+
+	let selectedHeroId = $state('');
+	let fromKit = $state('');
+	let toKit = $state('');
+	let reason = $state('');
+
+	function handleSwap() {
+		if (!selectedHeroId || !fromKit.trim() || !toKit.trim()) return;
+
+		onSwap?.({
+			heroId: selectedHeroId,
+			from: fromKit.trim(),
+			to: toKit.trim(),
+			reason: reason.trim() || undefined
+		});
+
+		// Reset form
+		fromKit = '';
+		toKit = '';
+		reason = '';
+	}
+
+	function getHeroName(heroId: string): string {
+		return heroes.find((h) => h.id === heroId)?.name || 'Unknown';
+	}
+</script>
+
+<div class="space-y-4">
+	<!-- Record New Swap -->
+	{#if onSwap && heroes.length > 0}
+		<div class="space-y-3 rounded-lg border border-slate-200 dark:border-slate-700 p-4">
+			<h4 class="text-sm font-medium text-slate-900 dark:text-white">Record Kit Swap</h4>
+
+			<!-- Hero Select -->
+			<div>
+				<label for="swap-hero" class="block text-xs text-slate-600 dark:text-slate-400 mb-1">Hero</label>
+				<select
+					id="swap-hero"
+					bind:value={selectedHeroId}
+					class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+				>
+					<option value="">Select hero...</option>
+					{#each heroes as hero}
+						<option value={hero.id}>{hero.name}</option>
+					{/each}
+				</select>
+			</div>
+
+			<!-- From/To -->
+			<div class="flex gap-2 items-end">
+				<div class="flex-1">
+					<label for="swap-from" class="block text-xs text-slate-600 dark:text-slate-400 mb-1">From Kit</label>
+					<input
+						id="swap-from"
+						type="text"
+						bind:value={fromKit}
+						placeholder="Current kit"
+						class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+					/>
+				</div>
+				<ArrowRight class="w-5 h-5 text-slate-400 mb-2" />
+				<div class="flex-1">
+					<label for="swap-to" class="block text-xs text-slate-600 dark:text-slate-400 mb-1">To Kit</label>
+					<input
+						id="swap-to"
+						type="text"
+						bind:value={toKit}
+						placeholder="New kit"
+						class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+					/>
+				</div>
+			</div>
+
+			<!-- Reason -->
+			<div>
+				<label for="swap-reason" class="block text-xs text-slate-600 dark:text-slate-400 mb-1">Reason (optional)</label>
+				<input
+					id="swap-reason"
+					type="text"
+					bind:value={reason}
+					placeholder="Why are they swapping?"
+					class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+				/>
+			</div>
+
+			<button
+				type="button"
+				onclick={handleSwap}
+				disabled={!selectedHeroId || !fromKit.trim() || !toKit.trim()}
+				class="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+			>
+				Record Swap
+			</button>
+		</div>
+	{/if}
+
+	<!-- Swap History -->
+	{#if kitSwaps.length > 0}
+		<div class="space-y-2">
+			<h4 class="text-sm font-medium text-slate-900 dark:text-white">Swap History</h4>
+			{#each kitSwaps as swap (swap.id)}
+				<div class="flex items-center gap-2 rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50 p-3 text-sm">
+					<span class="font-medium text-slate-900 dark:text-white">{getHeroName(swap.heroId)}</span>
+					<span class="text-slate-500 dark:text-slate-400">{swap.from}</span>
+					<ArrowRight class="w-4 h-4 text-slate-400" />
+					<span class="text-slate-900 dark:text-white">{swap.to}</span>
+					{#if swap.reason}
+						<span class="text-xs text-slate-500 dark:text-slate-400 italic ml-auto">({swap.reason})</span>
+					{/if}
+				</div>
+			{/each}
+		</div>
+	{:else}
+		<p class="text-sm text-slate-500 dark:text-slate-400">No kit swaps recorded.</p>
+	{/if}
+</div>

--- a/src/lib/components/respite/RespiteActivityCard.svelte
+++ b/src/lib/components/respite/RespiteActivityCard.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+	/**
+	 * RespiteActivityCard Component
+	 *
+	 * Displays a single respite activity with type badge and status indicator.
+	 */
+
+	import type { RespiteActivity } from '$lib/types/respite';
+	import { CheckCircle, Clock, Circle } from 'lucide-svelte';
+
+	interface Props {
+		activity: RespiteActivity;
+		onComplete?: (activityId: string) => void;
+		onStart?: (activityId: string) => void;
+	}
+
+	let { activity, onComplete, onStart }: Props = $props();
+
+	const typeBadgeColors: Record<string, string> = {
+		project: 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300',
+		crafting: 'bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-300',
+		socializing: 'bg-pink-100 dark:bg-pink-900/30 text-pink-700 dark:text-pink-300',
+		training: 'bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300',
+		investigation: 'bg-cyan-100 dark:bg-cyan-900/30 text-cyan-700 dark:text-cyan-300',
+		other: 'bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300'
+	};
+
+	function formatType(type: string): string {
+		return type.charAt(0).toUpperCase() + type.slice(1);
+	}
+
+	const statusIcon = $derived.by(() => {
+		if (activity.status === 'completed') return CheckCircle;
+		if (activity.status === 'in_progress') return Clock;
+		return Circle;
+	});
+
+	const statusColor = $derived.by(() => {
+		if (activity.status === 'completed') return 'text-green-600 dark:text-green-400';
+		if (activity.status === 'in_progress') return 'text-blue-600 dark:text-blue-400';
+		return 'text-slate-400 dark:text-slate-500';
+	});
+</script>
+
+<div
+	class="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4"
+	data-testid="activity-card"
+>
+	<div class="flex items-start justify-between gap-3">
+		<div class="flex items-start gap-2 flex-1">
+			<svelte:component this={statusIcon} class="w-5 h-5 mt-0.5 {statusColor}" />
+			<div class="flex-1">
+				<h4 class="font-medium text-slate-900 dark:text-white">{activity.name}</h4>
+				{#if activity.description}
+					<p class="text-sm text-slate-600 dark:text-slate-400 mt-1">{activity.description}</p>
+				{/if}
+			</div>
+		</div>
+
+		<!-- Type Badge -->
+		<span class="text-xs px-2 py-1 rounded-full font-medium {typeBadgeColors[activity.type] || typeBadgeColors.other}">
+			{formatType(activity.type)}
+		</span>
+	</div>
+
+	<!-- Hero Assignment -->
+	{#if activity.heroId}
+		<div class="mt-2 text-xs text-slate-500 dark:text-slate-400">
+			Assigned to hero
+		</div>
+	{/if}
+
+	<!-- Outcome -->
+	{#if activity.outcome}
+		<div class="mt-2 rounded-md bg-green-50 dark:bg-green-900/20 p-2 text-sm text-green-700 dark:text-green-300">
+			{activity.outcome}
+		</div>
+	{/if}
+
+	<!-- Notes -->
+	{#if activity.notes}
+		<p class="mt-2 text-sm text-slate-500 dark:text-slate-400 italic">{activity.notes}</p>
+	{/if}
+
+	<!-- Actions -->
+	{#if activity.status !== 'completed'}
+		<div class="mt-3 flex gap-2">
+			{#if activity.status === 'pending' && onStart}
+				<button
+					type="button"
+					onclick={() => onStart(activity.id)}
+					class="text-xs px-3 py-1 rounded-md bg-blue-600 text-white hover:bg-blue-700"
+				>
+					Start
+				</button>
+			{/if}
+			{#if onComplete}
+				<button
+					type="button"
+					onclick={() => onComplete(activity.id)}
+					class="text-xs px-3 py-1 rounded-md bg-green-600 text-white hover:bg-green-700"
+				>
+					Complete
+				</button>
+			{/if}
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/respite/RespiteAnalytics.svelte
+++ b/src/lib/components/respite/RespiteAnalytics.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+	/**
+	 * RespiteAnalytics Component
+	 *
+	 * Displays analytics and statistics about respite sessions.
+	 */
+
+	import { respiteStore } from '$lib/stores';
+	import { BarChart3 } from 'lucide-svelte';
+
+	const totalCompleted = $derived(respiteStore.completedRespites.length);
+	const totalVP = $derived(respiteStore.totalVPConverted);
+	const totalActivities = $derived(respiteStore.totalActivitiesCompleted);
+	const distribution = $derived(respiteStore.activityTypeDistribution);
+
+	const activityTypeLabels: Record<string, string> = {
+		project: 'Project',
+		crafting: 'Crafting',
+		socializing: 'Socializing',
+		training: 'Training',
+		investigation: 'Investigation',
+		other: 'Other'
+	};
+
+	const activityTypeColors: Record<string, string> = {
+		project: 'bg-blue-500',
+		crafting: 'bg-orange-500',
+		socializing: 'bg-pink-500',
+		training: 'bg-purple-500',
+		investigation: 'bg-cyan-500',
+		other: 'bg-slate-500'
+	};
+
+	const distributionEntries = $derived.by(() => {
+		return Object.entries(distribution).sort(([, a], [, b]) => b - a);
+	});
+
+	const maxCount = $derived.by(() => {
+		return Math.max(1, ...Object.values(distribution));
+	});
+</script>
+
+<div class="space-y-6">
+	<div class="flex items-center gap-2 mb-4">
+		<BarChart3 class="w-5 h-5 text-slate-600 dark:text-slate-400" />
+		<h3 class="text-lg font-semibold text-slate-900 dark:text-white">Respite Analytics</h3>
+	</div>
+
+	<!-- Summary Stats -->
+	<div class="grid grid-cols-3 gap-4">
+		<div class="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4 text-center">
+			<div class="text-2xl font-bold text-slate-900 dark:text-white">{totalCompleted}</div>
+			<div class="text-xs text-slate-500 dark:text-slate-400">Respites Completed</div>
+		</div>
+		<div class="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4 text-center">
+			<div class="text-2xl font-bold text-amber-600 dark:text-amber-400">{totalVP}</div>
+			<div class="text-xs text-slate-500 dark:text-slate-400">Total VP Converted</div>
+		</div>
+		<div class="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4 text-center">
+			<div class="text-2xl font-bold text-green-600 dark:text-green-400">{totalActivities}</div>
+			<div class="text-xs text-slate-500 dark:text-slate-400">Activities Completed</div>
+		</div>
+	</div>
+
+	<!-- Activity Type Distribution -->
+	{#if distributionEntries.length > 0}
+		<div>
+			<h4 class="text-sm font-medium text-slate-900 dark:text-white mb-3">Activity Distribution</h4>
+			<div class="space-y-2">
+				{#each distributionEntries as [type, count]}
+					<div class="flex items-center gap-3">
+						<span class="text-xs text-slate-600 dark:text-slate-400 w-24">
+							{activityTypeLabels[type] || type}
+						</span>
+						<div class="flex-1 bg-slate-200 dark:bg-slate-700 rounded-full h-4">
+							<div
+								class="{activityTypeColors[type] || 'bg-slate-500'} h-4 rounded-full transition-all"
+								style="width: {(count / maxCount) * 100}%"
+							></div>
+						</div>
+						<span class="text-xs font-medium text-slate-900 dark:text-white w-8 text-right">{count}</span>
+					</div>
+				{/each}
+			</div>
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/respite/RespiteProgress.svelte
+++ b/src/lib/components/respite/RespiteProgress.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+	/**
+	 * RespiteProgress Component
+	 *
+	 * Overall respite progress indicators showing heroes, activities, and VP status.
+	 */
+
+	import type { RespiteSession } from '$lib/types/respite';
+	import { Users, Activity, Trophy, Repeat } from 'lucide-svelte';
+
+	interface Props {
+		respite: RespiteSession;
+	}
+
+	let { respite }: Props = $props();
+
+	const completedActivities = $derived(
+		respite.activities.filter((a) => a.status === 'completed').length
+	);
+	const totalActivities = $derived(respite.activities.length);
+
+	const vpRemaining = $derived(
+		Math.max(0, respite.victoryPointsAvailable - respite.victoryPointsConverted)
+	);
+
+	const heroesFullyRested = $derived(
+		respite.heroes.filter((h) => h.recoveries.current >= h.recoveries.max).length
+	);
+</script>
+
+<div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
+	<!-- Heroes -->
+	<div class="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4">
+		<div class="flex items-center gap-2 mb-2">
+			<Users class="w-4 h-4 text-blue-500" />
+			<span class="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase">Heroes</span>
+		</div>
+		<div class="text-2xl font-bold text-slate-900 dark:text-white">{respite.heroes.length}</div>
+		<div class="text-xs text-slate-500 dark:text-slate-400">{heroesFullyRested} fully rested</div>
+	</div>
+
+	<!-- Activities -->
+	<div class="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4">
+		<div class="flex items-center gap-2 mb-2">
+			<Activity class="w-4 h-4 text-green-500" />
+			<span class="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase">Activities</span>
+		</div>
+		<div class="text-2xl font-bold text-slate-900 dark:text-white">
+			{completedActivities}/{totalActivities}
+		</div>
+		<div class="text-xs text-slate-500 dark:text-slate-400">completed</div>
+	</div>
+
+	<!-- Victory Points -->
+	<div class="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4">
+		<div class="flex items-center gap-2 mb-2">
+			<Trophy class="w-4 h-4 text-amber-500" />
+			<span class="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase">VP</span>
+		</div>
+		<div class="text-2xl font-bold text-slate-900 dark:text-white">
+			{respite.victoryPointsConverted}/{respite.victoryPointsAvailable}
+		</div>
+		<div class="text-xs text-slate-500 dark:text-slate-400">{vpRemaining} remaining</div>
+	</div>
+
+	<!-- Kit Swaps -->
+	<div class="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4">
+		<div class="flex items-center gap-2 mb-2">
+			<Repeat class="w-4 h-4 text-purple-500" />
+			<span class="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase">Kit Swaps</span>
+		</div>
+		<div class="text-2xl font-bold text-slate-900 dark:text-white">{respite.kitSwaps.length}</div>
+		<div class="text-xs text-slate-500 dark:text-slate-400">recorded</div>
+	</div>
+</div>

--- a/src/lib/components/respite/RespiteRulesReference.svelte
+++ b/src/lib/components/respite/RespiteRulesReference.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+	/**
+	 * RespiteRulesReference Component
+	 *
+	 * Collapsible Draw Steel respite rules reference panel.
+	 */
+
+	import { ChevronDown, ChevronUp, BookOpen } from 'lucide-svelte';
+
+	let isExpanded = $state(false);
+
+	function toggleExpanded() {
+		isExpanded = !isExpanded;
+	}
+</script>
+
+<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700">
+	<!-- Header -->
+	<button
+		type="button"
+		onclick={toggleExpanded}
+		class="w-full flex items-center justify-between p-4 hover:bg-slate-50 dark:hover:bg-slate-700/50 transition-colors"
+		aria-expanded={isExpanded}
+		aria-controls="respite-rules-content"
+	>
+		<div class="flex items-center gap-2">
+			<BookOpen class="w-5 h-5 text-slate-600 dark:text-slate-400" />
+			<h3 class="text-lg font-semibold text-slate-900 dark:text-white">Respite Rules</h3>
+		</div>
+		{#if isExpanded}
+			<ChevronUp class="w-5 h-5 text-slate-600 dark:text-slate-400" />
+		{:else}
+			<ChevronDown class="w-5 h-5 text-slate-600 dark:text-slate-400" />
+		{/if}
+	</button>
+
+	<!-- Content -->
+	{#if isExpanded}
+		<div id="respite-rules-content" class="p-4 pt-0 space-y-6 border-t border-slate-200 dark:border-slate-700">
+			<!-- What is a Respite -->
+			<section>
+				<h4 class="text-base font-semibold text-slate-900 dark:text-white mb-2">What is a Respite?</h4>
+				<p class="text-sm text-slate-700 dark:text-slate-300">
+					A respite is a period of 24 hours or more spent in a safe location where heroes can rest and recuperate.
+					During a respite, heroes regain recoveries, can convert victory points to experience, swap kits,
+					and undertake downtime activities.
+				</p>
+			</section>
+
+			<!-- Recoveries -->
+			<section>
+				<h4 class="text-base font-semibold text-slate-900 dark:text-white mb-2">Recoveries</h4>
+				<p class="text-sm text-slate-700 dark:text-slate-300">
+					During a respite, each hero regains all their recoveries (up to their maximum).
+					This is the primary way heroes heal between encounters.
+				</p>
+			</section>
+
+			<!-- Victory Points -->
+			<section>
+				<h4 class="text-base font-semibold text-slate-900 dark:text-white mb-2">Victory Points</h4>
+				<p class="text-sm text-slate-700 dark:text-slate-300">
+					Victory points (VP) earned during encounters can be converted to experience points (XP)
+					during a respite. Each VP converts to XP on a 1:1 basis.
+				</p>
+			</section>
+
+			<!-- Kit Swapping -->
+			<section>
+				<h4 class="text-base font-semibold text-slate-900 dark:text-white mb-2">Kit Swapping</h4>
+				<p class="text-sm text-slate-700 dark:text-slate-300">
+					Heroes can swap their kit during a respite. This allows them to change their
+					combat loadout and abilities for upcoming challenges.
+				</p>
+			</section>
+
+			<!-- Downtime Activities -->
+			<section>
+				<h4 class="text-base font-semibold text-slate-900 dark:text-white mb-2">Downtime Activities</h4>
+				<div class="space-y-2 text-sm">
+					<div class="flex gap-2 p-2 rounded bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800">
+						<dt class="font-semibold text-blue-900 dark:text-blue-200 min-w-[7rem]">Project:</dt>
+						<dd class="text-blue-800 dark:text-blue-300">Long-term undertaking progressed during downtime</dd>
+					</div>
+					<div class="flex gap-2 p-2 rounded bg-orange-50 dark:bg-orange-900/20 border border-orange-200 dark:border-orange-800">
+						<dt class="font-semibold text-orange-900 dark:text-orange-200 min-w-[7rem]">Crafting:</dt>
+						<dd class="text-orange-800 dark:text-orange-300">Creating or improving items and equipment</dd>
+					</div>
+					<div class="flex gap-2 p-2 rounded bg-pink-50 dark:bg-pink-900/20 border border-pink-200 dark:border-pink-800">
+						<dt class="font-semibold text-pink-900 dark:text-pink-200 min-w-[7rem]">Socializing:</dt>
+						<dd class="text-pink-800 dark:text-pink-300">Building relationships and gathering information</dd>
+					</div>
+					<div class="flex gap-2 p-2 rounded bg-purple-50 dark:bg-purple-900/20 border border-purple-200 dark:border-purple-800">
+						<dt class="font-semibold text-purple-900 dark:text-purple-200 min-w-[7rem]">Training:</dt>
+						<dd class="text-purple-800 dark:text-purple-300">Practicing skills and improving abilities</dd>
+					</div>
+					<div class="flex gap-2 p-2 rounded bg-cyan-50 dark:bg-cyan-900/20 border border-cyan-200 dark:border-cyan-800">
+						<dt class="font-semibold text-cyan-900 dark:text-cyan-200 min-w-[7rem]">Investigation:</dt>
+						<dd class="text-cyan-800 dark:text-cyan-300">Researching mysteries and uncovering secrets</dd>
+					</div>
+				</div>
+			</section>
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/respite/RespiteSetup.svelte
+++ b/src/lib/components/respite/RespiteSetup.svelte
@@ -1,0 +1,208 @@
+<script lang="ts">
+	import { Plus, Trash2 } from 'lucide-svelte';
+
+	interface HeroInput {
+		name: string;
+		heroId?: string;
+		recoveries: { current: number; max: number };
+	}
+
+	interface CreateRespiteSetupOutput {
+		name: string;
+		description?: string;
+		heroes: HeroInput[];
+		victoryPointsAvailable: number;
+	}
+
+	interface Props {
+		initialData?: Partial<CreateRespiteSetupOutput>;
+		onCreate?: (data: CreateRespiteSetupOutput) => void;
+		onCancel?: () => void;
+	}
+
+	let { initialData, onCreate, onCancel }: Props = $props();
+
+	// Form state
+	let name = $state(initialData?.name || '');
+	let description = $state(initialData?.description || '');
+	let heroes = $state<HeroInput[]>(initialData?.heroes || []);
+	let victoryPointsAvailable = $state(initialData?.victoryPointsAvailable || 0);
+
+	// Validation
+	let nameError = $state('');
+
+	function addHero() {
+		heroes.push({ name: '', recoveries: { current: 0, max: 8 } });
+	}
+
+	function removeHero(index: number) {
+		heroes.splice(index, 1);
+	}
+
+	function validate(): boolean {
+		let isValid = true;
+		if (!name.trim()) {
+			nameError = 'Name is required';
+			isValid = false;
+		} else {
+			nameError = '';
+		}
+		return isValid;
+	}
+
+	function handleSubmit() {
+		if (!validate()) return;
+
+		const validHeroes = heroes.filter((h) => h.name.trim());
+
+		if (onCreate) {
+			onCreate({
+				name: name.trim(),
+				description: description.trim() || undefined,
+				heroes: validHeroes,
+				victoryPointsAvailable
+			});
+		}
+	}
+
+	function handleCancel() {
+		if (onCancel) onCancel();
+	}
+
+	$effect(() => {
+		if (name) nameError = '';
+	});
+</script>
+
+<div class="space-y-6">
+	<!-- Name -->
+	<div>
+		<label for="respite-name" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+			Respite Name <span class="text-red-600">*</span>
+		</label>
+		<input
+			id="respite-name"
+			type="text"
+			bind:value={name}
+			required
+			aria-required="true"
+			aria-invalid={!!nameError}
+			placeholder="e.g., Rest at the Golden Inn"
+			class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+		/>
+		{#if nameError}
+			<p class="mt-1 text-sm text-red-600">{nameError}</p>
+		{/if}
+	</div>
+
+	<!-- Description -->
+	<div>
+		<label for="respite-description" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+			Description
+		</label>
+		<textarea
+			id="respite-description"
+			bind:value={description}
+			rows="3"
+			placeholder="Optional description of the respite location and circumstances"
+			class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+		></textarea>
+	</div>
+
+	<!-- Victory Points -->
+	<div>
+		<label for="vp-available" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+			Victory Points Available
+		</label>
+		<input
+			id="vp-available"
+			type="number"
+			min="0"
+			bind:value={victoryPointsAvailable}
+			class="mt-1 block w-32 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+		/>
+		<p class="mt-1 text-xs text-gray-500 dark:text-gray-400">VP earned that can be converted to XP during this respite</p>
+	</div>
+
+	<!-- Heroes -->
+	<fieldset class="space-y-3">
+		<legend class="text-lg font-semibold text-gray-900 dark:text-white">Heroes</legend>
+
+		{#if heroes.length === 0}
+			<p class="text-sm text-gray-500 dark:text-gray-400">No heroes added yet. Add heroes to track their recoveries.</p>
+		{:else}
+			<div class="space-y-3">
+				{#each heroes as hero, index}
+					<div class="flex items-start gap-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3">
+						<div class="flex-1 space-y-2">
+							<input
+								type="text"
+								bind:value={hero.name}
+								placeholder="Hero name"
+								class="block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+							/>
+							<div class="flex gap-3">
+								<div class="flex items-center gap-2">
+									<label for="hero-current-{index}" class="text-xs text-gray-600 dark:text-gray-400">Current</label>
+									<input
+										id="hero-current-{index}"
+										type="number"
+										min="0"
+										bind:value={hero.recoveries.current}
+										class="w-16 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 text-sm"
+									/>
+								</div>
+								<div class="flex items-center gap-2">
+									<label for="hero-max-{index}" class="text-xs text-gray-600 dark:text-gray-400">Max</label>
+									<input
+										id="hero-max-{index}"
+										type="number"
+										min="1"
+										bind:value={hero.recoveries.max}
+										class="w-16 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 text-sm"
+									/>
+								</div>
+							</div>
+						</div>
+						<button
+							type="button"
+							onclick={() => removeHero(index)}
+							class="rounded-md p-2 text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20"
+							aria-label="Remove hero"
+						>
+							<Trash2 class="h-5 w-5" />
+						</button>
+					</div>
+				{/each}
+			</div>
+		{/if}
+
+		<button
+			type="button"
+			onclick={addHero}
+			class="flex items-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
+		>
+			<Plus class="h-4 w-4" /> Add Hero
+		</button>
+	</fieldset>
+
+	<!-- Actions -->
+	<div class="flex justify-end gap-3 border-t border-gray-200 dark:border-gray-700 pt-4">
+		{#if onCancel}
+			<button
+				type="button"
+				onclick={handleCancel}
+				class="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+			>
+				Cancel
+			</button>
+		{/if}
+		<button
+			type="button"
+			onclick={handleSubmit}
+			class="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+		>
+			Create Respite
+		</button>
+	</div>
+</div>

--- a/src/lib/components/respite/VictoryPointsConverter.svelte
+++ b/src/lib/components/respite/VictoryPointsConverter.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+	/**
+	 * VictoryPointsConverter Component
+	 *
+	 * VP to XP conversion UI during respite.
+	 */
+
+	import { Trophy } from 'lucide-svelte';
+
+	interface Props {
+		available: number;
+		converted: number;
+		onConvert?: (amount: number) => void;
+	}
+
+	let { available, converted, onConvert }: Props = $props();
+
+	let convertAmount = $state(1);
+
+	const remaining = $derived(Math.max(0, available - converted));
+	const percent = $derived(available > 0 ? (converted / available) * 100 : 0);
+
+	function handleConvert() {
+		if (convertAmount > 0 && convertAmount <= remaining) {
+			onConvert?.(convertAmount);
+			convertAmount = 1;
+		}
+	}
+
+	function handleConvertAll() {
+		if (remaining > 0) {
+			onConvert?.(remaining);
+		}
+	}
+</script>
+
+<div class="space-y-4">
+	<!-- VP Status -->
+	<div class="flex items-center justify-between">
+		<div class="flex items-center gap-2">
+			<Trophy class="w-5 h-5 text-amber-500" />
+			<span class="font-medium text-slate-900 dark:text-white">Victory Points</span>
+		</div>
+		<span class="text-sm text-slate-600 dark:text-slate-400">
+			{converted}/{available} converted
+		</span>
+	</div>
+
+	<!-- Progress Bar -->
+	<div class="w-full bg-slate-200 dark:bg-slate-700 rounded-full h-3">
+		<div
+			class="bg-amber-500 h-3 rounded-full transition-all"
+			style="width: {percent}%"
+			role="progressbar"
+			aria-label="Victory points converted"
+			aria-valuenow={converted}
+			aria-valuemin={0}
+			aria-valuemax={available}
+		></div>
+	</div>
+
+	<!-- Remaining -->
+	<p class="text-sm text-slate-600 dark:text-slate-400">
+		{remaining} VP remaining to convert
+	</p>
+
+	<!-- Conversion Controls -->
+	{#if remaining > 0 && onConvert}
+		<div class="flex gap-2 items-end">
+			<div class="flex-1">
+				<label for="convert-amount" class="block text-xs text-slate-600 dark:text-slate-400 mb-1">
+					Amount to convert
+				</label>
+				<input
+					id="convert-amount"
+					type="number"
+					min="1"
+					max={remaining}
+					bind:value={convertAmount}
+					class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+				/>
+			</div>
+			<button
+				type="button"
+				onclick={handleConvert}
+				disabled={convertAmount <= 0 || convertAmount > remaining}
+				class="rounded-md bg-amber-600 px-4 py-2 text-sm font-medium text-white hover:bg-amber-700 disabled:opacity-50"
+			>
+				Convert
+			</button>
+			<button
+				type="button"
+				onclick={handleConvertAll}
+				class="rounded-md bg-amber-800 px-4 py-2 text-sm font-medium text-white hover:bg-amber-900"
+			>
+				All
+			</button>
+		</div>
+	{:else if available === 0}
+		<p class="text-sm text-slate-500 dark:text-slate-400 italic">No victory points available.</p>
+	{:else if remaining === 0}
+		<p class="text-sm text-green-600 dark:text-green-400 font-medium">All VP converted!</p>
+	{/if}
+</div>

--- a/src/lib/components/respite/index.ts
+++ b/src/lib/components/respite/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Respite Components - Draw Steel Respite Activity Tracker
+ *
+ * UI components for managing Draw Steel respite sessions.
+ * These components work together to provide a complete respite tracking interface.
+ */
+
+export { default as RespiteSetup } from './RespiteSetup.svelte';
+export { default as HeroRecoveryPanel } from './HeroRecoveryPanel.svelte';
+export { default as RespiteActivityCard } from './RespiteActivityCard.svelte';
+export { default as ActivityControls } from './ActivityControls.svelte';
+export { default as KitSwapTracker } from './KitSwapTracker.svelte';
+export { default as VictoryPointsConverter } from './VictoryPointsConverter.svelte';
+export { default as RespiteRulesReference } from './RespiteRulesReference.svelte';
+export { default as RespiteProgress } from './RespiteProgress.svelte';
+export { default as RespiteAnalytics } from './RespiteAnalytics.svelte';

--- a/src/lib/config/respiteTemplates.test.ts
+++ b/src/lib/config/respiteTemplates.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for Respite Activity Templates
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+	activityTemplates,
+	getTemplatesByType,
+	getTemplateTypes
+} from './respiteTemplates';
+
+describe('Respite Activity Templates', () => {
+	describe('activityTemplates', () => {
+		it('should have templates for all activity types', () => {
+			const types = new Set(activityTemplates.map((t) => t.type));
+			expect(types.has('project')).toBe(true);
+			expect(types.has('crafting')).toBe(true);
+			expect(types.has('socializing')).toBe(true);
+			expect(types.has('training')).toBe(true);
+			expect(types.has('investigation')).toBe(true);
+		});
+
+		it('should have non-empty name and description for all templates', () => {
+			for (const template of activityTemplates) {
+				expect(template.name.length).toBeGreaterThan(0);
+				expect(template.description.length).toBeGreaterThan(0);
+			}
+		});
+
+		it('should have at least 3 templates per type', () => {
+			const countByType: Record<string, number> = {};
+			for (const t of activityTemplates) {
+				countByType[t.type] = (countByType[t.type] || 0) + 1;
+			}
+			for (const count of Object.values(countByType)) {
+				expect(count).toBeGreaterThanOrEqual(3);
+			}
+		});
+	});
+
+	describe('getTemplatesByType', () => {
+		it('should return only templates matching the type', () => {
+			const craftingTemplates = getTemplatesByType('crafting');
+			expect(craftingTemplates.length).toBeGreaterThan(0);
+			for (const t of craftingTemplates) {
+				expect(t.type).toBe('crafting');
+			}
+		});
+
+		it('should return empty array for type with no templates', () => {
+			const otherTemplates = getTemplatesByType('other');
+			expect(otherTemplates).toEqual([]);
+		});
+	});
+
+	describe('getTemplateTypes', () => {
+		it('should return unique types', () => {
+			const types = getTemplateTypes();
+			expect(new Set(types).size).toBe(types.length);
+		});
+
+		it('should include all types that have templates', () => {
+			const types = getTemplateTypes();
+			expect(types).toContain('project');
+			expect(types).toContain('crafting');
+			expect(types).toContain('socializing');
+			expect(types).toContain('training');
+			expect(types).toContain('investigation');
+		});
+	});
+});

--- a/src/lib/config/respiteTemplates.ts
+++ b/src/lib/config/respiteTemplates.ts
@@ -1,0 +1,119 @@
+/**
+ * Respite Activity Templates
+ *
+ * Predefined activity templates for common Draw Steel respite activities.
+ * These templates provide quick-select options to speed up activity creation.
+ */
+
+import type { RespiteActivityType } from '$lib/types/respite';
+
+export interface ActivityTemplate {
+	name: string;
+	description: string;
+	type: RespiteActivityType;
+}
+
+/**
+ * Predefined activity templates organized by type.
+ */
+export const activityTemplates: ActivityTemplate[] = [
+	// Project activities
+	{
+		name: 'Build Fortifications',
+		description: 'Strengthen the defenses of a location',
+		type: 'project'
+	},
+	{
+		name: 'Establish Safe House',
+		description: 'Set up a hidden base of operations',
+		type: 'project'
+	},
+	{
+		name: 'Plan Next Mission',
+		description: 'Strategize and prepare for the next adventure',
+		type: 'project'
+	},
+
+	// Crafting activities
+	{
+		name: 'Brew Potions',
+		description: 'Create healing or utility potions',
+		type: 'crafting'
+	},
+	{
+		name: 'Repair Equipment',
+		description: 'Fix damaged weapons, armor, or gear',
+		type: 'crafting'
+	},
+	{
+		name: 'Enchant Item',
+		description: 'Imbue an item with magical properties',
+		type: 'crafting'
+	},
+
+	// Socializing activities
+	{
+		name: 'Visit the Tavern',
+		description: 'Relax and socialize with locals',
+		type: 'socializing'
+	},
+	{
+		name: 'Meet with Contact',
+		description: 'Connect with an NPC ally or informant',
+		type: 'socializing'
+	},
+	{
+		name: 'Attend Local Event',
+		description: 'Participate in a festival, market, or gathering',
+		type: 'socializing'
+	},
+
+	// Training activities
+	{
+		name: 'Practice Combat Techniques',
+		description: 'Hone fighting skills through sparring or drills',
+		type: 'training'
+	},
+	{
+		name: 'Study Spellcraft',
+		description: 'Deepen understanding of magical arts',
+		type: 'training'
+	},
+	{
+		name: 'Physical Conditioning',
+		description: 'Build strength and endurance',
+		type: 'training'
+	},
+
+	// Investigation activities
+	{
+		name: 'Research in Library',
+		description: 'Study ancient texts and historical records',
+		type: 'investigation'
+	},
+	{
+		name: 'Gather Intelligence',
+		description: 'Collect information about enemies or objectives',
+		type: 'investigation'
+	},
+	{
+		name: 'Decode Mystery',
+		description: 'Work on solving a puzzle or deciphering clues',
+		type: 'investigation'
+	}
+];
+
+/**
+ * Get templates filtered by activity type.
+ */
+export function getTemplatesByType(type: RespiteActivityType): ActivityTemplate[] {
+	return activityTemplates.filter((t) => t.type === type);
+}
+
+/**
+ * Get all unique activity types that have templates.
+ */
+export function getTemplateTypes(): RespiteActivityType[] {
+	const types = new Set(activityTemplates.map((t) => t.type));
+	return Array.from(types) as RespiteActivityType[];
+}

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -10,6 +10,7 @@ import type {
 	MontageSession,
 	NegotiationSession
 } from '$lib/types';
+import type { RespiteSession } from '$lib/types/respite';
 import type { CreatureTemplate } from '$lib/types/creature';
 import type { FieldSuggestion } from '$lib/types/ai';
 import { migrateCampaignToEntity } from './migrations/migrateCampaignToEntity';
@@ -32,6 +33,7 @@ class DMAssistantDB extends Dexie {
 	combatSessions!: Table<CombatSession>;
 	montageSessions!: Table<MontageSession>;
 	negotiationSessions!: Table<NegotiationSession>;
+	respiteSessions!: Table<RespiteSession>;
 	creatureTemplates!: Table<CreatureTemplate>;
 	fieldSuggestions!: Table<FieldSuggestion>;
 
@@ -156,6 +158,23 @@ class DMAssistantDB extends Dexie {
 			combatSessions: 'id, status, createdAt, updatedAt',
 			montageSessions: 'id, status, createdAt, updatedAt',
 			negotiationSessions: 'id, status, createdAt, updatedAt',
+			creatureTemplates: 'id, name, threat, *tags, createdAt, updatedAt',
+			fieldSuggestions: 'id, entityId, entityType, status, createdAt'
+		});
+
+		// Version 11: Add respiteSessions table for Draw Steel respite tracking
+		this.version(11).stores({
+			entities: 'id, type, name, *tags, createdAt, updatedAt',
+			campaign: 'id',
+			conversations: 'id, name, updatedAt',
+			chatMessages: 'id, conversationId, timestamp',
+			suggestions: 'id, type, status, createdAt, expiresAt, *affectedEntityIds',
+			appConfig: 'key',
+			relationshipSummaryCache: 'id, sourceId, targetId, relationship, generatedAt',
+			combatSessions: 'id, status, createdAt, updatedAt',
+			montageSessions: 'id, status, createdAt, updatedAt',
+			negotiationSessions: 'id, status, createdAt, updatedAt',
+			respiteSessions: 'id, status, createdAt, updatedAt',
 			creatureTemplates: 'id, name, threat, *tags, createdAt, updatedAt',
 			fieldSuggestions: 'id, entityId, entityType, status, createdAt'
 		});

--- a/src/lib/db/repositories/respiteRepository.test.ts
+++ b/src/lib/db/repositories/respiteRepository.test.ts
@@ -1,0 +1,775 @@
+/**
+ * Tests for Respite Repository
+ *
+ * Draw Steel Respite System - TDD RED Phase
+ *
+ * This repository manages respite sessions in IndexedDB, providing functionality
+ * for respite lifecycle, hero management, activity tracking, VP conversion, and kit swaps.
+ *
+ * Testing Strategy:
+ * - Helper functions for transition validation and VP calculation
+ * - CRUD operations for respite sessions
+ * - Respite lifecycle (start, complete)
+ * - Hero management (add, update, remove, duplicate prevention)
+ * - Activity management (record, update, complete)
+ * - VP conversion (math, prevent over-conversion)
+ * - Kit swap recording (hero association, from/to tracking)
+ * - Svelte 5 proxy handling (JSON.parse(JSON.stringify()) before IndexedDB)
+ *
+ * Draw Steel Respite Specifics:
+ * - Respite requires 24+ hours in a safe location
+ * - Heroes regain recoveries during respite
+ * - Victory points can be converted to XP
+ * - Heroes may swap kits during respite
+ * - Various downtime activities can be undertaken
+ */
+
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
+import { respiteRepository } from './respiteRepository';
+import { db } from '../index';
+import type { RespiteSession } from '$lib/types/respite';
+
+describe('RespiteRepository - Helper Functions', () => {
+	describe('isValidTransition', () => {
+		it('should allow preparing -> active', () => {
+			expect(respiteRepository.isValidTransition('preparing', 'active')).toBe(true);
+		});
+
+		it('should allow active -> completed', () => {
+			expect(respiteRepository.isValidTransition('active', 'completed')).toBe(true);
+		});
+
+		it('should not allow preparing -> completed', () => {
+			expect(respiteRepository.isValidTransition('preparing', 'completed')).toBe(false);
+		});
+
+		it('should not allow completed -> active', () => {
+			expect(respiteRepository.isValidTransition('completed', 'active')).toBe(false);
+		});
+
+		it('should not allow completed -> preparing', () => {
+			expect(respiteRepository.isValidTransition('completed', 'preparing')).toBe(false);
+		});
+
+		it('should not allow active -> preparing', () => {
+			expect(respiteRepository.isValidTransition('active', 'preparing')).toBe(false);
+		});
+	});
+
+	describe('calculateRemainingVP', () => {
+		it('should return available minus converted', () => {
+			expect(respiteRepository.calculateRemainingVP(10, 3)).toBe(7);
+		});
+
+		it('should return 0 when all converted', () => {
+			expect(respiteRepository.calculateRemainingVP(5, 5)).toBe(0);
+		});
+
+		it('should return 0 when over-converted (safety)', () => {
+			expect(respiteRepository.calculateRemainingVP(3, 5)).toBe(0);
+		});
+
+		it('should return full amount when none converted', () => {
+			expect(respiteRepository.calculateRemainingVP(10, 0)).toBe(10);
+		});
+	});
+});
+
+describe('RespiteRepository - CRUD Operations', () => {
+	beforeAll(async () => {
+		await db.open();
+	});
+
+	afterAll(async () => {
+		await db.close();
+	});
+
+	beforeEach(async () => {
+		await db.respiteSessions.clear();
+	});
+
+	afterEach(async () => {
+		await db.respiteSessions.clear();
+	});
+
+	describe('create', () => {
+		it('should create a respite session with defaults', async () => {
+			const respite = await respiteRepository.create({
+				name: 'Camp at the Inn'
+			});
+
+			expect(respite.id).toBeDefined();
+			expect(respite.name).toBe('Camp at the Inn');
+			expect(respite.status).toBe('preparing');
+			expect(respite.heroes).toEqual([]);
+			expect(respite.victoryPointsAvailable).toBe(0);
+			expect(respite.victoryPointsConverted).toBe(0);
+			expect(respite.activities).toEqual([]);
+			expect(respite.kitSwaps).toEqual([]);
+			expect(respite.createdAt).toBeInstanceOf(Date);
+			expect(respite.updatedAt).toBeInstanceOf(Date);
+		});
+
+		it('should create a respite session with heroes', async () => {
+			const respite = await respiteRepository.create({
+				name: 'Forest Rest',
+				heroes: [
+					{ name: 'Valora', recoveries: { current: 3, max: 8 } },
+					{ name: 'Kael', recoveries: { current: 5, max: 6 } }
+				],
+				victoryPointsAvailable: 12
+			});
+
+			expect(respite.heroes).toHaveLength(2);
+			expect(respite.heroes[0].name).toBe('Valora');
+			expect(respite.heroes[0].recoveries.current).toBe(3);
+			expect(respite.heroes[0].recoveries.max).toBe(8);
+			expect(respite.heroes[0].recoveries.gained).toBe(0);
+			expect(respite.heroes[1].name).toBe('Kael');
+			expect(respite.victoryPointsAvailable).toBe(12);
+		});
+
+		it('should create with description', async () => {
+			const respite = await respiteRepository.create({
+				name: 'Mountain Camp',
+				description: 'A quiet night in the mountains'
+			});
+
+			expect(respite.description).toBe('A quiet night in the mountains');
+		});
+	});
+
+	describe('getById', () => {
+		it('should return a respite session by ID', async () => {
+			const created = await respiteRepository.create({ name: 'Test Respite' });
+			const fetched = await respiteRepository.getById(created.id);
+
+			expect(fetched).toBeDefined();
+			expect(fetched!.name).toBe('Test Respite');
+		});
+
+		it('should return undefined for non-existent ID', async () => {
+			const result = await respiteRepository.getById('non-existent');
+			expect(result).toBeUndefined();
+		});
+	});
+
+	describe('update', () => {
+		it('should update name', async () => {
+			const created = await respiteRepository.create({ name: 'Old Name' });
+			const updated = await respiteRepository.update(created.id, { name: 'New Name' });
+
+			expect(updated.name).toBe('New Name');
+		});
+
+		it('should update description', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+			const updated = await respiteRepository.update(created.id, {
+				description: 'Updated desc'
+			});
+
+			expect(updated.description).toBe('Updated desc');
+		});
+
+		it('should update victoryPointsAvailable', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+			const updated = await respiteRepository.update(created.id, {
+				victoryPointsAvailable: 15
+			});
+
+			expect(updated.victoryPointsAvailable).toBe(15);
+		});
+
+		it('should throw for non-existent respite', async () => {
+			await expect(
+				respiteRepository.update('non-existent', { name: 'Nope' })
+			).rejects.toThrow('Respite session non-existent not found');
+		});
+
+		it('should update updatedAt timestamp', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+			const originalUpdatedAt = created.updatedAt;
+
+			// Small delay to ensure different timestamp
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			const updated = await respiteRepository.update(created.id, { name: 'Updated' });
+
+			expect(new Date(updated.updatedAt).getTime()).toBeGreaterThanOrEqual(
+				new Date(originalUpdatedAt).getTime()
+			);
+		});
+	});
+
+	describe('delete', () => {
+		it('should delete a respite session', async () => {
+			const created = await respiteRepository.create({ name: 'To Delete' });
+			await respiteRepository.delete(created.id);
+
+			const result = await respiteRepository.getById(created.id);
+			expect(result).toBeUndefined();
+		});
+	});
+});
+
+describe('RespiteRepository - Lifecycle Operations', () => {
+	beforeAll(async () => {
+		await db.open();
+	});
+
+	afterAll(async () => {
+		await db.close();
+	});
+
+	beforeEach(async () => {
+		await db.respiteSessions.clear();
+	});
+
+	afterEach(async () => {
+		await db.respiteSessions.clear();
+	});
+
+	describe('startRespite', () => {
+		it('should transition preparing -> active', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+			const started = await respiteRepository.startRespite(created.id);
+
+			expect(started.status).toBe('active');
+		});
+
+		it('should throw if already active', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+			await respiteRepository.startRespite(created.id);
+
+			await expect(respiteRepository.startRespite(created.id)).rejects.toThrow(
+				'Respite is already active'
+			);
+		});
+
+		it('should throw if completed', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+			await respiteRepository.startRespite(created.id);
+			await respiteRepository.completeRespite(created.id);
+
+			await expect(respiteRepository.startRespite(created.id)).rejects.toThrow(
+				'Cannot start a completed respite'
+			);
+		});
+
+		it('should throw for non-existent respite', async () => {
+			await expect(respiteRepository.startRespite('non-existent')).rejects.toThrow(
+				'Respite session non-existent not found'
+			);
+		});
+	});
+
+	describe('completeRespite', () => {
+		it('should transition active -> completed', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+			await respiteRepository.startRespite(created.id);
+			const completed = await respiteRepository.completeRespite(created.id);
+
+			expect(completed.status).toBe('completed');
+			expect(completed.completedAt).toBeDefined();
+		});
+
+		it('should throw if not active', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+
+			await expect(respiteRepository.completeRespite(created.id)).rejects.toThrow(
+				'Respite is not active'
+			);
+		});
+
+		it('should throw for non-existent respite', async () => {
+			await expect(respiteRepository.completeRespite('non-existent')).rejects.toThrow(
+				'Respite session non-existent not found'
+			);
+		});
+	});
+});
+
+describe('RespiteRepository - Hero Management', () => {
+	beforeAll(async () => {
+		await db.open();
+	});
+
+	afterAll(async () => {
+		await db.close();
+	});
+
+	beforeEach(async () => {
+		await db.respiteSessions.clear();
+	});
+
+	afterEach(async () => {
+		await db.respiteSessions.clear();
+	});
+
+	describe('addHero', () => {
+		it('should add a hero to the respite', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+			const updated = await respiteRepository.addHero(created.id, {
+				name: 'Valora',
+				recoveries: { current: 3, max: 8 }
+			});
+
+			expect(updated.heroes).toHaveLength(1);
+			expect(updated.heroes[0].name).toBe('Valora');
+			expect(updated.heroes[0].recoveries.gained).toBe(0);
+			expect(updated.heroes[0].id).toBeDefined();
+		});
+
+		it('should prevent duplicate heroes by name (case-insensitive)', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+			await respiteRepository.addHero(created.id, {
+				name: 'Valora',
+				recoveries: { current: 3, max: 8 }
+			});
+
+			await expect(
+				respiteRepository.addHero(created.id, {
+					name: 'valora',
+					recoveries: { current: 5, max: 8 }
+				})
+			).rejects.toThrow('Hero "valora" is already in this respite');
+		});
+
+		it('should add hero with heroId link', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+			const updated = await respiteRepository.addHero(created.id, {
+				name: 'Kael',
+				heroId: 'hero-123',
+				recoveries: { current: 2, max: 6 }
+			});
+
+			expect(updated.heroes[0].heroId).toBe('hero-123');
+		});
+
+		it('should throw for non-existent respite', async () => {
+			await expect(
+				respiteRepository.addHero('non-existent', {
+					name: 'Test',
+					recoveries: { current: 3, max: 8 }
+				})
+			).rejects.toThrow('Respite session non-existent not found');
+		});
+	});
+
+	describe('updateHero', () => {
+		it('should update hero recoveries', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+			const withHero = await respiteRepository.addHero(created.id, {
+				name: 'Valora',
+				recoveries: { current: 3, max: 8 }
+			});
+
+			const updated = await respiteRepository.updateHero(
+				created.id,
+				withHero.heroes[0].id,
+				{ recoveries: { current: 6, max: 8, gained: 3 } }
+			);
+
+			expect(updated.heroes[0].recoveries.current).toBe(6);
+			expect(updated.heroes[0].recoveries.gained).toBe(3);
+		});
+
+		it('should update hero notes', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+			const withHero = await respiteRepository.addHero(created.id, {
+				name: 'Valora',
+				recoveries: { current: 3, max: 8 }
+			});
+
+			const updated = await respiteRepository.updateHero(
+				created.id,
+				withHero.heroes[0].id,
+				{ notes: 'Resting well' }
+			);
+
+			expect(updated.heroes[0].notes).toBe('Resting well');
+		});
+
+		it('should update hero conditions', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+			const withHero = await respiteRepository.addHero(created.id, {
+				name: 'Valora',
+				recoveries: { current: 3, max: 8 }
+			});
+
+			const updated = await respiteRepository.updateHero(
+				created.id,
+				withHero.heroes[0].id,
+				{ conditions: ['exhausted', 'wounded'] }
+			);
+
+			expect(updated.heroes[0].conditions).toEqual(['exhausted', 'wounded']);
+		});
+
+		it('should throw for non-existent hero', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+
+			await expect(
+				respiteRepository.updateHero(created.id, 'non-existent', { notes: 'test' })
+			).rejects.toThrow('Hero non-existent not found in respite');
+		});
+	});
+
+	describe('removeHero', () => {
+		it('should remove a hero from the respite', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+			const withHero = await respiteRepository.addHero(created.id, {
+				name: 'Valora',
+				recoveries: { current: 3, max: 8 }
+			});
+
+			const updated = await respiteRepository.removeHero(
+				created.id,
+				withHero.heroes[0].id
+			);
+
+			expect(updated.heroes).toHaveLength(0);
+		});
+
+		it('should throw for non-existent hero', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+
+			await expect(
+				respiteRepository.removeHero(created.id, 'non-existent')
+			).rejects.toThrow('Hero non-existent not found in respite');
+		});
+	});
+});
+
+describe('RespiteRepository - Activity Management', () => {
+	beforeAll(async () => {
+		await db.open();
+	});
+
+	afterAll(async () => {
+		await db.close();
+	});
+
+	beforeEach(async () => {
+		await db.respiteSessions.clear();
+	});
+
+	afterEach(async () => {
+		await db.respiteSessions.clear();
+	});
+
+	describe('recordActivity', () => {
+		it('should record an activity with defaults', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+			const updated = await respiteRepository.recordActivity(created.id, {
+				name: 'Research ancient texts',
+				type: 'investigation'
+			});
+
+			expect(updated.activities).toHaveLength(1);
+			expect(updated.activities[0].name).toBe('Research ancient texts');
+			expect(updated.activities[0].type).toBe('investigation');
+			expect(updated.activities[0].status).toBe('pending');
+			expect(updated.activities[0].id).toBeDefined();
+			expect(updated.activities[0].createdAt).toBeDefined();
+		});
+
+		it('should record an activity with hero assignment', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+			const withHero = await respiteRepository.addHero(created.id, {
+				name: 'Valora',
+				recoveries: { current: 3, max: 8 }
+			});
+
+			const updated = await respiteRepository.recordActivity(created.id, {
+				name: 'Train with sword',
+				type: 'training',
+				heroId: withHero.heroes[0].id,
+				description: 'Practicing sword forms',
+				notes: 'Focus on parrying'
+			});
+
+			expect(updated.activities[0].heroId).toBe(withHero.heroes[0].id);
+			expect(updated.activities[0].description).toBe('Practicing sword forms');
+			expect(updated.activities[0].notes).toBe('Focus on parrying');
+		});
+
+		it('should add multiple activities', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+			await respiteRepository.recordActivity(created.id, {
+				name: 'Research',
+				type: 'investigation'
+			});
+			const updated = await respiteRepository.recordActivity(created.id, {
+				name: 'Crafting',
+				type: 'crafting'
+			});
+
+			expect(updated.activities).toHaveLength(2);
+		});
+
+		it('should throw for non-existent respite', async () => {
+			await expect(
+				respiteRepository.recordActivity('non-existent', {
+					name: 'Test',
+					type: 'other'
+				})
+			).rejects.toThrow('Respite session non-existent not found');
+		});
+	});
+
+	describe('updateActivity', () => {
+		it('should update activity status', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+			const withActivity = await respiteRepository.recordActivity(created.id, {
+				name: 'Research',
+				type: 'investigation'
+			});
+
+			const updated = await respiteRepository.updateActivity(
+				created.id,
+				withActivity.activities[0].id,
+				{ status: 'in_progress' }
+			);
+
+			expect(updated.activities[0].status).toBe('in_progress');
+		});
+
+		it('should update activity name and notes', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+			const withActivity = await respiteRepository.recordActivity(created.id, {
+				name: 'Research',
+				type: 'investigation'
+			});
+
+			const updated = await respiteRepository.updateActivity(
+				created.id,
+				withActivity.activities[0].id,
+				{ name: 'Deep Research', notes: 'Found something' }
+			);
+
+			expect(updated.activities[0].name).toBe('Deep Research');
+			expect(updated.activities[0].notes).toBe('Found something');
+		});
+
+		it('should throw for non-existent activity', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+
+			await expect(
+				respiteRepository.updateActivity(created.id, 'non-existent', {
+					status: 'completed'
+				})
+			).rejects.toThrow('Activity non-existent not found in respite');
+		});
+	});
+
+	describe('completeActivity', () => {
+		it('should complete an activity with outcome', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+			const withActivity = await respiteRepository.recordActivity(created.id, {
+				name: 'Research',
+				type: 'investigation'
+			});
+
+			const updated = await respiteRepository.completeActivity(
+				created.id,
+				withActivity.activities[0].id,
+				'Discovered a hidden map'
+			);
+
+			expect(updated.activities[0].status).toBe('completed');
+			expect(updated.activities[0].outcome).toBe('Discovered a hidden map');
+		});
+
+		it('should complete an activity without outcome', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+			const withActivity = await respiteRepository.recordActivity(created.id, {
+				name: 'Socializing',
+				type: 'socializing'
+			});
+
+			const updated = await respiteRepository.completeActivity(
+				created.id,
+				withActivity.activities[0].id
+			);
+
+			expect(updated.activities[0].status).toBe('completed');
+			expect(updated.activities[0].outcome).toBeUndefined();
+		});
+	});
+});
+
+describe('RespiteRepository - VP Conversion', () => {
+	beforeAll(async () => {
+		await db.open();
+	});
+
+	afterAll(async () => {
+		await db.close();
+	});
+
+	beforeEach(async () => {
+		await db.respiteSessions.clear();
+	});
+
+	afterEach(async () => {
+		await db.respiteSessions.clear();
+	});
+
+	describe('convertVictoryPoints', () => {
+		it('should convert VP successfully', async () => {
+			const created = await respiteRepository.create({
+				name: 'Test',
+				victoryPointsAvailable: 10
+			});
+
+			const updated = await respiteRepository.convertVictoryPoints(created.id, 5);
+
+			expect(updated.victoryPointsConverted).toBe(5);
+		});
+
+		it('should convert VP incrementally', async () => {
+			const created = await respiteRepository.create({
+				name: 'Test',
+				victoryPointsAvailable: 10
+			});
+
+			await respiteRepository.convertVictoryPoints(created.id, 3);
+			const updated = await respiteRepository.convertVictoryPoints(created.id, 4);
+
+			expect(updated.victoryPointsConverted).toBe(7);
+		});
+
+		it('should prevent over-conversion', async () => {
+			const created = await respiteRepository.create({
+				name: 'Test',
+				victoryPointsAvailable: 5
+			});
+
+			await expect(
+				respiteRepository.convertVictoryPoints(created.id, 6)
+			).rejects.toThrow('Cannot convert 6 VP: only 5 VP remaining');
+		});
+
+		it('should prevent conversion of zero or negative amount', async () => {
+			const created = await respiteRepository.create({
+				name: 'Test',
+				victoryPointsAvailable: 5
+			});
+
+			await expect(
+				respiteRepository.convertVictoryPoints(created.id, 0)
+			).rejects.toThrow('Conversion amount must be positive');
+		});
+
+		it('should allow converting exact remaining amount', async () => {
+			const created = await respiteRepository.create({
+				name: 'Test',
+				victoryPointsAvailable: 5
+			});
+
+			await respiteRepository.convertVictoryPoints(created.id, 3);
+			const updated = await respiteRepository.convertVictoryPoints(created.id, 2);
+
+			expect(updated.victoryPointsConverted).toBe(5);
+		});
+
+		it('should throw for non-existent respite', async () => {
+			await expect(
+				respiteRepository.convertVictoryPoints('non-existent', 5)
+			).rejects.toThrow('Respite session non-existent not found');
+		});
+	});
+});
+
+describe('RespiteRepository - Kit Swap Recording', () => {
+	beforeAll(async () => {
+		await db.open();
+	});
+
+	afterAll(async () => {
+		await db.close();
+	});
+
+	beforeEach(async () => {
+		await db.respiteSessions.clear();
+	});
+
+	afterEach(async () => {
+		await db.respiteSessions.clear();
+	});
+
+	describe('recordKitSwap', () => {
+		it('should record a kit swap for a hero', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+			const withHero = await respiteRepository.addHero(created.id, {
+				name: 'Valora',
+				recoveries: { current: 3, max: 8 }
+			});
+
+			const updated = await respiteRepository.recordKitSwap(created.id, {
+				heroId: withHero.heroes[0].id,
+				from: 'Shining Armor',
+				to: 'Shadow Cloak',
+				reason: 'Stealth mission ahead'
+			});
+
+			expect(updated.kitSwaps).toHaveLength(1);
+			expect(updated.kitSwaps[0].heroId).toBe(withHero.heroes[0].id);
+			expect(updated.kitSwaps[0].from).toBe('Shining Armor');
+			expect(updated.kitSwaps[0].to).toBe('Shadow Cloak');
+			expect(updated.kitSwaps[0].reason).toBe('Stealth mission ahead');
+			expect(updated.kitSwaps[0].id).toBeDefined();
+			expect(updated.kitSwaps[0].createdAt).toBeDefined();
+		});
+
+		it('should record a kit swap without reason', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+			const withHero = await respiteRepository.addHero(created.id, {
+				name: 'Valora',
+				recoveries: { current: 3, max: 8 }
+			});
+
+			const updated = await respiteRepository.recordKitSwap(created.id, {
+				heroId: withHero.heroes[0].id,
+				from: 'Shining Armor',
+				to: 'Shadow Cloak'
+			});
+
+			expect(updated.kitSwaps[0].reason).toBeUndefined();
+		});
+
+		it('should throw for non-existent hero in respite', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+
+			await expect(
+				respiteRepository.recordKitSwap(created.id, {
+					heroId: 'non-existent',
+					from: 'A',
+					to: 'B'
+				})
+			).rejects.toThrow('Hero non-existent not found in respite');
+		});
+
+		it('should record multiple kit swaps', async () => {
+			const created = await respiteRepository.create({ name: 'Test' });
+			const withHero = await respiteRepository.addHero(created.id, {
+				name: 'Valora',
+				recoveries: { current: 3, max: 8 }
+			});
+
+			await respiteRepository.recordKitSwap(created.id, {
+				heroId: withHero.heroes[0].id,
+				from: 'Shining Armor',
+				to: 'Shadow Cloak'
+			});
+
+			const updated = await respiteRepository.recordKitSwap(created.id, {
+				heroId: withHero.heroes[0].id,
+				from: 'Shadow Cloak',
+				to: 'Battle Plate'
+			});
+
+			expect(updated.kitSwaps).toHaveLength(2);
+		});
+	});
+});

--- a/src/lib/db/repositories/respiteRepository.ts
+++ b/src/lib/db/repositories/respiteRepository.ts
@@ -1,0 +1,523 @@
+/**
+ * Respite Repository
+ *
+ * Manages respite sessions in IndexedDB for Draw Steel RPG respite tracking.
+ *
+ * Features:
+ * - Respite lifecycle (preparing, active, completed)
+ * - Hero management (add, update, remove heroes)
+ * - Activity recording and tracking
+ * - Victory point to XP conversion
+ * - Kit swap recording
+ * - Recovery tracking per hero
+ */
+
+import { db, ensureDbReady } from '../index';
+import { liveQuery, type Observable } from 'dexie';
+import { nanoid } from 'nanoid';
+import type {
+	RespiteSession,
+	RespiteHero,
+	RespiteActivity,
+	KitSwap,
+	CreateRespiteInput,
+	UpdateRespiteInput,
+	RecordActivityInput,
+	RespiteActivityStatus
+} from '$lib/types/respite';
+import { createFromRespite } from '$lib/services/narrativeEventService';
+
+// ============================================================================
+// Helper Functions (Exported for Testing)
+// ============================================================================
+
+/**
+ * Validate a status transition for respite lifecycle.
+ *
+ * Valid transitions:
+ * - preparing -> active
+ * - active -> completed
+ */
+export function isValidTransition(
+	from: RespiteSession['status'],
+	to: RespiteSession['status']
+): boolean {
+	if (from === 'preparing' && to === 'active') return true;
+	if (from === 'active' && to === 'completed') return true;
+	return false;
+}
+
+/**
+ * Calculate remaining VP available for conversion.
+ */
+export function calculateRemainingVP(available: number, converted: number): number {
+	return Math.max(0, available - converted);
+}
+
+// ============================================================================
+// Respite Repository
+// ============================================================================
+
+export const respiteRepository = {
+	// Export helper functions for testing
+	isValidTransition,
+	calculateRemainingVP,
+
+	// ========================================================================
+	// CRUD Operations
+	// ========================================================================
+
+	/**
+	 * Get all respite sessions as a live query (reactive).
+	 */
+	getAll(): Observable<RespiteSession[]> {
+		return liveQuery(() => db.respiteSessions.toArray());
+	},
+
+	/**
+	 * Get single respite session by ID.
+	 */
+	async getById(id: string): Promise<RespiteSession | undefined> {
+		await ensureDbReady();
+		return db.respiteSessions.get(id);
+	},
+
+	/**
+	 * Create a new respite session.
+	 * Defaults: status='preparing', victoryPointsConverted=0
+	 */
+	async create(input: CreateRespiteInput): Promise<RespiteSession> {
+		await ensureDbReady();
+
+		const now = new Date();
+
+		// Initialize heroes with gained=0
+		const heroes: RespiteHero[] = (input.heroes || []).map((h) => ({
+			id: nanoid(),
+			name: h.name,
+			heroId: h.heroId,
+			recoveries: {
+				current: h.recoveries.current,
+				max: h.recoveries.max,
+				gained: 0
+			}
+		}));
+
+		const respite: RespiteSession = {
+			id: nanoid(),
+			name: input.name,
+			description: input.description,
+			status: 'preparing',
+			heroes,
+			victoryPointsAvailable: input.victoryPointsAvailable ?? 0,
+			victoryPointsConverted: 0,
+			activities: [],
+			kitSwaps: [],
+			createdAt: now,
+			updatedAt: now
+		};
+
+		await db.respiteSessions.add(JSON.parse(JSON.stringify(respite)));
+		return respite;
+	},
+
+	/**
+	 * Update respite session fields.
+	 */
+	async update(id: string, input: UpdateRespiteInput): Promise<RespiteSession> {
+		await ensureDbReady();
+
+		const respite = await db.respiteSessions.get(id);
+		if (!respite) {
+			throw new Error(`Respite session ${id} not found`);
+		}
+
+		const updated: RespiteSession = {
+			...respite,
+			...input,
+			updatedAt: new Date()
+		};
+
+		await db.respiteSessions.put(JSON.parse(JSON.stringify(updated)));
+		return updated;
+	},
+
+	/**
+	 * Delete respite session.
+	 */
+	async delete(id: string): Promise<void> {
+		await ensureDbReady();
+		await db.respiteSessions.delete(id);
+	},
+
+	/**
+	 * Get respite sessions by campaign ID.
+	 */
+	async getByCampaignId(campaignId: string): Promise<RespiteSession[]> {
+		await ensureDbReady();
+		const all = await db.respiteSessions.toArray();
+		return all.filter((r) => r.campaignId === campaignId);
+	},
+
+	/**
+	 * Get respite sessions that include a specific character.
+	 */
+	async getByCharacterId(characterId: string): Promise<RespiteSession[]> {
+		await ensureDbReady();
+		const all = await db.respiteSessions.toArray();
+		return all.filter(
+			(r) => r.characterIds && r.characterIds.includes(characterId)
+		);
+	},
+
+	// ========================================================================
+	// Lifecycle Operations
+	// ========================================================================
+
+	/**
+	 * Start respite (preparing -> active).
+	 */
+	async startRespite(id: string): Promise<RespiteSession> {
+		await ensureDbReady();
+
+		const respite = await db.respiteSessions.get(id);
+		if (!respite) {
+			throw new Error(`Respite session ${id} not found`);
+		}
+
+		if (respite.status === 'active') {
+			throw new Error('Respite is already active');
+		}
+
+		if (respite.status === 'completed') {
+			throw new Error('Cannot start a completed respite');
+		}
+
+		const updated: RespiteSession = {
+			...respite,
+			status: 'active',
+			updatedAt: new Date()
+		};
+
+		await db.respiteSessions.put(JSON.parse(JSON.stringify(updated)));
+		return updated;
+	},
+
+	/**
+	 * Complete respite (active -> completed).
+	 * Creates narrative event (wrapped in try/catch to prevent blocking completion).
+	 */
+	async completeRespite(id: string): Promise<RespiteSession> {
+		await ensureDbReady();
+
+		const respite = await db.respiteSessions.get(id);
+		if (!respite) {
+			throw new Error(`Respite session ${id} not found`);
+		}
+
+		if (respite.status !== 'active') {
+			throw new Error('Respite is not active');
+		}
+
+		const updated: RespiteSession = {
+			...respite,
+			status: 'completed',
+			completedAt: new Date(),
+			updatedAt: new Date()
+		};
+
+		await db.respiteSessions.put(JSON.parse(JSON.stringify(updated)));
+
+		// Create narrative event (non-blocking)
+		try {
+			await createFromRespite(updated);
+		} catch (error) {
+			console.error('Failed to create narrative event for respite:', error);
+		}
+
+		return updated;
+	},
+
+	// ========================================================================
+	// Hero Management
+	// ========================================================================
+
+	/**
+	 * Add a hero to the respite session.
+	 * Prevents duplicate heroes by name.
+	 */
+	async addHero(
+		id: string,
+		hero: { name: string; heroId?: string; recoveries: { current: number; max: number } }
+	): Promise<RespiteSession> {
+		await ensureDbReady();
+
+		const respite = await db.respiteSessions.get(id);
+		if (!respite) {
+			throw new Error(`Respite session ${id} not found`);
+		}
+
+		// Check for duplicate hero by name
+		const existing = respite.heroes.find(
+			(h) => h.name.toLowerCase() === hero.name.toLowerCase()
+		);
+		if (existing) {
+			throw new Error(`Hero "${hero.name}" is already in this respite`);
+		}
+
+		const newHero: RespiteHero = {
+			id: nanoid(),
+			name: hero.name,
+			heroId: hero.heroId,
+			recoveries: {
+				current: hero.recoveries.current,
+				max: hero.recoveries.max,
+				gained: 0
+			}
+		};
+
+		const updated: RespiteSession = {
+			...respite,
+			heroes: [...respite.heroes, newHero],
+			updatedAt: new Date()
+		};
+
+		await db.respiteSessions.put(JSON.parse(JSON.stringify(updated)));
+		return updated;
+	},
+
+	/**
+	 * Update a hero's data in the respite session.
+	 */
+	async updateHero(
+		id: string,
+		heroId: string,
+		updates: Partial<Pick<RespiteHero, 'name' | 'recoveries' | 'conditions' | 'notes'>>
+	): Promise<RespiteSession> {
+		await ensureDbReady();
+
+		const respite = await db.respiteSessions.get(id);
+		if (!respite) {
+			throw new Error(`Respite session ${id} not found`);
+		}
+
+		const heroIndex = respite.heroes.findIndex((h) => h.id === heroId);
+		if (heroIndex === -1) {
+			throw new Error(`Hero ${heroId} not found in respite`);
+		}
+
+		const heroes = [...respite.heroes];
+		heroes[heroIndex] = {
+			...heroes[heroIndex],
+			...updates,
+			recoveries: updates.recoveries
+				? { ...heroes[heroIndex].recoveries, ...updates.recoveries }
+				: heroes[heroIndex].recoveries
+		};
+
+		const updated: RespiteSession = {
+			...respite,
+			heroes,
+			updatedAt: new Date()
+		};
+
+		await db.respiteSessions.put(JSON.parse(JSON.stringify(updated)));
+		return updated;
+	},
+
+	/**
+	 * Remove a hero from the respite session.
+	 */
+	async removeHero(id: string, heroId: string): Promise<RespiteSession> {
+		await ensureDbReady();
+
+		const respite = await db.respiteSessions.get(id);
+		if (!respite) {
+			throw new Error(`Respite session ${id} not found`);
+		}
+
+		const heroIndex = respite.heroes.findIndex((h) => h.id === heroId);
+		if (heroIndex === -1) {
+			throw new Error(`Hero ${heroId} not found in respite`);
+		}
+
+		const updated: RespiteSession = {
+			...respite,
+			heroes: respite.heroes.filter((h) => h.id !== heroId),
+			updatedAt: new Date()
+		};
+
+		await db.respiteSessions.put(JSON.parse(JSON.stringify(updated)));
+		return updated;
+	},
+
+	// ========================================================================
+	// Activity Management
+	// ========================================================================
+
+	/**
+	 * Record an activity in the respite.
+	 */
+	async recordActivity(id: string, input: RecordActivityInput): Promise<RespiteSession> {
+		await ensureDbReady();
+
+		const respite = await db.respiteSessions.get(id);
+		if (!respite) {
+			throw new Error(`Respite session ${id} not found`);
+		}
+
+		const activity: RespiteActivity = {
+			id: nanoid(),
+			name: input.name,
+			description: input.description,
+			type: input.type,
+			heroId: input.heroId,
+			status: 'pending',
+			notes: input.notes,
+			createdAt: new Date()
+		};
+
+		const updated: RespiteSession = {
+			...respite,
+			activities: [...respite.activities, activity],
+			updatedAt: new Date()
+		};
+
+		await db.respiteSessions.put(JSON.parse(JSON.stringify(updated)));
+		return updated;
+	},
+
+	/**
+	 * Update an activity's status and outcome.
+	 */
+	async updateActivity(
+		id: string,
+		activityId: string,
+		updates: Partial<Pick<RespiteActivity, 'name' | 'description' | 'status' | 'outcome' | 'notes'>>
+	): Promise<RespiteSession> {
+		await ensureDbReady();
+
+		const respite = await db.respiteSessions.get(id);
+		if (!respite) {
+			throw new Error(`Respite session ${id} not found`);
+		}
+
+		const activityIndex = respite.activities.findIndex((a) => a.id === activityId);
+		if (activityIndex === -1) {
+			throw new Error(`Activity ${activityId} not found in respite`);
+		}
+
+		const activities = [...respite.activities];
+		activities[activityIndex] = {
+			...activities[activityIndex],
+			...updates
+		};
+
+		const updated: RespiteSession = {
+			...respite,
+			activities,
+			updatedAt: new Date()
+		};
+
+		await db.respiteSessions.put(JSON.parse(JSON.stringify(updated)));
+		return updated;
+	},
+
+	/**
+	 * Complete an activity with an outcome.
+	 */
+	async completeActivity(
+		id: string,
+		activityId: string,
+		outcome?: string
+	): Promise<RespiteSession> {
+		return this.updateActivity(id, activityId, {
+			status: 'completed' as RespiteActivityStatus,
+			outcome
+		});
+	},
+
+	// ========================================================================
+	// Victory Point Conversion
+	// ========================================================================
+
+	/**
+	 * Convert victory points to XP.
+	 * Prevents over-conversion (cannot convert more than available).
+	 */
+	async convertVictoryPoints(id: string, amount: number): Promise<RespiteSession> {
+		await ensureDbReady();
+
+		const respite = await db.respiteSessions.get(id);
+		if (!respite) {
+			throw new Error(`Respite session ${id} not found`);
+		}
+
+		if (amount <= 0) {
+			throw new Error('Conversion amount must be positive');
+		}
+
+		const remaining = calculateRemainingVP(
+			respite.victoryPointsAvailable,
+			respite.victoryPointsConverted
+		);
+
+		if (amount > remaining) {
+			throw new Error(
+				`Cannot convert ${amount} VP: only ${remaining} VP remaining`
+			);
+		}
+
+		const updated: RespiteSession = {
+			...respite,
+			victoryPointsConverted: respite.victoryPointsConverted + amount,
+			updatedAt: new Date()
+		};
+
+		await db.respiteSessions.put(JSON.parse(JSON.stringify(updated)));
+		return updated;
+	},
+
+	// ========================================================================
+	// Kit Swap Recording
+	// ========================================================================
+
+	/**
+	 * Record a kit swap for a hero.
+	 */
+	async recordKitSwap(
+		id: string,
+		swap: { heroId: string; from: string; to: string; reason?: string }
+	): Promise<RespiteSession> {
+		await ensureDbReady();
+
+		const respite = await db.respiteSessions.get(id);
+		if (!respite) {
+			throw new Error(`Respite session ${id} not found`);
+		}
+
+		// Validate hero exists in the respite
+		const hero = respite.heroes.find((h) => h.id === swap.heroId);
+		if (!hero) {
+			throw new Error(`Hero ${swap.heroId} not found in respite`);
+		}
+
+		const kitSwap: KitSwap = {
+			id: nanoid(),
+			heroId: swap.heroId,
+			from: swap.from,
+			to: swap.to,
+			reason: swap.reason,
+			createdAt: new Date()
+		};
+
+		const updated: RespiteSession = {
+			...respite,
+			kitSwaps: [...respite.kitSwaps, kitSwap],
+			updatedAt: new Date()
+		};
+
+		await db.respiteSessions.put(JSON.parse(JSON.stringify(updated)));
+		return updated;
+	}
+};

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -9,3 +9,4 @@ export { uiStore } from './ui.svelte';
 export { combatStore } from './combat.svelte';
 export { montageStore } from './montage.svelte';
 export { negotiationStore } from './negotiation.svelte';
+export { respiteStore } from './respite.svelte';

--- a/src/lib/stores/respite.svelte.test.ts
+++ b/src/lib/stores/respite.svelte.test.ts
@@ -1,0 +1,598 @@
+/**
+ * Tests for Respite Store (Svelte 5 Runes)
+ *
+ * TDD RED PHASE - These tests define the expected behavior of the respite store.
+ *
+ * The store manages reactive state for Draw Steel respite sessions including:
+ * - Reactive respite list with live queries
+ * - Active respite selection
+ * - Derived values (filtered lists, hero stats, VP stats, activity stats)
+ * - All repository operations wrapped with reactive state updates
+ * - Loading and error state management
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type {
+	RespiteSession,
+	CreateRespiteInput,
+	UpdateRespiteInput,
+	RecordActivityInput,
+	RespiteHero,
+	RespiteActivity
+} from '$lib/types/respite';
+
+/**
+ * Helper function to create mock respite sessions for testing.
+ */
+function createMockRespite(overrides?: Partial<RespiteSession>): RespiteSession {
+	const now = new Date();
+	return {
+		id: 'respite-' + Math.random(),
+		name: 'Test Respite',
+		description: 'Test description',
+		status: 'preparing',
+		heroes: [
+			{
+				id: 'hero-1',
+				name: 'Valora',
+				recoveries: { current: 3, max: 8, gained: 0 }
+			},
+			{
+				id: 'hero-2',
+				name: 'Kael',
+				recoveries: { current: 6, max: 6, gained: 0 }
+			}
+		],
+		victoryPointsAvailable: 10,
+		victoryPointsConverted: 0,
+		activities: [],
+		kitSwaps: [],
+		createdAt: now,
+		updatedAt: now,
+		...overrides
+	};
+}
+
+// ============================================================================
+// Mock the respite repository
+// ============================================================================
+
+const mockGetAll = vi.fn(() => ({
+	subscribe: vi.fn((observer: any) => {
+		observer.next([]);
+		return {
+			unsubscribe: vi.fn()
+		};
+	})
+}));
+
+const mockCreate = vi.fn();
+const mockGetById = vi.fn();
+const mockUpdate = vi.fn();
+const mockDelete = vi.fn();
+const mockStartRespite = vi.fn();
+const mockCompleteRespite = vi.fn();
+const mockAddHero = vi.fn();
+const mockUpdateHero = vi.fn();
+const mockRemoveHero = vi.fn();
+const mockRecordActivity = vi.fn();
+const mockUpdateActivity = vi.fn();
+const mockCompleteActivity = vi.fn();
+const mockConvertVictoryPoints = vi.fn();
+const mockRecordKitSwap = vi.fn();
+
+vi.mock('$lib/db/repositories/respiteRepository', () => ({
+	respiteRepository: {
+		getAll: mockGetAll,
+		create: mockCreate,
+		getById: mockGetById,
+		update: mockUpdate,
+		delete: mockDelete,
+		startRespite: mockStartRespite,
+		completeRespite: mockCompleteRespite,
+		addHero: mockAddHero,
+		updateHero: mockUpdateHero,
+		removeHero: mockRemoveHero,
+		recordActivity: mockRecordActivity,
+		updateActivity: mockUpdateActivity,
+		completeActivity: mockCompleteActivity,
+		convertVictoryPoints: mockConvertVictoryPoints,
+		recordKitSwap: mockRecordKitSwap
+	}
+}));
+
+// ============================================================================
+// Test Suite
+// ============================================================================
+
+describe('Respite Store - Initial State and Reactivity', () => {
+	let respiteStore: any;
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		vi.resetModules();
+		const module = await import('./respite.svelte');
+		respiteStore = module.respiteStore;
+	});
+
+	it('should have empty initial state', () => {
+		expect(respiteStore.respites).toEqual([]);
+		expect(respiteStore.activeRespite).toBeNull();
+		expect(respiteStore.isLoading).toBe(false);
+		expect(respiteStore.error).toBeNull();
+	});
+
+	it('should have empty derived values initially', () => {
+		expect(respiteStore.activeRespites).toEqual([]);
+		expect(respiteStore.preparingRespites).toEqual([]);
+		expect(respiteStore.completedRespites).toEqual([]);
+		expect(respiteStore.heroCount).toBe(0);
+		expect(respiteStore.fullyRestedHeroes).toEqual([]);
+		expect(respiteStore.vpRemaining).toBe(0);
+		expect(respiteStore.vpConversionPercent).toBe(0);
+		expect(respiteStore.pendingActivities).toEqual([]);
+		expect(respiteStore.inProgressActivities).toEqual([]);
+		expect(respiteStore.completedActivities).toEqual([]);
+		expect(respiteStore.kitSwapHistory).toEqual([]);
+	});
+});
+
+describe('Respite Store - CRUD Operations', () => {
+	let respiteStore: any;
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		vi.resetModules();
+		const module = await import('./respite.svelte');
+		respiteStore = module.respiteStore;
+	});
+
+	describe('createRespite', () => {
+		it('should call repository create and return result', async () => {
+			const mockResult = createMockRespite({ name: 'New Respite' });
+			mockCreate.mockResolvedValue(mockResult);
+
+			const result = await respiteStore.createRespite({ name: 'New Respite' });
+
+			expect(mockCreate).toHaveBeenCalledWith({ name: 'New Respite' });
+			expect(result.name).toBe('New Respite');
+		});
+
+		it('should set error on failure', async () => {
+			mockCreate.mockRejectedValue(new Error('Create failed'));
+
+			await expect(respiteStore.createRespite({ name: 'Test' })).rejects.toThrow(
+				'Create failed'
+			);
+			expect(respiteStore.error).toBe('Create failed');
+		});
+	});
+
+	describe('selectRespite', () => {
+		it('should set active respite from repository', async () => {
+			const mockResult = createMockRespite({ id: 'test-id' });
+			mockGetById.mockResolvedValue(mockResult);
+
+			await respiteStore.selectRespite('test-id');
+
+			expect(respiteStore.activeRespite).toBeDefined();
+			expect(respiteStore.activeRespite.id).toBe('test-id');
+		});
+
+		it('should set active respite to null for missing ID', async () => {
+			mockGetById.mockResolvedValue(undefined);
+
+			await respiteStore.selectRespite('missing');
+
+			expect(respiteStore.activeRespite).toBeNull();
+		});
+	});
+
+	describe('updateRespite', () => {
+		it('should call repository update', async () => {
+			const mockResult = createMockRespite({ name: 'Updated' });
+			mockUpdate.mockResolvedValue(mockResult);
+
+			await respiteStore.updateRespite('test-id', { name: 'Updated' });
+
+			expect(mockUpdate).toHaveBeenCalledWith('test-id', { name: 'Updated' });
+		});
+
+		it('should update active respite if matching', async () => {
+			const initial = createMockRespite({ id: 'test-id', name: 'Original' });
+			mockGetById.mockResolvedValue(initial);
+			await respiteStore.selectRespite('test-id');
+
+			const updated = { ...initial, name: 'Updated' };
+			mockUpdate.mockResolvedValue(updated);
+			await respiteStore.updateRespite('test-id', { name: 'Updated' });
+
+			expect(respiteStore.activeRespite.name).toBe('Updated');
+		});
+	});
+
+	describe('deleteRespite', () => {
+		it('should call repository delete', async () => {
+			mockDelete.mockResolvedValue(undefined);
+
+			await respiteStore.deleteRespite('test-id');
+
+			expect(mockDelete).toHaveBeenCalledWith('test-id');
+		});
+
+		it('should clear active respite if matching', async () => {
+			const mock = createMockRespite({ id: 'test-id' });
+			mockGetById.mockResolvedValue(mock);
+			await respiteStore.selectRespite('test-id');
+
+			mockDelete.mockResolvedValue(undefined);
+			await respiteStore.deleteRespite('test-id');
+
+			expect(respiteStore.activeRespite).toBeNull();
+		});
+	});
+});
+
+describe('Respite Store - Lifecycle Operations', () => {
+	let respiteStore: any;
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		vi.resetModules();
+		const module = await import('./respite.svelte');
+		respiteStore = module.respiteStore;
+	});
+
+	describe('startRespite', () => {
+		it('should call repository startRespite', async () => {
+			const mockResult = createMockRespite({ status: 'active' });
+			mockStartRespite.mockResolvedValue(mockResult);
+
+			const result = await respiteStore.startRespite('test-id');
+
+			expect(mockStartRespite).toHaveBeenCalledWith('test-id');
+			expect(result.status).toBe('active');
+		});
+
+		it('should update active respite if matching', async () => {
+			const initial = createMockRespite({ id: 'test-id', status: 'preparing' });
+			mockGetById.mockResolvedValue(initial);
+			await respiteStore.selectRespite('test-id');
+
+			const started = { ...initial, status: 'active' as const };
+			mockStartRespite.mockResolvedValue(started);
+			await respiteStore.startRespite('test-id');
+
+			expect(respiteStore.activeRespite.status).toBe('active');
+		});
+
+		it('should set error on failure', async () => {
+			mockStartRespite.mockRejectedValue(new Error('Already active'));
+
+			await expect(respiteStore.startRespite('test-id')).rejects.toThrow('Already active');
+			expect(respiteStore.error).toBe('Already active');
+		});
+	});
+
+	describe('completeRespite', () => {
+		it('should call repository completeRespite', async () => {
+			const mockResult = createMockRespite({ status: 'completed' });
+			mockCompleteRespite.mockResolvedValue(mockResult);
+
+			const result = await respiteStore.completeRespite('test-id');
+
+			expect(mockCompleteRespite).toHaveBeenCalledWith('test-id');
+			expect(result.status).toBe('completed');
+		});
+	});
+});
+
+describe('Respite Store - Hero Management', () => {
+	let respiteStore: any;
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		vi.resetModules();
+		const module = await import('./respite.svelte');
+		respiteStore = module.respiteStore;
+	});
+
+	describe('addHero', () => {
+		it('should call repository addHero', async () => {
+			const mockResult = createMockRespite();
+			mockAddHero.mockResolvedValue(mockResult);
+
+			const hero = { name: 'New Hero', recoveries: { current: 3, max: 8 } };
+			await respiteStore.addHero('test-id', hero);
+
+			expect(mockAddHero).toHaveBeenCalledWith('test-id', hero);
+		});
+
+		it('should set error on duplicate hero', async () => {
+			mockAddHero.mockRejectedValue(new Error('Hero "Valora" is already in this respite'));
+
+			await expect(
+				respiteStore.addHero('test-id', {
+					name: 'Valora',
+					recoveries: { current: 3, max: 8 }
+				})
+			).rejects.toThrow('Hero "Valora" is already in this respite');
+			expect(respiteStore.error).toBe('Hero "Valora" is already in this respite');
+		});
+	});
+
+	describe('updateHero', () => {
+		it('should call repository updateHero', async () => {
+			const mockResult = createMockRespite();
+			mockUpdateHero.mockResolvedValue(mockResult);
+
+			await respiteStore.updateHero('test-id', 'hero-1', { notes: 'Resting' });
+
+			expect(mockUpdateHero).toHaveBeenCalledWith('test-id', 'hero-1', { notes: 'Resting' });
+		});
+	});
+
+	describe('removeHero', () => {
+		it('should call repository removeHero', async () => {
+			const mockResult = createMockRespite({ heroes: [] });
+			mockRemoveHero.mockResolvedValue(mockResult);
+
+			await respiteStore.removeHero('test-id', 'hero-1');
+
+			expect(mockRemoveHero).toHaveBeenCalledWith('test-id', 'hero-1');
+		});
+	});
+});
+
+describe('Respite Store - Activity Management', () => {
+	let respiteStore: any;
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		vi.resetModules();
+		const module = await import('./respite.svelte');
+		respiteStore = module.respiteStore;
+	});
+
+	describe('recordActivity', () => {
+		it('should call repository recordActivity', async () => {
+			const mockResult = createMockRespite();
+			mockRecordActivity.mockResolvedValue(mockResult);
+
+			const input: RecordActivityInput = {
+				name: 'Research',
+				type: 'investigation'
+			};
+			await respiteStore.recordActivity('test-id', input);
+
+			expect(mockRecordActivity).toHaveBeenCalledWith('test-id', input);
+		});
+	});
+
+	describe('updateActivity', () => {
+		it('should call repository updateActivity', async () => {
+			const mockResult = createMockRespite();
+			mockUpdateActivity.mockResolvedValue(mockResult);
+
+			await respiteStore.updateActivity('test-id', 'activity-1', {
+				status: 'in_progress'
+			});
+
+			expect(mockUpdateActivity).toHaveBeenCalledWith('test-id', 'activity-1', {
+				status: 'in_progress'
+			});
+		});
+	});
+
+	describe('completeActivity', () => {
+		it('should call repository completeActivity', async () => {
+			const mockResult = createMockRespite();
+			mockCompleteActivity.mockResolvedValue(mockResult);
+
+			await respiteStore.completeActivity('test-id', 'activity-1', 'Found a map');
+
+			expect(mockCompleteActivity).toHaveBeenCalledWith(
+				'test-id',
+				'activity-1',
+				'Found a map'
+			);
+		});
+	});
+});
+
+describe('Respite Store - VP Conversion', () => {
+	let respiteStore: any;
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		vi.resetModules();
+		const module = await import('./respite.svelte');
+		respiteStore = module.respiteStore;
+	});
+
+	describe('convertVictoryPoints', () => {
+		it('should call repository convertVictoryPoints', async () => {
+			const mockResult = createMockRespite({ victoryPointsConverted: 5 });
+			mockConvertVictoryPoints.mockResolvedValue(mockResult);
+
+			await respiteStore.convertVictoryPoints('test-id', 5);
+
+			expect(mockConvertVictoryPoints).toHaveBeenCalledWith('test-id', 5);
+		});
+
+		it('should set error on over-conversion', async () => {
+			mockConvertVictoryPoints.mockRejectedValue(
+				new Error('Cannot convert 20 VP: only 10 VP remaining')
+			);
+
+			await expect(
+				respiteStore.convertVictoryPoints('test-id', 20)
+			).rejects.toThrow('Cannot convert 20 VP: only 10 VP remaining');
+			expect(respiteStore.error).toBe('Cannot convert 20 VP: only 10 VP remaining');
+		});
+	});
+});
+
+describe('Respite Store - Kit Swap', () => {
+	let respiteStore: any;
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		vi.resetModules();
+		const module = await import('./respite.svelte');
+		respiteStore = module.respiteStore;
+	});
+
+	describe('recordKitSwap', () => {
+		it('should call repository recordKitSwap', async () => {
+			const mockResult = createMockRespite();
+			mockRecordKitSwap.mockResolvedValue(mockResult);
+
+			const swap = { heroId: 'hero-1', from: 'Kit A', to: 'Kit B' };
+			await respiteStore.recordKitSwap('test-id', swap);
+
+			expect(mockRecordKitSwap).toHaveBeenCalledWith('test-id', swap);
+		});
+	});
+});
+
+describe('Respite Store - Derived Values with Active Respite', () => {
+	let respiteStore: any;
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		vi.resetModules();
+		const module = await import('./respite.svelte');
+		respiteStore = module.respiteStore;
+	});
+
+	it('should compute heroCount from active respite', async () => {
+		const mock = createMockRespite({
+			id: 'test-id',
+			heroes: [
+				{ id: 'h1', name: 'Hero 1', recoveries: { current: 3, max: 8, gained: 0 } },
+				{ id: 'h2', name: 'Hero 2', recoveries: { current: 5, max: 6, gained: 0 } }
+			]
+		});
+		mockGetById.mockResolvedValue(mock);
+		await respiteStore.selectRespite('test-id');
+
+		expect(respiteStore.heroCount).toBe(2);
+	});
+
+	it('should compute fullyRestedHeroes', async () => {
+		const mock = createMockRespite({
+			id: 'test-id',
+			heroes: [
+				{ id: 'h1', name: 'Hero 1', recoveries: { current: 8, max: 8, gained: 5 } },
+				{ id: 'h2', name: 'Hero 2', recoveries: { current: 3, max: 6, gained: 0 } }
+			]
+		});
+		mockGetById.mockResolvedValue(mock);
+		await respiteStore.selectRespite('test-id');
+
+		expect(respiteStore.fullyRestedHeroes).toHaveLength(1);
+		expect(respiteStore.fullyRestedHeroes[0].name).toBe('Hero 1');
+	});
+
+	it('should compute vpRemaining', async () => {
+		const mock = createMockRespite({
+			id: 'test-id',
+			victoryPointsAvailable: 10,
+			victoryPointsConverted: 3
+		});
+		mockGetById.mockResolvedValue(mock);
+		await respiteStore.selectRespite('test-id');
+
+		expect(respiteStore.vpRemaining).toBe(7);
+	});
+
+	it('should compute vpConversionPercent', async () => {
+		const mock = createMockRespite({
+			id: 'test-id',
+			victoryPointsAvailable: 10,
+			victoryPointsConverted: 5
+		});
+		mockGetById.mockResolvedValue(mock);
+		await respiteStore.selectRespite('test-id');
+
+		expect(respiteStore.vpConversionPercent).toBe(50);
+	});
+
+	it('should compute activities by status', async () => {
+		const mock = createMockRespite({
+			id: 'test-id',
+			activities: [
+				{
+					id: 'a1',
+					name: 'Research',
+					type: 'investigation',
+					status: 'pending',
+					createdAt: new Date()
+				},
+				{
+					id: 'a2',
+					name: 'Training',
+					type: 'training',
+					status: 'in_progress',
+					createdAt: new Date()
+				},
+				{
+					id: 'a3',
+					name: 'Crafting',
+					type: 'crafting',
+					status: 'completed',
+					outcome: 'Made a sword',
+					createdAt: new Date()
+				}
+			]
+		});
+		mockGetById.mockResolvedValue(mock);
+		await respiteStore.selectRespite('test-id');
+
+		expect(respiteStore.pendingActivities).toHaveLength(1);
+		expect(respiteStore.inProgressActivities).toHaveLength(1);
+		expect(respiteStore.completedActivities).toHaveLength(1);
+	});
+
+	it('should compute kitSwapHistory', async () => {
+		const mock = createMockRespite({
+			id: 'test-id',
+			kitSwaps: [
+				{
+					id: 'ks1',
+					heroId: 'hero-1',
+					from: 'Kit A',
+					to: 'Kit B',
+					createdAt: new Date()
+				}
+			]
+		});
+		mockGetById.mockResolvedValue(mock);
+		await respiteStore.selectRespite('test-id');
+
+		expect(respiteStore.kitSwapHistory).toHaveLength(1);
+	});
+});
+
+describe('Respite Store - Error Handling', () => {
+	let respiteStore: any;
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		vi.resetModules();
+		const module = await import('./respite.svelte');
+		respiteStore = module.respiteStore;
+	});
+
+	it('should clear error with clearError()', () => {
+		// Trigger an error first
+		respiteStore.clearError();
+		expect(respiteStore.error).toBeNull();
+	});
+
+	it('should have destroy method for cleanup', () => {
+		expect(typeof respiteStore.destroy).toBe('function');
+		respiteStore.destroy();
+	});
+});

--- a/src/lib/stores/respite.svelte.ts
+++ b/src/lib/stores/respite.svelte.ts
@@ -1,0 +1,534 @@
+/**
+ * Respite Store (Svelte 5 Runes)
+ *
+ * Reactive state management for Draw Steel respite sessions.
+ *
+ * Features:
+ * - Reactive respite list with live queries
+ * - Active respite selection
+ * - Derived values for UI (filtered lists, hero stats, activity stats)
+ * - All repository operations wrapped with reactive state updates
+ * - Loading and error state management
+ */
+
+import { respiteRepository } from '$lib/db/repositories/respiteRepository';
+import type {
+	RespiteSession,
+	CreateRespiteInput,
+	UpdateRespiteInput,
+	RecordActivityInput,
+	RespiteHero,
+	RespiteActivity
+} from '$lib/types/respite';
+
+function createRespiteStore() {
+	// ========================================================================
+	// State
+	// ========================================================================
+
+	let respites = $state<RespiteSession[]>([]);
+	let activeRespite = $state<RespiteSession | null>(null);
+	let isLoading = $state(false);
+	let error = $state<string | null>(null);
+
+	// ========================================================================
+	// Initialize live query subscription
+	// ========================================================================
+
+	let unsubscribe: (() => void) | undefined;
+
+	// Subscribe to all respites
+	const subscription = respiteRepository.getAll().subscribe({
+		next: (data) => {
+			respites = data;
+			isLoading = false;
+		},
+		error: (err) => {
+			console.error('Respite store subscription error:', err);
+			error = err.message;
+			isLoading = false;
+		}
+	});
+
+	unsubscribe = () => subscription.unsubscribe();
+
+	// ========================================================================
+	// Derived Values
+	// ========================================================================
+
+	/**
+	 * Active respites (status: active).
+	 */
+	const activeRespites = $derived.by(() => {
+		return respites.filter((r) => r.status === 'active');
+	});
+
+	/**
+	 * Preparing respites (status: preparing).
+	 */
+	const preparingRespites = $derived.by(() => {
+		return respites.filter((r) => r.status === 'preparing');
+	});
+
+	/**
+	 * Completed respites (status: completed).
+	 */
+	const completedRespites = $derived.by(() => {
+		return respites.filter((r) => r.status === 'completed');
+	});
+
+	/**
+	 * Total heroes in the active respite.
+	 */
+	const heroCount = $derived.by((): number => {
+		if (!activeRespite) return 0;
+		return activeRespite.heroes.length;
+	});
+
+	/**
+	 * Heroes who have gained all recoveries (fully rested).
+	 */
+	const fullyRestedHeroes = $derived.by((): RespiteHero[] => {
+		if (!activeRespite) return [];
+		return activeRespite.heroes.filter(
+			(h) => h.recoveries.current >= h.recoveries.max
+		);
+	});
+
+	/**
+	 * Victory points remaining to convert.
+	 */
+	const vpRemaining = $derived.by((): number => {
+		if (!activeRespite) return 0;
+		return Math.max(
+			0,
+			activeRespite.victoryPointsAvailable - activeRespite.victoryPointsConverted
+		);
+	});
+
+	/**
+	 * VP conversion percentage.
+	 */
+	const vpConversionPercent = $derived.by((): number => {
+		if (!activeRespite || activeRespite.victoryPointsAvailable === 0) return 0;
+		return (activeRespite.victoryPointsConverted / activeRespite.victoryPointsAvailable) * 100;
+	});
+
+	/**
+	 * Activities by status.
+	 */
+	const pendingActivities = $derived.by((): RespiteActivity[] => {
+		if (!activeRespite) return [];
+		return activeRespite.activities.filter((a) => a.status === 'pending');
+	});
+
+	const inProgressActivities = $derived.by((): RespiteActivity[] => {
+		if (!activeRespite) return [];
+		return activeRespite.activities.filter((a) => a.status === 'in_progress');
+	});
+
+	const completedActivities = $derived.by((): RespiteActivity[] => {
+		if (!activeRespite) return [];
+		return activeRespite.activities.filter((a) => a.status === 'completed');
+	});
+
+	/**
+	 * Kit swaps in the active respite.
+	 */
+	const kitSwapHistory = $derived.by(() => {
+		if (!activeRespite) return [];
+		return activeRespite.kitSwaps ?? [];
+	});
+
+	// ========================================================================
+	// Analytics Derived Values
+	// ========================================================================
+
+	/**
+	 * Total VP converted across all completed respites.
+	 */
+	const totalVPConverted = $derived.by((): number => {
+		return respites
+			.filter((r) => r.status === 'completed')
+			.reduce((sum, r) => sum + r.victoryPointsConverted, 0);
+	});
+
+	/**
+	 * Total activities completed across all respites.
+	 */
+	const totalActivitiesCompleted = $derived.by((): number => {
+		return respites.reduce(
+			(sum, r) => sum + r.activities.filter((a) => a.status === 'completed').length,
+			0
+		);
+	});
+
+	/**
+	 * Activity type distribution across all respites.
+	 */
+	const activityTypeDistribution = $derived.by((): Record<string, number> => {
+		const dist: Record<string, number> = {};
+		for (const r of respites) {
+			for (const a of r.activities) {
+				dist[a.type] = (dist[a.type] || 0) + 1;
+			}
+		}
+		return dist;
+	});
+
+	// ========================================================================
+	// Helper Methods
+	// ========================================================================
+
+	/**
+	 * Update active respite if it matches the updated respite ID.
+	 */
+	function updateActiveRespiteIfMatch(updated: RespiteSession) {
+		if (activeRespite && activeRespite.id === updated.id) {
+			activeRespite = updated;
+		}
+	}
+
+	/**
+	 * Clear active respite if it matches the respite ID.
+	 */
+	function clearActiveRespiteIfMatch(respiteId: string) {
+		if (activeRespite && activeRespite.id === respiteId) {
+			activeRespite = null;
+		}
+	}
+
+	// ========================================================================
+	// CRUD Operations
+	// ========================================================================
+
+	async function createRespite(input: CreateRespiteInput): Promise<RespiteSession> {
+		try {
+			error = null;
+			isLoading = true;
+			const respite = await respiteRepository.create(input);
+			return respite;
+		} catch (err: any) {
+			error = err.message;
+			throw err;
+		} finally {
+			isLoading = false;
+		}
+	}
+
+	async function selectRespite(id: string): Promise<void> {
+		try {
+			error = null;
+			isLoading = true;
+			const respite = await respiteRepository.getById(id);
+			activeRespite = respite || null;
+		} catch (err: any) {
+			error = err.message;
+			activeRespite = null;
+		} finally {
+			isLoading = false;
+		}
+	}
+
+	async function updateRespite(
+		id: string,
+		input: UpdateRespiteInput
+	): Promise<RespiteSession> {
+		try {
+			error = null;
+			const updated = await respiteRepository.update(id, input);
+			updateActiveRespiteIfMatch(updated);
+			return updated;
+		} catch (err: any) {
+			error = err.message;
+			throw err;
+		}
+	}
+
+	async function deleteRespite(id: string): Promise<void> {
+		try {
+			error = null;
+			await respiteRepository.delete(id);
+			clearActiveRespiteIfMatch(id);
+		} catch (err: any) {
+			error = err.message;
+			throw err;
+		}
+	}
+
+	// ========================================================================
+	// Lifecycle Operations
+	// ========================================================================
+
+	async function startRespite(id: string): Promise<RespiteSession> {
+		try {
+			error = null;
+			const updated = await respiteRepository.startRespite(id);
+			updateActiveRespiteIfMatch(updated);
+			return updated;
+		} catch (err: any) {
+			error = err.message;
+			throw err;
+		}
+	}
+
+	async function completeRespite(id: string): Promise<RespiteSession> {
+		try {
+			error = null;
+			const updated = await respiteRepository.completeRespite(id);
+			updateActiveRespiteIfMatch(updated);
+			return updated;
+		} catch (err: any) {
+			error = err.message;
+			throw err;
+		}
+	}
+
+	// ========================================================================
+	// Hero Management
+	// ========================================================================
+
+	async function addHero(
+		id: string,
+		hero: { name: string; heroId?: string; recoveries: { current: number; max: number } }
+	): Promise<RespiteSession> {
+		try {
+			error = null;
+			const updated = await respiteRepository.addHero(id, hero);
+			updateActiveRespiteIfMatch(updated);
+			return updated;
+		} catch (err: any) {
+			error = err.message;
+			throw err;
+		}
+	}
+
+	async function updateHero(
+		id: string,
+		heroId: string,
+		updates: Partial<Pick<RespiteHero, 'name' | 'recoveries' | 'conditions' | 'notes'>>
+	): Promise<RespiteSession> {
+		try {
+			error = null;
+			const updated = await respiteRepository.updateHero(id, heroId, updates);
+			updateActiveRespiteIfMatch(updated);
+			return updated;
+		} catch (err: any) {
+			error = err.message;
+			throw err;
+		}
+	}
+
+	async function removeHero(id: string, heroId: string): Promise<RespiteSession> {
+		try {
+			error = null;
+			const updated = await respiteRepository.removeHero(id, heroId);
+			updateActiveRespiteIfMatch(updated);
+			return updated;
+		} catch (err: any) {
+			error = err.message;
+			throw err;
+		}
+	}
+
+	// ========================================================================
+	// Activity Management
+	// ========================================================================
+
+	async function recordActivity(
+		id: string,
+		input: RecordActivityInput
+	): Promise<RespiteSession> {
+		try {
+			error = null;
+			const updated = await respiteRepository.recordActivity(id, input);
+			updateActiveRespiteIfMatch(updated);
+			return updated;
+		} catch (err: any) {
+			error = err.message;
+			throw err;
+		}
+	}
+
+	async function updateActivity(
+		id: string,
+		activityId: string,
+		updates: Partial<Pick<RespiteActivity, 'name' | 'description' | 'status' | 'outcome' | 'notes'>>
+	): Promise<RespiteSession> {
+		try {
+			error = null;
+			const updated = await respiteRepository.updateActivity(id, activityId, updates);
+			updateActiveRespiteIfMatch(updated);
+			return updated;
+		} catch (err: any) {
+			error = err.message;
+			throw err;
+		}
+	}
+
+	async function completeActivity(
+		id: string,
+		activityId: string,
+		outcome?: string
+	): Promise<RespiteSession> {
+		try {
+			error = null;
+			const updated = await respiteRepository.completeActivity(id, activityId, outcome);
+			updateActiveRespiteIfMatch(updated);
+			return updated;
+		} catch (err: any) {
+			error = err.message;
+			throw err;
+		}
+	}
+
+	// ========================================================================
+	// VP Conversion
+	// ========================================================================
+
+	async function convertVictoryPoints(
+		id: string,
+		amount: number
+	): Promise<RespiteSession> {
+		try {
+			error = null;
+			const updated = await respiteRepository.convertVictoryPoints(id, amount);
+			updateActiveRespiteIfMatch(updated);
+			return updated;
+		} catch (err: any) {
+			error = err.message;
+			throw err;
+		}
+	}
+
+	// ========================================================================
+	// Kit Swap Recording
+	// ========================================================================
+
+	async function recordKitSwap(
+		id: string,
+		swap: { heroId: string; from: string; to: string; reason?: string }
+	): Promise<RespiteSession> {
+		try {
+			error = null;
+			const updated = await respiteRepository.recordKitSwap(id, swap);
+			updateActiveRespiteIfMatch(updated);
+			return updated;
+		} catch (err: any) {
+			error = err.message;
+			throw err;
+		}
+	}
+
+	// ========================================================================
+	// Helper Methods for UI
+	// ========================================================================
+
+	function clearError(): void {
+		error = null;
+	}
+
+	// ========================================================================
+	// Return Store API
+	// ========================================================================
+
+	return {
+		// State (reactive)
+		get respites() {
+			return respites;
+		},
+		get activeRespite() {
+			return activeRespite;
+		},
+		get isLoading() {
+			return isLoading;
+		},
+		get error() {
+			return error;
+		},
+
+		// Derived values (reactive)
+		get activeRespites() {
+			return activeRespites;
+		},
+		get preparingRespites() {
+			return preparingRespites;
+		},
+		get completedRespites() {
+			return completedRespites;
+		},
+		get heroCount() {
+			return heroCount;
+		},
+		get fullyRestedHeroes() {
+			return fullyRestedHeroes;
+		},
+		get vpRemaining() {
+			return vpRemaining;
+		},
+		get vpConversionPercent() {
+			return vpConversionPercent;
+		},
+		get pendingActivities() {
+			return pendingActivities;
+		},
+		get inProgressActivities() {
+			return inProgressActivities;
+		},
+		get completedActivities() {
+			return completedActivities;
+		},
+		get kitSwapHistory() {
+			return kitSwapHistory;
+		},
+
+		// Analytics
+		get totalVPConverted() {
+			return totalVPConverted;
+		},
+		get totalActivitiesCompleted() {
+			return totalActivitiesCompleted;
+		},
+		get activityTypeDistribution() {
+			return activityTypeDistribution;
+		},
+
+		// CRUD
+		createRespite,
+		selectRespite,
+		updateRespite,
+		deleteRespite,
+
+		// Lifecycle
+		startRespite,
+		completeRespite,
+
+		// Hero Management
+		addHero,
+		updateHero,
+		removeHero,
+
+		// Activity Management
+		recordActivity,
+		updateActivity,
+		completeActivity,
+
+		// VP Conversion
+		convertVictoryPoints,
+
+		// Kit Swap
+		recordKitSwap,
+
+		// Helpers
+		clearError,
+
+		// Cleanup
+		destroy: () => {
+			if (unsubscribe) {
+				unsubscribe();
+			}
+		}
+	};
+}
+
+export const respiteStore = createRespiteStore();

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -7,6 +7,7 @@ export * from './systems';
 export * from './combat';
 export * from './montage';
 export * from './negotiation';
+export * from './respite';
 export * from './playerExport';
 export * from './entityTypeExport';
 export * from './creature';

--- a/src/lib/types/respite.ts
+++ b/src/lib/types/respite.ts
@@ -1,0 +1,174 @@
+/**
+ * Respite Activity Tracker Types for Draw Steel RPG
+ *
+ * This module defines the type system for the Respite Activity Tracker,
+ * implementing Draw Steel's respite mechanics:
+ * - Respite sessions (24+ hours of downtime in a safe location)
+ * - Hero recovery tracking (regain recoveries)
+ * - Victory point to XP conversion
+ * - Kit swapping
+ * - Downtime activities (project, crafting, socializing, training, investigation, other)
+ */
+
+// ============================================================================
+// Respite Status
+// ============================================================================
+
+/**
+ * Current status of the respite session.
+ * - preparing: Setup phase, selecting heroes and configuring options
+ * - active: Respite in progress, activities being tracked
+ * - completed: Respite finished, all activities resolved
+ */
+export type RespiteStatus = 'preparing' | 'active' | 'completed';
+
+// ============================================================================
+// Activity Type
+// ============================================================================
+
+/**
+ * Type of downtime activity during a respite.
+ * Draw Steel canonical activity types.
+ */
+export type RespiteActivityType =
+	| 'project'
+	| 'crafting'
+	| 'socializing'
+	| 'training'
+	| 'investigation'
+	| 'other';
+
+// ============================================================================
+// Activity Status
+// ============================================================================
+
+/**
+ * Status of an individual respite activity.
+ * - pending: Not yet started
+ * - in_progress: Currently being worked on
+ * - completed: Finished with an outcome
+ */
+export type RespiteActivityStatus = 'pending' | 'in_progress' | 'completed';
+
+// ============================================================================
+// Respite Hero
+// ============================================================================
+
+/**
+ * Hero participating in a respite session.
+ * Tracks recovery status and individual hero notes.
+ */
+export interface RespiteHero {
+	id: string;
+	name: string;
+	heroId?: string;
+	recoveries: {
+		current: number;
+		max: number;
+		gained: number;
+	};
+	conditions?: string[];
+	notes?: string;
+}
+
+// ============================================================================
+// Respite Activity
+// ============================================================================
+
+/**
+ * Individual activity undertaken during a respite.
+ * Records the type, assignment, status, and outcome of each activity.
+ */
+export interface RespiteActivity {
+	id: string;
+	name: string;
+	description?: string;
+	type: RespiteActivityType;
+	heroId?: string;
+	status: RespiteActivityStatus;
+	outcome?: string;
+	notes?: string;
+	createdAt: Date;
+}
+
+// ============================================================================
+// Kit Swap
+// ============================================================================
+
+/**
+ * Record of a hero swapping their kit during respite.
+ * Tracks which hero changed kits and what they changed from/to.
+ */
+export interface KitSwap {
+	id: string;
+	heroId: string;
+	from: string;
+	to: string;
+	reason?: string;
+	createdAt: Date;
+}
+
+// ============================================================================
+// Respite Session
+// ============================================================================
+
+/**
+ * Complete respite session.
+ * Tracks the full state of a respite including heroes, activities,
+ * victory point conversion, and kit swaps.
+ */
+export interface RespiteSession {
+	id: string;
+	name: string;
+	description?: string;
+	status: RespiteStatus;
+	heroes: RespiteHero[];
+	victoryPointsAvailable: number;
+	victoryPointsConverted: number;
+	activities: RespiteActivity[];
+	kitSwaps: KitSwap[];
+	campaignId?: string;
+	characterIds?: string[];
+	linkedSessionIds?: string[];
+	createdAt: Date;
+	updatedAt: Date;
+	completedAt?: Date;
+}
+
+// ============================================================================
+// Input Types for Repository Operations
+// ============================================================================
+
+/**
+ * Input for creating a new respite session.
+ */
+export interface CreateRespiteInput {
+	name: string;
+	description?: string;
+	heroes?: Array<{
+		name: string;
+		heroId?: string;
+		recoveries: { current: number; max: number };
+	}>;
+	victoryPointsAvailable?: number;
+}
+
+/**
+ * Input for updating respite session fields.
+ */
+export interface UpdateRespiteInput {
+	name?: string;
+	description?: string;
+	victoryPointsAvailable?: number;
+}
+
+/**
+ * Input for recording an activity in the respite.
+ */
+export interface RecordActivityInput {
+	name: string;
+	description?: string;
+	type: RespiteActivityType;
+	heroId?: string;
+	notes?: string;
+}

--- a/src/routes/respite/+page.svelte
+++ b/src/routes/respite/+page.svelte
@@ -1,0 +1,201 @@
+<script lang="ts">
+	import { Coffee, Plus, Trash2 } from 'lucide-svelte';
+	import { goto } from '$app/navigation';
+	import { respiteStore } from '$lib/stores';
+	import { formatDistanceToNow } from 'date-fns';
+
+	let confirmDeleteId = $state<string | null>(null);
+
+	const respites = $derived(respiteStore.respites);
+
+	// Sort respites: active first, then by most recently updated
+	const sortedRespites = $derived.by(() => {
+		return [...respites].sort((a, b) => {
+			if (a.status === 'active' && b.status !== 'active') return -1;
+			if (a.status !== 'active' && b.status === 'active') return 1;
+			return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+		});
+	});
+
+	function getStatusBadgeClass(status: string): string {
+		switch (status) {
+			case 'active':
+				return 'bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200';
+			case 'preparing':
+				return 'bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-200';
+			case 'completed':
+				return 'bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200';
+			default:
+				return 'bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-200';
+		}
+	}
+
+	function handleNewRespite() {
+		goto('/respite/new');
+	}
+
+	function handleRespiteClick(respiteId: string) {
+		goto(`/respite/${respiteId}`);
+	}
+
+	function handleCardKeydown(event: KeyboardEvent, respiteId: string) {
+		if (event.key === 'Enter') {
+			goto(`/respite/${respiteId}`);
+		}
+	}
+
+	function handleDeleteClick(event: MouseEvent, respiteId: string) {
+		event.stopPropagation();
+		confirmDeleteId = respiteId;
+	}
+
+	async function handleConfirmDelete() {
+		if (confirmDeleteId) {
+			await respiteStore.deleteRespite(confirmDeleteId);
+			confirmDeleteId = null;
+		}
+	}
+
+	function handleCancelDelete() {
+		confirmDeleteId = null;
+	}
+</script>
+
+<div class="respite-list-page p-6 max-w-7xl mx-auto">
+	<!-- Header -->
+	<div class="flex items-center justify-between mb-6">
+		<div class="flex items-center gap-3">
+			<Coffee class="w-8 h-8 text-slate-700 dark:text-slate-300" />
+			<h1 class="text-3xl font-bold text-slate-900 dark:text-white">Respites</h1>
+		</div>
+		<button class="btn btn-primary" onclick={handleNewRespite}>
+			<Plus class="w-4 h-4" />
+			New Respite
+		</button>
+	</div>
+
+	<!-- Respite Grid -->
+	{#if sortedRespites.length === 0}
+		<div class="text-center py-16 px-4">
+			<Coffee class="w-16 h-16 text-slate-300 dark:text-slate-600 mx-auto mb-4" />
+			<h2 class="text-xl font-semibold text-slate-700 dark:text-slate-300 mb-2">
+				No respites yet
+			</h2>
+			<p class="text-slate-500 dark:text-slate-400 mb-6">
+				Create your first respite to track hero downtime
+			</p>
+			<button class="btn btn-primary" onclick={handleNewRespite}>
+				<Plus class="w-4 h-4" />
+				New Respite
+			</button>
+		</div>
+	{:else}
+		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+			{#each sortedRespites as respite (respite.id)}
+				<div
+					class="respite-card p-4 rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 hover:shadow-lg transition-shadow cursor-pointer"
+					data-testid="respite-card"
+					role="button"
+					tabindex="0"
+					aria-label="{respite.name} - {respite.status}"
+					onclick={() => handleRespiteClick(respite.id)}
+					onkeydown={(e) => handleCardKeydown(e, respite.id)}
+				>
+					<!-- Status Badge and Delete -->
+					<div class="flex items-center justify-between mb-3">
+						<span
+							class={`px-2 py-1 rounded-full text-xs font-medium ${getStatusBadgeClass(respite.status)}`}
+							data-testid="status-badge"
+						>
+							{respite.status.charAt(0).toUpperCase() + respite.status.slice(1)}
+						</span>
+						<button
+							class="p-1.5 rounded-md text-slate-400 hover:text-red-600 hover:bg-red-50 dark:hover:text-red-400 dark:hover:bg-red-900/20 transition-colors"
+							onclick={(e) => handleDeleteClick(e, respite.id)}
+							aria-label="Delete respite"
+						>
+							<Trash2 class="w-4 h-4" />
+						</button>
+					</div>
+
+					<!-- Name -->
+					<h3 class="text-lg font-semibold text-slate-900 dark:text-white mb-2 truncate">
+						{respite.name}
+					</h3>
+
+					<!-- Description -->
+					{#if respite.description}
+						<p class="text-sm text-slate-600 dark:text-slate-400 mb-3 line-clamp-2">
+							{respite.description}
+						</p>
+					{/if}
+
+					<!-- Stats -->
+					<div class="flex items-center gap-4 text-sm text-slate-600 dark:text-slate-400 mb-3">
+						<span>{respite.heroes.length} {respite.heroes.length === 1 ? 'hero' : 'heroes'}</span>
+						<span>{respite.activities.length} {respite.activities.length === 1 ? 'activity' : 'activities'}</span>
+					</div>
+
+					<!-- VP Status -->
+					{#if respite.victoryPointsAvailable > 0}
+						<div class="text-sm text-slate-600 dark:text-slate-400 mb-3">
+							<span class="font-medium">{respite.victoryPointsConverted}/{respite.victoryPointsAvailable}</span> VP converted
+						</div>
+					{/if}
+
+					<!-- Created Date -->
+					<div class="text-xs text-slate-500 dark:text-slate-400">
+						Created {formatDistanceToNow(new Date(respite.createdAt), { addSuffix: true })}
+					</div>
+				</div>
+			{/each}
+		</div>
+	{/if}
+</div>
+
+<!-- Delete Confirmation Dialog -->
+{#if confirmDeleteId}
+	<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+	<div
+		class="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+		onclick={handleCancelDelete}
+		onkeydown={(e) => e.key === 'Escape' && handleCancelDelete()}
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby="delete-dialog-title"
+		tabindex="-1"
+	>
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<!-- svelte-ignore a11y_click_events_have_key_events -->
+		<div
+			class="bg-white dark:bg-slate-800 rounded-lg p-6 max-w-sm mx-4 shadow-xl"
+			onclick={(e) => e.stopPropagation()}
+		>
+			<h2 id="delete-dialog-title" class="text-lg font-semibold text-slate-900 dark:text-white mb-2">
+				Delete Respite?
+			</h2>
+			<p class="text-slate-600 dark:text-slate-400 mb-4">
+				This will permanently delete this respite session and all its data. This action cannot be undone.
+			</p>
+			<div class="flex justify-end gap-3">
+				<button class="btn btn-secondary" onclick={handleCancelDelete}>Cancel</button>
+				<button class="btn bg-red-600 hover:bg-red-700 text-white" onclick={handleConfirmDelete}>Delete</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.line-clamp-2 {
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+
+	.truncate {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+</style>

--- a/src/routes/respite/[id]/+page.svelte
+++ b/src/routes/respite/[id]/+page.svelte
@@ -1,0 +1,313 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
+	import { onMount } from 'svelte';
+	import { respiteStore } from '$lib/stores';
+	import {
+		RespiteProgress,
+		HeroRecoveryPanel,
+		ActivityControls,
+		RespiteActivityCard,
+		KitSwapTracker,
+		VictoryPointsConverter,
+		RespiteRulesReference,
+		RespiteSetup
+	} from '$lib/components/respite';
+	import { ArrowLeft, Play, StopCircle } from 'lucide-svelte';
+	import type { RecordActivityInput } from '$lib/types/respite';
+
+	const respiteId = $derived($page.params.id);
+
+	onMount(async () => {
+		if (respiteId) {
+			await respiteStore.selectRespite(respiteId);
+		}
+	});
+
+	const respite = $derived(respiteStore.activeRespite);
+	const isLoading = $derived(respiteStore.isLoading);
+
+	function handleBack() {
+		goto('/respite');
+	}
+
+	async function handleStartRespite() {
+		if (!respite) return;
+		await respiteStore.startRespite(respite.id);
+	}
+
+	async function handleCompleteRespite() {
+		if (!respite) return;
+		await respiteStore.completeRespite(respite.id);
+	}
+
+	async function handleRecordActivity(data: RecordActivityInput) {
+		if (!respite) return;
+		await respiteStore.recordActivity(respite.id, data);
+	}
+
+	async function handleStartActivity(activityId: string) {
+		if (!respite) return;
+		await respiteStore.updateActivity(respite.id, activityId, { status: 'in_progress' });
+	}
+
+	async function handleCompleteActivity(activityId: string) {
+		if (!respite) return;
+		await respiteStore.completeActivity(respite.id, activityId);
+	}
+
+	async function handleUpdateRecovery(heroId: string, gained: number) {
+		if (!respite) return;
+		const hero = respite.heroes.find((h) => h.id === heroId);
+		if (!hero) return;
+		const newCurrent = Math.min(
+			hero.recoveries.max,
+			hero.recoveries.current - hero.recoveries.gained + gained
+		);
+		await respiteStore.updateHero(respite.id, heroId, {
+			recoveries: { current: newCurrent, max: hero.recoveries.max, gained }
+		});
+	}
+
+	async function handleConvertVP(amount: number) {
+		if (!respite) return;
+		await respiteStore.convertVictoryPoints(respite.id, amount);
+	}
+
+	async function handleKitSwap(swap: { heroId: string; from: string; to: string; reason?: string }) {
+		if (!respite) return;
+		await respiteStore.recordKitSwap(respite.id, swap);
+	}
+
+	// For editing in preparing state
+	interface RespiteSetupOutput {
+		name: string;
+		description?: string;
+		heroes: Array<{
+			name: string;
+			heroId?: string;
+			recoveries: { current: number; max: number };
+		}>;
+		victoryPointsAvailable: number;
+	}
+
+	async function handleUpdateSetup(data: RespiteSetupOutput) {
+		if (!respite) return;
+		await respiteStore.updateRespite(respite.id, {
+			name: data.name,
+			description: data.description,
+			victoryPointsAvailable: data.victoryPointsAvailable
+		});
+	}
+
+	const setupInitialData = $derived.by(() => {
+		if (!respite) return undefined;
+		return {
+			name: respite.name,
+			description: respite.description,
+			heroes: respite.heroes.map((h) => ({
+				name: h.name,
+				heroId: h.heroId,
+				recoveries: { current: h.recoveries.current, max: h.recoveries.max }
+			})),
+			victoryPointsAvailable: respite.victoryPointsAvailable
+		};
+	});
+</script>
+
+<div class="respite-detail-page p-6 max-w-5xl mx-auto">
+	{#if isLoading}
+		<div class="text-center py-16">
+			<div class="text-lg text-slate-600 dark:text-slate-400">Loading respite...</div>
+		</div>
+	{:else if !respite}
+		<div class="text-center py-16">
+			<div class="text-lg text-slate-600 dark:text-slate-400 mb-4">Respite not found</div>
+			<button class="btn btn-primary" onclick={handleBack}>
+				<ArrowLeft class="w-4 h-4" />
+				Back to List
+			</button>
+		</div>
+	{:else}
+		<!-- Back Button -->
+		<button class="btn btn-secondary mb-6" onclick={handleBack} aria-label="Back to respite list">
+			<ArrowLeft class="w-4 h-4" />
+			Back
+		</button>
+
+		<!-- Header -->
+		<div class="mb-6">
+			<div class="flex items-start justify-between gap-4 mb-2">
+				<div>
+					<h1 class="text-3xl font-bold text-slate-900 dark:text-white mb-1">
+						{respite.name}
+					</h1>
+					{#if respite.description}
+						<p class="text-slate-600 dark:text-slate-400 mt-2">{respite.description}</p>
+					{/if}
+				</div>
+
+				<!-- Status Badge -->
+				<div class="flex-shrink-0">
+					{#if respite.status === 'preparing'}
+						<span class="inline-flex items-center px-3 py-1.5 rounded-full text-sm font-medium bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-200">
+							Preparing
+						</span>
+					{:else if respite.status === 'active'}
+						<span class="inline-flex items-center px-3 py-1.5 rounded-full text-sm font-medium bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200">
+							Active
+						</span>
+					{:else}
+						<span class="inline-flex items-center px-3 py-1.5 rounded-full text-sm font-medium bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200">
+							Completed
+						</span>
+					{/if}
+				</div>
+			</div>
+		</div>
+
+		<!-- Preparing State -->
+		{#if respite.status === 'preparing'}
+			<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6 mb-6">
+				<h2 class="text-lg font-semibold text-slate-900 dark:text-white mb-4">Setup Respite</h2>
+				<RespiteSetup
+					initialData={setupInitialData}
+					onCreate={handleUpdateSetup}
+					onCancel={handleBack}
+				/>
+			</div>
+
+			<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6 mb-6 text-center">
+				<h2 class="text-xl font-semibold text-slate-900 dark:text-white mb-3">Ready to Start?</h2>
+				<p class="text-slate-600 dark:text-slate-400 mb-6">
+					Begin the respite for your heroes.
+				</p>
+				<button class="btn btn-primary" onclick={handleStartRespite}>
+					<Play class="w-4 h-4" />
+					Start Respite
+				</button>
+			</div>
+		{/if}
+
+		<!-- Active State -->
+		{#if respite.status === 'active'}
+			<!-- Progress Overview -->
+			<div class="mb-6">
+				<RespiteProgress {respite} />
+			</div>
+
+			<div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
+				<!-- Column 1: Heroes -->
+				<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6">
+					<h2 class="text-lg font-semibold text-slate-900 dark:text-white mb-4">Heroes</h2>
+					<HeroRecoveryPanel
+						heroes={respite.heroes}
+						onUpdateRecovery={handleUpdateRecovery}
+					/>
+				</div>
+
+				<!-- Column 2: Activities -->
+				<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6">
+					<h2 class="text-lg font-semibold text-slate-900 dark:text-white mb-4">Activities</h2>
+
+					<!-- Activity List -->
+					{#if respite.activities.length > 0}
+						<div class="space-y-3 mb-4">
+							{#each respite.activities as activity (activity.id)}
+								<RespiteActivityCard
+									{activity}
+									onComplete={handleCompleteActivity}
+									onStart={handleStartActivity}
+								/>
+							{/each}
+						</div>
+					{/if}
+
+					<!-- Add Activity Form -->
+					<div class="border-t border-slate-200 dark:border-slate-700 pt-4">
+						<h3 class="text-sm font-medium text-slate-900 dark:text-white mb-3">Add Activity</h3>
+						<ActivityControls onRecord={handleRecordActivity} />
+					</div>
+				</div>
+
+				<!-- Column 3: VP & Kit Swaps -->
+				<div class="space-y-6">
+					<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6">
+						<h2 class="text-lg font-semibold text-slate-900 dark:text-white mb-4">Victory Points</h2>
+						<VictoryPointsConverter
+							available={respite.victoryPointsAvailable}
+							converted={respite.victoryPointsConverted}
+							onConvert={handleConvertVP}
+						/>
+					</div>
+
+					<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6">
+						<h2 class="text-lg font-semibold text-slate-900 dark:text-white mb-4">Kit Swaps</h2>
+						<KitSwapTracker
+							kitSwaps={respite.kitSwaps}
+							heroes={respite.heroes}
+							onSwap={handleKitSwap}
+						/>
+					</div>
+				</div>
+			</div>
+
+			<!-- Rules Reference -->
+			<div class="mb-6">
+				<RespiteRulesReference />
+			</div>
+
+			<!-- Complete Respite -->
+			<div class="mb-6 text-center">
+				<button class="btn btn-secondary" onclick={handleCompleteRespite}>
+					<StopCircle class="w-4 h-4" />
+					Complete Respite
+				</button>
+			</div>
+		{/if}
+
+		<!-- Completed State -->
+		{#if respite.status === 'completed'}
+			<!-- Summary -->
+			<div class="bg-green-50 dark:bg-green-900/20 rounded-lg border border-green-200 dark:border-green-800 p-6 mb-6">
+				<h2 class="text-xl font-semibold text-green-900 dark:text-green-100 mb-3">Respite Complete</h2>
+				<div class="space-y-2 text-sm text-green-800 dark:text-green-200">
+					<p>{respite.heroes.length} heroes rested</p>
+					<p>{respite.activities.filter((a) => a.status === 'completed').length} activities completed</p>
+					<p>{respite.victoryPointsConverted} VP converted to XP</p>
+					<p>{respite.kitSwaps.length} kit swaps recorded</p>
+				</div>
+			</div>
+
+			<!-- Read-only views -->
+			<div class="mb-6">
+				<RespiteProgress {respite} />
+			</div>
+
+			{#if respite.heroes.length > 0}
+				<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6 mb-6">
+					<h2 class="text-lg font-semibold text-slate-900 dark:text-white mb-4">Heroes</h2>
+					<HeroRecoveryPanel heroes={respite.heroes} />
+				</div>
+			{/if}
+
+			{#if respite.activities.length > 0}
+				<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6 mb-6">
+					<h2 class="text-lg font-semibold text-slate-900 dark:text-white mb-4">Activities</h2>
+					<div class="space-y-3">
+						{#each respite.activities as activity (activity.id)}
+							<RespiteActivityCard {activity} />
+						{/each}
+					</div>
+				</div>
+			{/if}
+
+			<div class="mb-6 text-center">
+				<button class="btn btn-primary" onclick={handleBack}>
+					<ArrowLeft class="w-4 h-4" />
+					Back to List
+				</button>
+			</div>
+		{/if}
+	{/if}
+</div>

--- a/src/routes/respite/new/+page.svelte
+++ b/src/routes/respite/new/+page.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { respiteStore } from '$lib/stores';
+	import { RespiteSetup } from '$lib/components/respite';
+	import { ArrowLeft } from 'lucide-svelte';
+
+	interface RespiteSetupOutput {
+		name: string;
+		description?: string;
+		heroes: Array<{
+			name: string;
+			heroId?: string;
+			recoveries: { current: number; max: number };
+		}>;
+		victoryPointsAvailable: number;
+	}
+
+	async function handleCreate(data: RespiteSetupOutput) {
+		const input = {
+			name: data.name,
+			description: data.description,
+			heroes: data.heroes,
+			victoryPointsAvailable: data.victoryPointsAvailable
+		};
+
+		const respite = await respiteStore.createRespite(input);
+		goto(`/respite/${respite.id}`);
+	}
+
+	function handleCancel() {
+		goto('/respite');
+	}
+</script>
+
+<div class="new-respite-page p-6 max-w-2xl mx-auto">
+	<!-- Back Button -->
+	<button class="btn btn-secondary mb-6" onclick={handleCancel} aria-label="Back to respite list">
+		<ArrowLeft class="w-4 h-4" />
+		Back
+	</button>
+
+	<!-- Header -->
+	<div class="mb-6">
+		<h1 class="text-3xl font-bold text-slate-900 dark:text-white mb-2">New Respite</h1>
+		<p class="text-slate-600 dark:text-slate-400">
+			Set up a new Draw Steel respite session for your heroes.
+		</p>
+	</div>
+
+	<!-- Setup Form -->
+	<div class="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6">
+		<RespiteSetup onCreate={handleCreate} onCancel={handleCancel} />
+	</div>
+</div>


### PR DESCRIPTION
## Summary

- **Core (#408)**: Types, DB schema v11, repository (CRUD, lifecycle, hero/activity/VP/kit-swap ops), Svelte 5 runes store with live queries and derived values
- **UI (#409)**: 9 components, 3 routes (list/new/detail view with 3-column layout), sidebar nav with active respite badge
- **Integration (#410)**: Campaign/character queries, narrative event auto-creation on completion, cross-session analytics
- **QoL (#412)**: 15 activity templates across 5 types with quick-select in ActivityControls
- **Docs (#411)**: Architecture overview, test strategy, changelog, gap analysis update

## Details

Implements Draw Steel's respite mechanics — downtime periods (24+ hours in safe locations) where heroes regain recoveries, convert victory points to XP, swap kits, and undertake activities (crafting, training, socializing, investigation, projects).

**Lifecycle:** preparing → active → completed

**96 new tests** (57 repository + 32 store + 7 template) — all 12,225 tests pass across 253 files.

**32 files changed**, 6,143 lines added.

## Test plan

- [x] `npm run check` passes (2 pre-existing errors only)
- [x] `npx vitest run` — 12,225 tests pass, 253 files
- [x] `npm run build` — production build succeeds
- [ ] Manual smoke test of respite create/start/complete flow

Closes #408, #409, #410, #411, #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)