### PR TITLE
feat(v1.8.0): Configurable Player Export Field Visibility

### DIFF
--- a/src/lib/components/entity/FieldVisibilityToggle.svelte
+++ b/src/lib/components/entity/FieldVisibilityToggle.svelte
@@ -1,0 +1,88 @@
+<!--
+  @component FieldVisibilityToggle
+
+  A small toggle button for controlling per-entity field visibility in player exports.
+  Cycles through three states on click:
+    1. Inherit (no override) - faded icon showing category default
+    2. Explicitly included - solid green eye icon
+    3. Explicitly excluded - solid red closed-eye icon
+
+  Designed to appear next to field labels in the entity editor.
+
+  @prop {string} fieldKey - The field key
+  @prop {Record<string, unknown>} entityMetadata - The entity's metadata object
+  @prop {boolean} categoryDefault - The category-level default visibility for this field
+  @prop {(fieldKey: string, value: boolean | undefined) => void} onToggle - Callback when toggled
+
+  @example
+  ```svelte
+  <FieldVisibilityToggle
+    fieldKey="occupation"
+    entityMetadata={entity.metadata}
+    categoryDefault={true}
+    onToggle={(key, value) => handleVisibilityChange(key, value)}
+  />
+  ```
+-->
+<script lang="ts">
+	import { Eye, EyeOff } from 'lucide-svelte';
+	import {
+		getFieldOverrideState,
+		cycleFieldOverrideState,
+		getResolvedFieldVisibility
+	} from '$lib/services/entityFieldVisibilityService';
+
+	interface Props {
+		fieldKey: string;
+		entityMetadata: Record<string, unknown>;
+		categoryDefault: boolean;
+		onToggle: (fieldKey: string, value: boolean | undefined) => void;
+	}
+
+	let { fieldKey, entityMetadata, categoryDefault, onToggle }: Props = $props();
+
+	const overrideState = $derived(getFieldOverrideState(entityMetadata, fieldKey));
+	const resolved = $derived(getResolvedFieldVisibility(entityMetadata, fieldKey, categoryDefault));
+
+	const tooltipText = $derived.by(() => {
+		if (overrideState === true) {
+			return 'Visible to players (overridden)';
+		}
+		if (overrideState === false) {
+			return 'Hidden from players (overridden)';
+		}
+		// Inheriting
+		if (categoryDefault) {
+			return 'Visible to players (default)';
+		}
+		return 'Hidden from players (default)';
+	});
+
+	const ariaLabel = $derived.by(() => {
+		return `${tooltipText} - Click to cycle visibility for ${fieldKey}`;
+	});
+
+	function handleClick() {
+		const nextState = cycleFieldOverrideState(overrideState);
+		onToggle(fieldKey, nextState);
+	}
+</script>
+
+<button
+	type="button"
+	onclick={handleClick}
+	title={tooltipText}
+	aria-label={ariaLabel}
+	class="inline-flex items-center justify-center rounded p-0.5 transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1
+		{overrideState === true
+		? 'text-green-600 dark:text-green-400 hover:bg-green-100 dark:hover:bg-green-900/30'
+		: overrideState === false
+			? 'text-red-500 dark:text-red-400 hover:bg-red-100 dark:hover:bg-red-900/30'
+			: 'text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700 opacity-60'}"
+>
+	{#if resolved.visible}
+		<Eye class="h-3.5 w-3.5" />
+	{:else}
+		<EyeOff class="h-3.5 w-3.5" />
+	{/if}
+</button>

--- a/src/lib/components/settings/PlayerExportFieldSettings.svelte
+++ b/src/lib/components/settings/PlayerExportFieldSettings.svelte
@@ -1,0 +1,214 @@
+<script lang="ts">
+	import { ChevronDown, ChevronRight, Lock, Info, RotateCcw } from 'lucide-svelte';
+	import type { EntityTypeDefinition } from '$lib/types/entities';
+	import type { PlayerExportFieldConfig } from '$lib/types/playerFieldVisibility';
+	import {
+		getFieldVisibilitySetting,
+		setFieldVisibilitySetting,
+		removeFieldVisibilitySetting,
+		resetEntityTypeConfig,
+		getHardcodedDefault
+	} from '$lib/services/playerExportFieldConfigService';
+
+	interface Props {
+		entityTypes: EntityTypeDefinition[];
+		config: PlayerExportFieldConfig;
+		onConfigChange: (config: PlayerExportFieldConfig) => void;
+	}
+
+	let { entityTypes, config, onConfigChange }: Props = $props();
+
+	// Track which accordion sections are expanded
+	let expandedSections = $state<Record<string, boolean>>({});
+
+	function toggleSection(entityType: string) {
+		expandedSections = {
+			...expandedSections,
+			[entityType]: !expandedSections[entityType]
+		};
+	}
+
+	function handleFieldToggle(entityType: string, fieldKey: string, visible: boolean) {
+		const newConfig = setFieldVisibilitySetting(config, entityType, fieldKey, visible);
+		onConfigChange(newConfig);
+	}
+
+	function handleResetEntityType(entityType: string) {
+		const newConfig = resetEntityTypeConfig(config, entityType);
+		onConfigChange(newConfig);
+	}
+
+	function getEffectiveVisibility(entityType: string, fieldKey: string, fieldDef: import('$lib/types/entities').FieldDefinition): boolean {
+		const setting = getFieldVisibilitySetting(config, entityType, fieldKey);
+		if (setting !== undefined) {
+			return setting;
+		}
+		return getHardcodedDefault(fieldKey, fieldDef, entityType);
+	}
+
+	function hasCustomConfig(entityType: string): boolean {
+		const entityConfig = config.fieldVisibility[entityType];
+		return !!entityConfig && Object.keys(entityConfig).length > 0;
+	}
+
+	function getFieldTypeBadgeColor(fieldType: string): string {
+		switch (fieldType) {
+			case 'text':
+			case 'textarea':
+			case 'richtext':
+				return 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300';
+			case 'number':
+				return 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300';
+			case 'boolean':
+				return 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300';
+			case 'select':
+			case 'multi-select':
+				return 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300';
+			case 'tags':
+				return 'bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-300';
+			case 'entity-ref':
+			case 'entity-refs':
+				return 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300';
+			case 'date':
+				return 'bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-300';
+			case 'url':
+			case 'image':
+				return 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-300';
+			case 'computed':
+				return 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300';
+			case 'dice':
+				return 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300';
+			case 'resource':
+				return 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300';
+			case 'duration':
+				return 'bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-300';
+			default:
+				return 'bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-300';
+		}
+	}
+</script>
+
+<div class="space-y-3">
+	{#each entityTypes as entityTypeDef}
+		{@const isExpanded = expandedSections[entityTypeDef.type] ?? false}
+		{@const hasConfig = hasCustomConfig(entityTypeDef.type)}
+
+		<div class="border border-slate-200 dark:border-slate-700 rounded-lg overflow-hidden">
+			<!-- Accordion Header -->
+			<button
+				type="button"
+				class="w-full flex items-center gap-3 p-4 bg-slate-50 dark:bg-slate-800 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors text-left"
+				onclick={() => toggleSection(entityTypeDef.type)}
+				aria-expanded={isExpanded}
+				aria-controls="section-{entityTypeDef.type}"
+			>
+				<!-- Expand/Collapse Icon -->
+				<span class="flex-shrink-0 text-slate-400">
+					{#if isExpanded}
+						<ChevronDown class="w-4 h-4" />
+					{:else}
+						<ChevronRight class="w-4 h-4" />
+					{/if}
+				</span>
+
+				<!-- Entity Type Icon + Label -->
+				<span class="flex-shrink-0 text-lg" aria-hidden="true">{entityTypeDef.icon}</span>
+				<span class="flex-1 font-medium text-slate-900 dark:text-white">
+					{entityTypeDef.label}
+				</span>
+
+				<!-- Custom config indicator -->
+				{#if hasConfig}
+					<span class="text-xs px-2 py-0.5 bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 rounded-full">
+						Customized
+					</span>
+				{/if}
+
+				<!-- Field count -->
+				<span class="text-xs text-slate-500 dark:text-slate-400">
+					{entityTypeDef.fieldDefinitions.length} field{entityTypeDef.fieldDefinitions.length !== 1 ? 's' : ''}
+				</span>
+			</button>
+
+			<!-- Accordion Content -->
+			{#if isExpanded}
+				<div
+					id="section-{entityTypeDef.type}"
+					class="border-t border-slate-200 dark:border-slate-700"
+				>
+					<!-- Reset Button -->
+					{#if hasConfig}
+						<div class="px-4 pt-3 pb-1 flex justify-end">
+							<button
+								type="button"
+								class="inline-flex items-center gap-1.5 text-xs text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200 transition-colors"
+								onclick={() => handleResetEntityType(entityTypeDef.type)}
+								title="Reset all fields to default visibility"
+							>
+								<RotateCcw class="w-3 h-3" />
+								Reset to Defaults
+							</button>
+						</div>
+					{/if}
+
+					<!-- Field List -->
+					<div class="px-4 pb-4 {hasConfig ? 'pt-1' : 'pt-3'} space-y-1">
+						{#each entityTypeDef.fieldDefinitions as fieldDef}
+							{@const isVisible = getEffectiveVisibility(entityTypeDef.type, fieldDef.key, fieldDef)}
+							{@const isSecretField = fieldDef.section === 'hidden'}
+							{@const isNotesField = fieldDef.key === 'notes'}
+
+							<label
+								class="flex items-center gap-3 p-2 rounded-md hover:bg-slate-50 dark:hover:bg-slate-800/50 cursor-pointer transition-colors"
+							>
+								<!-- Checkbox -->
+								<input
+									type="checkbox"
+									checked={isVisible}
+									onchange={(e) => handleFieldToggle(entityTypeDef.type, fieldDef.key, e.currentTarget.checked)}
+									class="w-4 h-4 rounded border-slate-300 dark:border-slate-600 text-blue-600 focus:ring-blue-500 flex-shrink-0"
+								/>
+
+								<!-- Field Label -->
+								<span class="flex-1 text-sm text-slate-700 dark:text-slate-300 {!isVisible ? 'line-through opacity-60' : ''}">
+									{fieldDef.label}
+								</span>
+
+								<!-- Field Type Badge -->
+								<span class="flex-shrink-0 text-xs px-1.5 py-0.5 rounded {getFieldTypeBadgeColor(fieldDef.type)}">
+									{fieldDef.type}
+								</span>
+
+								<!-- Secret Field Indicator -->
+								{#if isSecretField}
+									<span class="flex-shrink-0" title="Secret field - hidden by default">
+										<Lock class="w-3.5 h-3.5 text-amber-500 dark:text-amber-400" />
+									</span>
+								{/if}
+
+								<!-- Notes Field Indicator -->
+								{#if isNotesField}
+									<span class="flex-shrink-0" title="DM notes - always hidden by default">
+										<Info class="w-3.5 h-3.5 text-slate-400 dark:text-slate-500" />
+									</span>
+								{/if}
+							</label>
+						{/each}
+
+						{#if entityTypeDef.fieldDefinitions.length === 0}
+							<p class="text-sm text-slate-500 dark:text-slate-400 italic py-2">
+								No fields defined for this entity type.
+							</p>
+						{/if}
+					</div>
+				</div>
+			{/if}
+		</div>
+	{/each}
+
+	{#if entityTypes.length === 0}
+		<p class="text-sm text-slate-500 dark:text-slate-400 italic py-4 text-center">
+			No entity types available.
+		</p>
+	{/if}
+</div>

--- a/src/lib/components/settings/index.ts
+++ b/src/lib/components/settings/index.ts
@@ -14,3 +14,4 @@ export { default as FieldTemplateDeleteModal } from './FieldTemplateDeleteModal.
 export { default as FieldTemplatePicker } from './FieldTemplatePicker.svelte';
 export { default as EntityTypeExportModal } from './EntityTypeExportModal.svelte';
 export { default as EntityTypeImportModal } from './EntityTypeImportModal.svelte';
+export { default as PlayerExportFieldSettings } from './PlayerExportFieldSettings.svelte';

--- a/src/lib/services/entityFieldVisibilityService.test.ts
+++ b/src/lib/services/entityFieldVisibilityService.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Tests for Entity Field Visibility Service (TDD RED Phase)
+ * GitHub Issue #438: Per-entity field visibility toggle checkboxes in entity editor
+ *
+ * Tests the helper service functions for managing per-entity field visibility
+ * overrides. These functions support the FieldVisibilityToggle component which
+ * provides a three-state cycling UI (inherit -> include -> exclude -> inherit).
+ *
+ * Functions under test:
+ * - getFieldOverrideState: reads override from entity metadata
+ * - cycleFieldOverrideState: computes next state in the toggle cycle
+ * - setFieldOverride: immutably applies an override to entity metadata
+ * - getResolvedFieldVisibility: combines override + category default into final state
+ *
+ * RED Phase: These tests SHOULD FAIL because the implementation does not exist yet.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+	getFieldOverrideState,
+	cycleFieldOverrideState,
+	setFieldOverride,
+	getResolvedFieldVisibility
+} from './entityFieldVisibilityService';
+
+// ---------------------------------------------------------------------------
+// 1. getFieldOverrideState
+// ---------------------------------------------------------------------------
+describe('getFieldOverrideState', () => {
+	it('returns undefined when no overrides exist in metadata', () => {
+		const metadata: Record<string, unknown> = {};
+		const result = getFieldOverrideState(metadata, 'occupation');
+		expect(result).toBeUndefined();
+	});
+
+	it('returns undefined when overrides exist but field is not listed', () => {
+		const metadata: Record<string, unknown> = {
+			playerExportFieldOverrides: { alignment: true }
+		};
+		const result = getFieldOverrideState(metadata, 'occupation');
+		expect(result).toBeUndefined();
+	});
+
+	it('returns true when field override is true', () => {
+		const metadata: Record<string, unknown> = {
+			playerExportFieldOverrides: { occupation: true }
+		};
+		const result = getFieldOverrideState(metadata, 'occupation');
+		expect(result).toBe(true);
+	});
+
+	it('returns false when field override is false', () => {
+		const metadata: Record<string, unknown> = {
+			playerExportFieldOverrides: { occupation: false }
+		};
+		const result = getFieldOverrideState(metadata, 'occupation');
+		expect(result).toBe(false);
+	});
+
+	it('returns undefined when metadata is empty object', () => {
+		const metadata: Record<string, unknown> = {};
+		const result = getFieldOverrideState(metadata, 'notes');
+		expect(result).toBeUndefined();
+	});
+
+	it('returns undefined when playerExportFieldOverrides is an empty object', () => {
+		const metadata: Record<string, unknown> = {
+			playerExportFieldOverrides: {}
+		};
+		const result = getFieldOverrideState(metadata, 'notes');
+		expect(result).toBeUndefined();
+	});
+
+	it('returns correct value when multiple overrides exist', () => {
+		const metadata: Record<string, unknown> = {
+			playerExportFieldOverrides: {
+				occupation: true,
+				secret_plan: false,
+				alignment: true
+			}
+		};
+		expect(getFieldOverrideState(metadata, 'occupation')).toBe(true);
+		expect(getFieldOverrideState(metadata, 'secret_plan')).toBe(false);
+		expect(getFieldOverrideState(metadata, 'alignment')).toBe(true);
+		expect(getFieldOverrideState(metadata, 'nonexistent')).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 2. cycleFieldOverrideState
+// ---------------------------------------------------------------------------
+describe('cycleFieldOverrideState', () => {
+	it('cycles undefined -> true (inherit -> force include)', () => {
+		const result = cycleFieldOverrideState(undefined);
+		expect(result).toBe(true);
+	});
+
+	it('cycles true -> false (force include -> force exclude)', () => {
+		const result = cycleFieldOverrideState(true);
+		expect(result).toBe(false);
+	});
+
+	it('cycles false -> undefined (force exclude -> inherit)', () => {
+		const result = cycleFieldOverrideState(false);
+		expect(result).toBeUndefined();
+	});
+
+	it('completes a full cycle: undefined -> true -> false -> undefined', () => {
+		let state: boolean | undefined = undefined;
+		state = cycleFieldOverrideState(state);
+		expect(state).toBe(true);
+		state = cycleFieldOverrideState(state);
+		expect(state).toBe(false);
+		state = cycleFieldOverrideState(state);
+		expect(state).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 3. setFieldOverride
+// ---------------------------------------------------------------------------
+describe('setFieldOverride', () => {
+	it('adds override to metadata with no existing overrides', () => {
+		const metadata: Record<string, unknown> = {};
+		const result = setFieldOverride(metadata, 'occupation', true);
+		expect(result).toEqual({
+			playerExportFieldOverrides: { occupation: true }
+		});
+	});
+
+	it('adds override to metadata with existing overrides for other fields', () => {
+		const metadata: Record<string, unknown> = {
+			playerExportFieldOverrides: { alignment: true }
+		};
+		const result = setFieldOverride(metadata, 'occupation', false);
+		expect(result).toEqual({
+			playerExportFieldOverrides: { alignment: true, occupation: false }
+		});
+	});
+
+	it('updates existing override', () => {
+		const metadata: Record<string, unknown> = {
+			playerExportFieldOverrides: { occupation: true }
+		};
+		const result = setFieldOverride(metadata, 'occupation', false);
+		expect(result).toEqual({
+			playerExportFieldOverrides: { occupation: false }
+		});
+	});
+
+	it('removes override when value is undefined (cleans up)', () => {
+		const metadata: Record<string, unknown> = {
+			playerExportFieldOverrides: { occupation: true, alignment: false }
+		};
+		const result = setFieldOverride(metadata, 'occupation', undefined);
+		expect(result).toEqual({
+			playerExportFieldOverrides: { alignment: false }
+		});
+	});
+
+	it('removes entire playerExportFieldOverrides key if last override removed', () => {
+		const metadata: Record<string, unknown> = {
+			playerExportFieldOverrides: { occupation: true }
+		};
+		const result = setFieldOverride(metadata, 'occupation', undefined);
+		expect(result).toEqual({});
+		expect('playerExportFieldOverrides' in result).toBe(false);
+	});
+
+	it('does not mutate original metadata', () => {
+		const metadata: Record<string, unknown> = {
+			playerExportFieldOverrides: { occupation: true }
+		};
+		const originalMetadata = JSON.parse(JSON.stringify(metadata));
+		setFieldOverride(metadata, 'occupation', false);
+		expect(metadata).toEqual(originalMetadata);
+	});
+
+	it('does not mutate original overrides object', () => {
+		const overrides = { occupation: true, alignment: false };
+		const metadata: Record<string, unknown> = {
+			playerExportFieldOverrides: overrides
+		};
+		setFieldOverride(metadata, 'occupation', false);
+		expect(overrides).toEqual({ occupation: true, alignment: false });
+	});
+
+	it('preserves other metadata keys', () => {
+		const metadata: Record<string, unknown> = {
+			someOtherKey: 'preserved-value',
+			anotherKey: 42,
+			playerExportFieldOverrides: { alignment: true }
+		};
+		const result = setFieldOverride(metadata, 'occupation', true);
+		expect(result).toEqual({
+			someOtherKey: 'preserved-value',
+			anotherKey: 42,
+			playerExportFieldOverrides: { alignment: true, occupation: true }
+		});
+	});
+
+	it('preserves other metadata keys when removing last override', () => {
+		const metadata: Record<string, unknown> = {
+			someOtherKey: 'preserved-value',
+			playerExportFieldOverrides: { occupation: true }
+		};
+		const result = setFieldOverride(metadata, 'occupation', undefined);
+		expect(result).toEqual({
+			someOtherKey: 'preserved-value'
+		});
+	});
+
+	it('handles setting override to true on metadata without overrides key', () => {
+		const metadata: Record<string, unknown> = {
+			someOtherKey: 'value'
+		};
+		const result = setFieldOverride(metadata, 'notes', true);
+		expect(result).toEqual({
+			someOtherKey: 'value',
+			playerExportFieldOverrides: { notes: true }
+		});
+	});
+
+	it('handles removing override when no overrides key exists (no-op, returns clean copy)', () => {
+		const metadata: Record<string, unknown> = {
+			someOtherKey: 'value'
+		};
+		const result = setFieldOverride(metadata, 'notes', undefined);
+		expect(result).toEqual({
+			someOtherKey: 'value'
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 4. getResolvedFieldVisibility
+// ---------------------------------------------------------------------------
+describe('getResolvedFieldVisibility', () => {
+	it('override true -> visible:true, isOverridden:true', () => {
+		const metadata: Record<string, unknown> = {
+			playerExportFieldOverrides: { occupation: true }
+		};
+		const result = getResolvedFieldVisibility(metadata, 'occupation', false);
+		expect(result).toEqual({ visible: true, isOverridden: true });
+	});
+
+	it('override false -> visible:false, isOverridden:true', () => {
+		const metadata: Record<string, unknown> = {
+			playerExportFieldOverrides: { occupation: false }
+		};
+		const result = getResolvedFieldVisibility(metadata, 'occupation', true);
+		expect(result).toEqual({ visible: false, isOverridden: true });
+	});
+
+	it('no override + categoryDefault true -> visible:true, isOverridden:false', () => {
+		const metadata: Record<string, unknown> = {};
+		const result = getResolvedFieldVisibility(metadata, 'occupation', true);
+		expect(result).toEqual({ visible: true, isOverridden: false });
+	});
+
+	it('no override + categoryDefault false -> visible:false, isOverridden:false', () => {
+		const metadata: Record<string, unknown> = {};
+		const result = getResolvedFieldVisibility(metadata, 'occupation', false);
+		expect(result).toEqual({ visible: false, isOverridden: false });
+	});
+
+	it('override true with categoryDefault true -> visible:true, isOverridden:true', () => {
+		const metadata: Record<string, unknown> = {
+			playerExportFieldOverrides: { occupation: true }
+		};
+		const result = getResolvedFieldVisibility(metadata, 'occupation', true);
+		expect(result).toEqual({ visible: true, isOverridden: true });
+	});
+
+	it('override false with categoryDefault false -> visible:false, isOverridden:true', () => {
+		const metadata: Record<string, unknown> = {
+			playerExportFieldOverrides: { occupation: false }
+		};
+		const result = getResolvedFieldVisibility(metadata, 'occupation', false);
+		expect(result).toEqual({ visible: false, isOverridden: true });
+	});
+
+	it('empty overrides object treated as no override', () => {
+		const metadata: Record<string, unknown> = {
+			playerExportFieldOverrides: {}
+		};
+		const result = getResolvedFieldVisibility(metadata, 'occupation', true);
+		expect(result).toEqual({ visible: true, isOverridden: false });
+	});
+
+	it('override for different field does not affect queried field', () => {
+		const metadata: Record<string, unknown> = {
+			playerExportFieldOverrides: { alignment: true }
+		};
+		const result = getResolvedFieldVisibility(metadata, 'occupation', false);
+		expect(result).toEqual({ visible: false, isOverridden: false });
+	});
+});

--- a/src/lib/services/entityFieldVisibilityService.ts
+++ b/src/lib/services/entityFieldVisibilityService.ts
@@ -1,0 +1,140 @@
+/**
+ * Entity Field Visibility Service
+ * GitHub Issue #438: Per-entity field visibility toggle checkboxes in entity editor
+ *
+ * Helper functions for managing per-entity field visibility overrides.
+ * These support the FieldVisibilityToggle component which provides a
+ * three-state cycling UI: inherit -> force include -> force exclude -> inherit.
+ *
+ * Overrides are stored in entity.metadata.playerExportFieldOverrides
+ * as Record<string, boolean>, where:
+ *   - true = force include in player export
+ *   - false = force exclude from player export
+ *   - absent = inherit from category default / hardcoded rules
+ */
+
+import { PLAYER_EXPORT_FIELD_OVERRIDES_KEY } from '$lib/types/playerFieldVisibility';
+import type { PlayerExportFieldOverrides } from '$lib/types/playerFieldVisibility';
+
+/**
+ * Get the current override state for a field on an entity.
+ *
+ * @param entityMetadata - The entity's metadata object
+ * @param fieldKey - The field key to look up
+ * @returns true (force include), false (force exclude), or undefined (inherit)
+ */
+export function getFieldOverrideState(
+	entityMetadata: Record<string, unknown>,
+	fieldKey: string
+): boolean | undefined {
+	const overrides = entityMetadata[PLAYER_EXPORT_FIELD_OVERRIDES_KEY] as
+		| PlayerExportFieldOverrides
+		| undefined;
+
+	if (!overrides || !(fieldKey in overrides)) {
+		return undefined;
+	}
+
+	return overrides[fieldKey];
+}
+
+/**
+ * Compute the next state in the three-state cycle.
+ *
+ * Cycle: undefined (inherit) -> true (force include) -> false (force exclude) -> undefined
+ *
+ * @param current - The current override state
+ * @returns The next state in the cycle
+ */
+export function cycleFieldOverrideState(current: boolean | undefined): boolean | undefined {
+	if (current === undefined) {
+		return true;
+	}
+	if (current === true) {
+		return false;
+	}
+	// current === false
+	return undefined;
+}
+
+/**
+ * Apply a field override to entity metadata. Returns a new metadata object
+ * without mutating the original.
+ *
+ * When value is undefined, the override for that field is removed.
+ * If removing the last override, the entire playerExportFieldOverrides
+ * key is removed from metadata to keep it clean.
+ *
+ * @param entityMetadata - The entity's current metadata object
+ * @param fieldKey - The field key to set/remove
+ * @param value - true (force include), false (force exclude), or undefined (remove override)
+ * @returns A new metadata object with the override applied
+ */
+export function setFieldOverride(
+	entityMetadata: Record<string, unknown>,
+	fieldKey: string,
+	value: boolean | undefined
+): Record<string, unknown> {
+	const existingOverrides = entityMetadata[PLAYER_EXPORT_FIELD_OVERRIDES_KEY] as
+		| PlayerExportFieldOverrides
+		| undefined;
+
+	if (value === undefined) {
+		// Remove the override for this field
+		if (!existingOverrides || !(fieldKey in existingOverrides)) {
+			// Nothing to remove; return a shallow copy without the overrides key if it doesn't exist
+			const { [PLAYER_EXPORT_FIELD_OVERRIDES_KEY]: _, ...rest } = entityMetadata;
+			if (existingOverrides && Object.keys(existingOverrides).length > 0) {
+				return { ...rest, [PLAYER_EXPORT_FIELD_OVERRIDES_KEY]: { ...existingOverrides } };
+			}
+			return { ...rest };
+		}
+
+		const { [fieldKey]: _, ...remainingOverrides } = existingOverrides;
+
+		if (Object.keys(remainingOverrides).length === 0) {
+			// Last override removed; drop the key entirely
+			const { [PLAYER_EXPORT_FIELD_OVERRIDES_KEY]: __, ...restMetadata } = entityMetadata;
+			return { ...restMetadata };
+		}
+
+		return {
+			...entityMetadata,
+			[PLAYER_EXPORT_FIELD_OVERRIDES_KEY]: remainingOverrides
+		};
+	}
+
+	// Set or update the override
+	const newOverrides: PlayerExportFieldOverrides = {
+		...(existingOverrides || {}),
+		[fieldKey]: value
+	};
+
+	return {
+		...entityMetadata,
+		[PLAYER_EXPORT_FIELD_OVERRIDES_KEY]: newOverrides
+	};
+}
+
+/**
+ * Get the resolved visibility for a field, considering the entity-level
+ * override and the category default.
+ *
+ * @param entityMetadata - The entity's metadata object
+ * @param fieldKey - The field key to resolve
+ * @param categoryDefault - The category-level default visibility for this field
+ * @returns An object with { visible: boolean, isOverridden: boolean }
+ */
+export function getResolvedFieldVisibility(
+	entityMetadata: Record<string, unknown>,
+	fieldKey: string,
+	categoryDefault: boolean
+): { visible: boolean; isOverridden: boolean } {
+	const override = getFieldOverrideState(entityMetadata, fieldKey);
+
+	if (override !== undefined) {
+		return { visible: override, isOverridden: true };
+	}
+
+	return { visible: categoryDefault, isOverridden: false };
+}

--- a/src/lib/services/playerExportCustomFieldsIntegration.test.ts
+++ b/src/lib/services/playerExportCustomFieldsIntegration.test.ts
@@ -1,0 +1,593 @@
+/**
+ * Integration Tests: Custom Fields with Player Export Visibility System
+ * GitHub Issue #440
+ *
+ * Verifies that custom fields (from custom entity types and from entity type
+ * overrides' additionalFields) fully participate in the player export visibility
+ * system. Uses REAL implementations (no mocks).
+ *
+ * Custom field sources tested:
+ * 1. Custom entity types (EntityTypeDefinition where isBuiltIn: false)
+ * 2. Entity type overrides (built-in types with additionalFields via EntityTypeOverride)
+ *
+ * Services exercised:
+ * - isFieldPlayerVisible (cascade: per-entity override > category config > hardcoded)
+ * - playerExportFieldConfigService (CRUD for category-level config)
+ * - entityFieldVisibilityService (per-entity override helpers)
+ * - filterEntitiesForPlayer / filterEntityForPlayer (end-to-end filtering)
+ */
+import { describe, it, expect } from 'vitest';
+import { isFieldPlayerVisible } from './playerFieldVisibility';
+import {
+	getFieldVisibilitySetting,
+	setFieldVisibilitySetting,
+	resetEntityTypeConfig,
+	getHardcodedDefault
+} from './playerExportFieldConfigService';
+import {
+	getFieldOverrideState,
+	setFieldOverride,
+	getResolvedFieldVisibility
+} from './entityFieldVisibilityService';
+import {
+	filterEntityForPlayer,
+	filterEntitiesForPlayer
+} from './playerExportFilterService';
+import type {
+	BaseEntity,
+	EntityTypeDefinition,
+	EntityTypeOverride,
+	FieldDefinition
+} from '$lib/types/entities';
+import type { PlayerExportFieldConfig } from '$lib/types/playerFieldVisibility';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeCustomEntityType(): EntityTypeDefinition {
+	return {
+		type: 'custom_vehicle',
+		label: 'Vehicle',
+		labelPlural: 'Vehicles',
+		icon: 'car',
+		color: 'orange',
+		isBuiltIn: false,
+		fieldDefinitions: [
+			{ key: 'speed', label: 'Speed', type: 'number', required: false, order: 1 },
+			{ key: 'fuel_type', label: 'Fuel Type', type: 'text', required: false, order: 2 },
+			{
+				key: 'secret_weapon',
+				label: 'Secret Weapon',
+				type: 'text',
+				required: false,
+				section: 'hidden',
+				order: 3
+			}
+		],
+		defaultRelationships: []
+	};
+}
+
+function makeEntityTypeOverrideWithAdditionalFields(): EntityTypeOverride {
+	return {
+		type: 'npc',
+		additionalFields: [
+			{
+				key: 'custom_weakness',
+				label: 'Custom Weakness',
+				type: 'textarea',
+				required: false,
+				order: 100
+			},
+			{
+				key: 'custom_secret',
+				label: 'Custom Secret',
+				type: 'text',
+				required: false,
+				section: 'hidden',
+				order: 101
+			}
+		]
+	};
+}
+
+function makeNpcTypeDefinition(): EntityTypeDefinition {
+	return {
+		type: 'npc',
+		label: 'NPC',
+		labelPlural: 'NPCs',
+		icon: 'users',
+		color: 'blue',
+		isBuiltIn: true,
+		fieldDefinitions: [
+			{ key: 'occupation', label: 'Occupation', type: 'text', required: false, order: 1 },
+			{
+				key: 'secret_motivation',
+				label: 'Secret Motivation',
+				type: 'textarea',
+				required: false,
+				section: 'hidden',
+				order: 2
+			}
+		],
+		defaultRelationships: []
+	};
+}
+
+/**
+ * Build an NPC type definition that merges the base fields with the
+ * additionalFields from an EntityTypeOverride, mimicking what the app
+ * does at runtime.
+ */
+function makeNpcTypeWithAdditionalFields(): EntityTypeDefinition {
+	const base = makeNpcTypeDefinition();
+	const override = makeEntityTypeOverrideWithAdditionalFields();
+	return {
+		...base,
+		fieldDefinitions: [...base.fieldDefinitions, ...(override.additionalFields ?? [])]
+	};
+}
+
+function makeCustomVehicleEntity(overrides: Partial<BaseEntity> = {}): BaseEntity {
+	return {
+		id: 'vehicle-1',
+		type: 'custom_vehicle',
+		name: 'War Wagon',
+		description: 'An armored wagon',
+		tags: ['military'],
+		fields: {
+			speed: 60,
+			fuel_type: 'horse-drawn',
+			secret_weapon: 'Concealed ballista'
+		},
+		links: [],
+		notes: 'DM notes about the wagon',
+		createdAt: new Date('2025-06-01'),
+		updatedAt: new Date('2025-06-10'),
+		metadata: {},
+		...overrides
+	};
+}
+
+function makeNpcEntity(overrides: Partial<BaseEntity> = {}): BaseEntity {
+	return {
+		id: 'npc-1',
+		type: 'npc',
+		name: 'Thalira',
+		description: 'A mysterious merchant',
+		tags: ['merchant'],
+		fields: {
+			occupation: 'Merchant',
+			secret_motivation: 'Spy for the crown',
+			custom_weakness: 'Afraid of fire',
+			custom_secret: 'Has a hidden twin'
+		},
+		links: [],
+		notes: 'DM notes about Thalira',
+		createdAt: new Date('2025-06-01'),
+		updatedAt: new Date('2025-06-10'),
+		metadata: {},
+		...overrides
+	};
+}
+
+// ---------------------------------------------------------------------------
+// 1. isFieldPlayerVisible with custom entity types and custom fields
+// ---------------------------------------------------------------------------
+describe('isFieldPlayerVisible with custom fields', () => {
+	describe('custom entity type fields respect cascade', () => {
+		it('custom field defaults to visible when no config or overrides exist', () => {
+			const entity = makeCustomVehicleEntity();
+			const fieldDef: FieldDefinition = { key: 'speed', label: 'Speed', type: 'number', required: false, order: 1 };
+
+			expect(isFieldPlayerVisible('speed', fieldDef, 'custom_vehicle', entity, undefined)).toBe(true);
+		});
+
+		it('custom field with section: hidden is hidden by default (hardcoded rule)', () => {
+			const entity = makeCustomVehicleEntity();
+			const fieldDef: FieldDefinition = {
+				key: 'secret_weapon',
+				label: 'Secret Weapon',
+				type: 'text',
+				required: false,
+				section: 'hidden',
+				order: 3
+			};
+
+			expect(
+				isFieldPlayerVisible('secret_weapon', fieldDef, 'custom_vehicle', entity, undefined)
+			).toBe(false);
+		});
+
+		it('category config overrides hardcoded rule for custom entity type field', () => {
+			const entity = makeCustomVehicleEntity();
+			const fieldDef: FieldDefinition = {
+				key: 'secret_weapon',
+				label: 'Secret Weapon',
+				type: 'text',
+				required: false,
+				section: 'hidden',
+				order: 3
+			};
+			const config: PlayerExportFieldConfig = {
+				fieldVisibility: { custom_vehicle: { secret_weapon: true } }
+			};
+
+			// Category config says visible, overriding the section:'hidden' hardcoded rule
+			expect(
+				isFieldPlayerVisible('secret_weapon', fieldDef, 'custom_vehicle', entity, config)
+			).toBe(true);
+		});
+
+		it('per-entity override wins over category config for custom entity type', () => {
+			const entity = makeCustomVehicleEntity({
+				metadata: { playerExportFieldOverrides: { speed: false } }
+			});
+			const fieldDef: FieldDefinition = { key: 'speed', label: 'Speed', type: 'number', required: false, order: 1 };
+			const config: PlayerExportFieldConfig = {
+				fieldVisibility: { custom_vehicle: { speed: true } }
+			};
+
+			// Entity override (false) wins over category config (true)
+			expect(isFieldPlayerVisible('speed', fieldDef, 'custom_vehicle', entity, config)).toBe(false);
+		});
+
+		it('per-entity override force-includes a hidden custom field', () => {
+			const entity = makeCustomVehicleEntity({
+				metadata: { playerExportFieldOverrides: { secret_weapon: true } }
+			});
+			const fieldDef: FieldDefinition = {
+				key: 'secret_weapon',
+				label: 'Secret Weapon',
+				type: 'text',
+				required: false,
+				section: 'hidden',
+				order: 3
+			};
+
+			expect(
+				isFieldPlayerVisible('secret_weapon', fieldDef, 'custom_vehicle', entity, undefined)
+			).toBe(true);
+		});
+	});
+
+	describe('additionalFields on built-in types respect cascade', () => {
+		it('additional field with no section defaults to visible', () => {
+			const entity = makeNpcEntity();
+			const fieldDef: FieldDefinition = {
+				key: 'custom_weakness',
+				label: 'Custom Weakness',
+				type: 'textarea',
+				required: false,
+				order: 100
+			};
+
+			expect(isFieldPlayerVisible('custom_weakness', fieldDef, 'npc', entity, undefined)).toBe(true);
+		});
+
+		it('additional field with section: hidden defaults to hidden', () => {
+			const entity = makeNpcEntity();
+			const fieldDef: FieldDefinition = {
+				key: 'custom_secret',
+				label: 'Custom Secret',
+				type: 'text',
+				required: false,
+				section: 'hidden',
+				order: 101
+			};
+
+			expect(isFieldPlayerVisible('custom_secret', fieldDef, 'npc', entity, undefined)).toBe(false);
+		});
+
+		it('category config can reveal a hidden additional field', () => {
+			const entity = makeNpcEntity();
+			const fieldDef: FieldDefinition = {
+				key: 'custom_secret',
+				label: 'Custom Secret',
+				type: 'text',
+				required: false,
+				section: 'hidden',
+				order: 101
+			};
+			const config: PlayerExportFieldConfig = {
+				fieldVisibility: { npc: { custom_secret: true } }
+			};
+
+			expect(isFieldPlayerVisible('custom_secret', fieldDef, 'npc', entity, config)).toBe(true);
+		});
+
+		it('per-entity override hides a normally visible additional field', () => {
+			const entity = makeNpcEntity({
+				metadata: { playerExportFieldOverrides: { custom_weakness: false } }
+			});
+			const fieldDef: FieldDefinition = {
+				key: 'custom_weakness',
+				label: 'Custom Weakness',
+				type: 'textarea',
+				required: false,
+				order: 100
+			};
+
+			expect(isFieldPlayerVisible('custom_weakness', fieldDef, 'npc', entity, undefined)).toBe(false);
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 2. playerExportFieldConfigService with custom entity types
+// ---------------------------------------------------------------------------
+describe('playerExportFieldConfigService with custom entity types', () => {
+	it('can set and get visibility for a custom entity type field', () => {
+		let config: PlayerExportFieldConfig = { fieldVisibility: {} };
+
+		config = setFieldVisibilitySetting(config, 'custom_vehicle', 'speed', false);
+		config = setFieldVisibilitySetting(config, 'custom_vehicle', 'fuel_type', true);
+		config = setFieldVisibilitySetting(config, 'custom_vehicle', 'secret_weapon', true);
+
+		expect(getFieldVisibilitySetting(config, 'custom_vehicle', 'speed')).toBe(false);
+		expect(getFieldVisibilitySetting(config, 'custom_vehicle', 'fuel_type')).toBe(true);
+		expect(getFieldVisibilitySetting(config, 'custom_vehicle', 'secret_weapon')).toBe(true);
+	});
+
+	it('returns undefined for unconfigured custom entity type fields', () => {
+		const config: PlayerExportFieldConfig = { fieldVisibility: {} };
+
+		expect(getFieldVisibilitySetting(config, 'custom_vehicle', 'speed')).toBeUndefined();
+	});
+
+	it('resets config for a custom entity type', () => {
+		let config: PlayerExportFieldConfig = { fieldVisibility: {} };
+		config = setFieldVisibilitySetting(config, 'custom_vehicle', 'speed', false);
+		config = setFieldVisibilitySetting(config, 'custom_vehicle', 'fuel_type', true);
+		config = setFieldVisibilitySetting(config, 'npc', 'occupation', true);
+
+		config = resetEntityTypeConfig(config, 'custom_vehicle');
+
+		expect(getFieldVisibilitySetting(config, 'custom_vehicle', 'speed')).toBeUndefined();
+		expect(getFieldVisibilitySetting(config, 'custom_vehicle', 'fuel_type')).toBeUndefined();
+		// NPC config is untouched
+		expect(getFieldVisibilitySetting(config, 'npc', 'occupation')).toBe(true);
+	});
+
+	it('getHardcodedDefault works for custom entity type fields', () => {
+		const vehicleType = makeCustomEntityType();
+		const speedDef = vehicleType.fieldDefinitions.find((f) => f.key === 'speed')!;
+		const secretDef = vehicleType.fieldDefinitions.find((f) => f.key === 'secret_weapon')!;
+
+		expect(getHardcodedDefault('speed', speedDef, 'custom_vehicle')).toBe(true);
+		expect(getHardcodedDefault('secret_weapon', secretDef, 'custom_vehicle')).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 3. filterEntitiesForPlayer with custom entity types
+// ---------------------------------------------------------------------------
+describe('filterEntitiesForPlayer with custom fields', () => {
+	it('filters a custom entity type using hardcoded rules (no config)', () => {
+		const vehicleTypeDef = makeCustomEntityType();
+		const entity = makeCustomVehicleEntity();
+
+		const result = filterEntitiesForPlayer([entity], [vehicleTypeDef]);
+
+		expect(result).toHaveLength(1);
+		const exported = result[0];
+		// 'speed' and 'fuel_type' are visible (no hidden section)
+		expect(exported.fields.speed).toBe(60);
+		expect(exported.fields.fuel_type).toBe('horse-drawn');
+		// 'secret_weapon' has section:'hidden' -> excluded by hardcoded rule
+		expect('secret_weapon' in exported.fields).toBe(false);
+		// 'notes' is always excluded from PlayerEntity at top level
+		expect('notes' in exported).toBe(false);
+	});
+
+	it('filters a custom entity type using category config', () => {
+		const vehicleTypeDef = makeCustomEntityType();
+		const entity = makeCustomVehicleEntity();
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: {
+				custom_vehicle: {
+					speed: false, // hide speed
+					secret_weapon: true // reveal secret weapon
+				}
+			}
+		};
+
+		const result = filterEntitiesForPlayer([entity], [vehicleTypeDef], config);
+
+		expect(result).toHaveLength(1);
+		const exported = result[0];
+		expect('speed' in exported.fields).toBe(false); // hidden by config
+		expect(exported.fields.fuel_type).toBe('horse-drawn'); // no config -> hardcoded: visible
+		expect(exported.fields.secret_weapon).toBe('Concealed ballista'); // revealed by config
+	});
+
+	it('filters built-in entity with additional custom fields', () => {
+		const npcTypeDef = makeNpcTypeWithAdditionalFields();
+		const entity = makeNpcEntity();
+
+		const result = filterEntitiesForPlayer([entity], [npcTypeDef]);
+
+		expect(result).toHaveLength(1);
+		const exported = result[0];
+		// Built-in field: occupation (visible by default)
+		expect(exported.fields.occupation).toBe('Merchant');
+		// Built-in hidden field: secret_motivation (section:'hidden' -> excluded)
+		expect('secret_motivation' in exported.fields).toBe(false);
+		// Additional field: custom_weakness (no section -> visible)
+		expect(exported.fields.custom_weakness).toBe('Afraid of fire');
+		// Additional field: custom_secret (section:'hidden' -> excluded)
+		expect('custom_secret' in exported.fields).toBe(false);
+	});
+
+	it('filters built-in entity with additional fields and category config', () => {
+		const npcTypeDef = makeNpcTypeWithAdditionalFields();
+		const entity = makeNpcEntity();
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: {
+				npc: {
+					custom_weakness: false, // hide the custom weakness
+					custom_secret: true // reveal the custom secret
+				}
+			}
+		};
+
+		const result = filterEntitiesForPlayer([entity], [npcTypeDef], config);
+
+		expect(result).toHaveLength(1);
+		const exported = result[0];
+		expect(exported.fields.occupation).toBe('Merchant'); // no config -> hardcoded: visible
+		expect('custom_weakness' in exported.fields).toBe(false); // hidden by config
+		expect(exported.fields.custom_secret).toBe('Has a hidden twin'); // revealed by config
+	});
+
+	it('respects playerVisible=false on custom entity type entities', () => {
+		const vehicleTypeDef = makeCustomEntityType();
+		const hiddenVehicle = makeCustomVehicleEntity({ playerVisible: false });
+
+		const result = filterEntitiesForPlayer([hiddenVehicle], [vehicleTypeDef]);
+
+		expect(result).toHaveLength(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 4. End-to-end integration scenarios
+// ---------------------------------------------------------------------------
+describe('end-to-end integration: custom entity type with config + per-entity overrides', () => {
+	it('full scenario: per-entity override > category config > hardcoded for custom type', () => {
+		const vehicleTypeDef = makeCustomEntityType();
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: {
+				custom_vehicle: {
+					speed: false, // hide speed at category level
+					secret_weapon: true // reveal secret weapon at category level
+				}
+			}
+		};
+
+		// Entity overrides: force speed visible (overrides category hide),
+		// and force secret_weapon hidden (overrides category reveal)
+		const entity = makeCustomVehicleEntity({
+			metadata: {
+				playerExportFieldOverrides: {
+					speed: true,
+					secret_weapon: false
+				}
+			}
+		});
+
+		const result = filterEntitiesForPlayer([entity], [vehicleTypeDef], config);
+
+		expect(result).toHaveLength(1);
+		const exported = result[0];
+		// speed: entity override (true) wins over category config (false)
+		expect(exported.fields.speed).toBe(60);
+		// fuel_type: no override, no config -> hardcoded: visible
+		expect(exported.fields.fuel_type).toBe('horse-drawn');
+		// secret_weapon: entity override (false) wins over category config (true)
+		expect('secret_weapon' in exported.fields).toBe(false);
+	});
+});
+
+describe('end-to-end integration: built-in type with additionalFields + config + per-entity overrides', () => {
+	it('full scenario: all three cascade levels interact for additional fields', () => {
+		const npcTypeDef = makeNpcTypeWithAdditionalFields();
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: {
+				npc: {
+					occupation: false, // hide built-in field at category level
+					custom_weakness: false, // hide additional field at category level
+					custom_secret: true // reveal hidden additional field at category level
+				}
+			}
+		};
+
+		// Entity overrides: force occupation visible, force custom_secret hidden
+		const entity = makeNpcEntity({
+			metadata: {
+				playerExportFieldOverrides: {
+					occupation: true,
+					custom_secret: false
+				}
+			}
+		});
+
+		const result = filterEntitiesForPlayer([entity], [npcTypeDef], config);
+
+		expect(result).toHaveLength(1);
+		const exported = result[0];
+		// occupation: entity override (true) wins over category config (false)
+		expect(exported.fields.occupation).toBe('Merchant');
+		// secret_motivation: no override, no config -> hardcoded: hidden (section:'hidden')
+		expect('secret_motivation' in exported.fields).toBe(false);
+		// custom_weakness: no override -> category config (false) -> hidden
+		expect('custom_weakness' in exported.fields).toBe(false);
+		// custom_secret: entity override (false) wins over category config (true)
+		expect('custom_secret' in exported.fields).toBe(false);
+	});
+
+	it('entityFieldVisibilityService helpers work with custom field keys', () => {
+		// Use the entity-level helpers to set overrides for custom fields
+		let metadata: Record<string, unknown> = {};
+
+		// Set override for a custom additional field
+		metadata = setFieldOverride(metadata, 'custom_weakness', false);
+		expect(getFieldOverrideState(metadata, 'custom_weakness')).toBe(false);
+
+		// Set override for a custom entity type field
+		metadata = setFieldOverride(metadata, 'speed', true);
+		expect(getFieldOverrideState(metadata, 'speed')).toBe(true);
+
+		// Unset field -> inherit
+		expect(getFieldOverrideState(metadata, 'fuel_type')).toBeUndefined();
+
+		// getResolvedFieldVisibility with a custom field
+		const resolved = getResolvedFieldVisibility(metadata, 'custom_weakness', true);
+		expect(resolved.visible).toBe(false);
+		expect(resolved.isOverridden).toBe(true);
+
+		const inherited = getResolvedFieldVisibility(metadata, 'fuel_type', true);
+		expect(inherited.visible).toBe(true);
+		expect(inherited.isOverridden).toBe(false);
+	});
+
+	it('mixed custom and built-in entities are filtered together', () => {
+		const vehicleTypeDef = makeCustomEntityType();
+		const npcTypeDef = makeNpcTypeWithAdditionalFields();
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: {
+				custom_vehicle: { secret_weapon: true },
+				npc: { custom_secret: true }
+			}
+		};
+
+		const vehicleEntity = makeCustomVehicleEntity();
+		const npcEntity = makeNpcEntity();
+		const hiddenNpc = makeNpcEntity({ id: 'npc-2', name: 'Hidden NPC', playerVisible: false });
+
+		const result = filterEntitiesForPlayer(
+			[vehicleEntity, npcEntity, hiddenNpc],
+			[vehicleTypeDef, npcTypeDef],
+			config
+		);
+
+		expect(result).toHaveLength(2);
+		// Vehicle is exported with secret_weapon revealed
+		const vehicle = result.find((e) => e.type === 'custom_vehicle')!;
+		expect(vehicle).toBeDefined();
+		expect(vehicle.fields.secret_weapon).toBe('Concealed ballista');
+		expect(vehicle.fields.speed).toBe(60);
+
+		// NPC is exported with custom_secret revealed
+		const npc = result.find((e) => e.type === 'npc')!;
+		expect(npc).toBeDefined();
+		expect(npc.fields.custom_secret).toBe('Has a hidden twin');
+		expect(npc.fields.occupation).toBe('Merchant');
+		// secret_motivation still hidden (no config override, section:'hidden')
+		expect('secret_motivation' in npc.fields).toBe(false);
+
+		// Hidden NPC excluded
+		expect(result.find((e) => e.name === 'Hidden NPC')).toBeUndefined();
+	});
+});

--- a/src/lib/services/playerExportFieldConfigService.test.ts
+++ b/src/lib/services/playerExportFieldConfigService.test.ts
@@ -1,0 +1,400 @@
+/**
+ * Tests for Player Export Field Config Service (TDD RED Phase)
+ * GitHub Issue #437: Settings UI for per-category player export field defaults
+ *
+ * Tests the service functions for managing per-category field visibility
+ * defaults stored in CampaignMetadata.playerExportFieldConfig.
+ *
+ * RED Phase: These tests SHOULD FAIL because the implementation does not exist yet.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+	getPlayerExportFieldConfig,
+	getFieldVisibilitySetting,
+	setFieldVisibilitySetting,
+	removeFieldVisibilitySetting,
+	resetEntityTypeConfig,
+	getHardcodedDefault
+} from './playerExportFieldConfigService';
+import type { CampaignMetadata } from '$lib/types/campaign';
+import type { PlayerExportFieldConfig } from '$lib/types/playerFieldVisibility';
+import type { FieldDefinition } from '$lib/types/entities';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeCampaignMetadata(
+	overrides: Partial<CampaignMetadata> = {}
+): CampaignMetadata {
+	return {
+		customEntityTypes: [],
+		entityTypeOverrides: [],
+		settings: {
+			customRelationships: [],
+			enabledEntityTypes: [],
+			theme: 'system'
+		},
+		...overrides
+	};
+}
+
+function makeFieldDef(overrides: Partial<FieldDefinition> = {}): FieldDefinition {
+	return {
+		key: 'someField',
+		label: 'Some Field',
+		type: 'text',
+		required: false,
+		order: 1,
+		...overrides
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('getPlayerExportFieldConfig', () => {
+	it('returns config from campaign metadata when present', () => {
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: { npc: { occupation: true, secret: false } }
+		};
+		const metadata = makeCampaignMetadata({
+			playerExportFieldConfig: config
+		});
+
+		const result = getPlayerExportFieldConfig(metadata);
+		expect(result).toEqual(config);
+	});
+
+	it('returns empty config when metadata has no playerExportFieldConfig', () => {
+		const metadata = makeCampaignMetadata();
+
+		const result = getPlayerExportFieldConfig(metadata);
+		expect(result).toEqual({ fieldVisibility: {} });
+	});
+
+	it('returns empty config when playerExportFieldConfig is undefined', () => {
+		const metadata = makeCampaignMetadata({
+			playerExportFieldConfig: undefined
+		});
+
+		const result = getPlayerExportFieldConfig(metadata);
+		expect(result).toEqual({ fieldVisibility: {} });
+	});
+});
+
+describe('getFieldVisibilitySetting', () => {
+	it('returns true when field is set to visible', () => {
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: { npc: { occupation: true } }
+		};
+
+		const result = getFieldVisibilitySetting(config, 'npc', 'occupation');
+		expect(result).toBe(true);
+	});
+
+	it('returns false when field is set to hidden', () => {
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: { npc: { secret_plan: false } }
+		};
+
+		const result = getFieldVisibilitySetting(config, 'npc', 'secret_plan');
+		expect(result).toBe(false);
+	});
+
+	it('returns undefined when field not configured', () => {
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: { npc: { occupation: true } }
+		};
+
+		const result = getFieldVisibilitySetting(config, 'npc', 'alignment');
+		expect(result).toBeUndefined();
+	});
+
+	it('returns undefined when entity type not configured', () => {
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: { npc: { occupation: true } }
+		};
+
+		const result = getFieldVisibilitySetting(config, 'location', 'population');
+		expect(result).toBeUndefined();
+	});
+
+	it('returns undefined when fieldVisibility is empty', () => {
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: {}
+		};
+
+		const result = getFieldVisibilitySetting(config, 'npc', 'occupation');
+		expect(result).toBeUndefined();
+	});
+});
+
+describe('setFieldVisibilitySetting', () => {
+	it('sets visibility for new entity type and field', () => {
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: {}
+		};
+
+		const result = setFieldVisibilitySetting(config, 'npc', 'occupation', true);
+		expect(result.fieldVisibility.npc.occupation).toBe(true);
+	});
+
+	it('updates existing visibility setting', () => {
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: { npc: { occupation: true } }
+		};
+
+		const result = setFieldVisibilitySetting(config, 'npc', 'occupation', false);
+		expect(result.fieldVisibility.npc.occupation).toBe(false);
+	});
+
+	it('preserves other entity type configs', () => {
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: {
+				npc: { occupation: true },
+				location: { population: false }
+			}
+		};
+
+		const result = setFieldVisibilitySetting(config, 'npc', 'occupation', false);
+		expect(result.fieldVisibility.location).toEqual({ population: false });
+	});
+
+	it('preserves other field configs within same entity type', () => {
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: {
+				npc: { occupation: true, alignment: false }
+			}
+		};
+
+		const result = setFieldVisibilitySetting(config, 'npc', 'occupation', false);
+		expect(result.fieldVisibility.npc.alignment).toBe(false);
+		expect(result.fieldVisibility.npc.occupation).toBe(false);
+	});
+
+	it('does not mutate original config', () => {
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: { npc: { occupation: true } }
+		};
+		const originalJson = JSON.stringify(config);
+
+		setFieldVisibilitySetting(config, 'npc', 'occupation', false);
+		expect(JSON.stringify(config)).toBe(originalJson);
+	});
+
+	it('does not mutate original config when adding new entity type', () => {
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: {}
+		};
+		const originalJson = JSON.stringify(config);
+
+		setFieldVisibilitySetting(config, 'npc', 'occupation', true);
+		expect(JSON.stringify(config)).toBe(originalJson);
+	});
+});
+
+describe('removeFieldVisibilitySetting', () => {
+	it('removes specific field from config', () => {
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: { npc: { occupation: true, alignment: false } }
+		};
+
+		const result = removeFieldVisibilitySetting(config, 'npc', 'occupation');
+		expect(result.fieldVisibility.npc.occupation).toBeUndefined();
+		expect('occupation' in result.fieldVisibility.npc).toBe(false);
+	});
+
+	it('preserves other fields in same entity type', () => {
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: { npc: { occupation: true, alignment: false } }
+		};
+
+		const result = removeFieldVisibilitySetting(config, 'npc', 'occupation');
+		expect(result.fieldVisibility.npc.alignment).toBe(false);
+	});
+
+	it('does not mutate original config', () => {
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: { npc: { occupation: true, alignment: false } }
+		};
+		const originalJson = JSON.stringify(config);
+
+		removeFieldVisibilitySetting(config, 'npc', 'occupation');
+		expect(JSON.stringify(config)).toBe(originalJson);
+	});
+
+	it('cleans up empty entity type entries', () => {
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: { npc: { occupation: true } }
+		};
+
+		const result = removeFieldVisibilitySetting(config, 'npc', 'occupation');
+		expect(result.fieldVisibility.npc).toBeUndefined();
+		expect('npc' in result.fieldVisibility).toBe(false);
+	});
+
+	it('preserves other entity type configs when cleaning up', () => {
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: {
+				npc: { occupation: true },
+				location: { population: false }
+			}
+		};
+
+		const result = removeFieldVisibilitySetting(config, 'npc', 'occupation');
+		expect(result.fieldVisibility.npc).toBeUndefined();
+		expect(result.fieldVisibility.location).toEqual({ population: false });
+	});
+
+	it('handles removing field from non-existent entity type gracefully', () => {
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: { npc: { occupation: true } }
+		};
+
+		const result = removeFieldVisibilitySetting(config, 'location', 'population');
+		// Should return config unchanged (no mutation, but structurally identical)
+		expect(result.fieldVisibility).toEqual(config.fieldVisibility);
+	});
+
+	it('handles removing non-existent field gracefully', () => {
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: { npc: { occupation: true } }
+		};
+
+		const result = removeFieldVisibilitySetting(config, 'npc', 'alignment');
+		expect(result.fieldVisibility.npc.occupation).toBe(true);
+	});
+});
+
+describe('resetEntityTypeConfig', () => {
+	it('removes all field configs for entity type', () => {
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: {
+				npc: { occupation: true, alignment: false, secret: false }
+			}
+		};
+
+		const result = resetEntityTypeConfig(config, 'npc');
+		expect(result.fieldVisibility.npc).toBeUndefined();
+		expect('npc' in result.fieldVisibility).toBe(false);
+	});
+
+	it('preserves other entity type configs', () => {
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: {
+				npc: { occupation: true },
+				location: { population: false },
+				character: { level: true }
+			}
+		};
+
+		const result = resetEntityTypeConfig(config, 'npc');
+		expect(result.fieldVisibility.npc).toBeUndefined();
+		expect(result.fieldVisibility.location).toEqual({ population: false });
+		expect(result.fieldVisibility.character).toEqual({ level: true });
+	});
+
+	it('does not mutate original config', () => {
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: {
+				npc: { occupation: true },
+				location: { population: false }
+			}
+		};
+		const originalJson = JSON.stringify(config);
+
+		resetEntityTypeConfig(config, 'npc');
+		expect(JSON.stringify(config)).toBe(originalJson);
+	});
+
+	it('handles resetting non-existent entity type gracefully', () => {
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: { npc: { occupation: true } }
+		};
+
+		const result = resetEntityTypeConfig(config, 'location');
+		expect(result.fieldVisibility).toEqual(config.fieldVisibility);
+	});
+
+	it('returns config with empty fieldVisibility when last entity type is removed', () => {
+		const config: PlayerExportFieldConfig = {
+			fieldVisibility: { npc: { occupation: true } }
+		};
+
+		const result = resetEntityTypeConfig(config, 'npc');
+		expect(result.fieldVisibility).toEqual({});
+	});
+});
+
+describe('getHardcodedDefault', () => {
+	it("returns false for 'notes' field", () => {
+		const fieldDef = makeFieldDef({ key: 'notes' });
+
+		const result = getHardcodedDefault('notes', fieldDef, 'npc');
+		expect(result).toBe(false);
+	});
+
+	it("returns false for field with section: 'hidden'", () => {
+		const fieldDef = makeFieldDef({ key: 'secret_motivation', section: 'hidden' });
+
+		const result = getHardcodedDefault('secret_motivation', fieldDef, 'npc');
+		expect(result).toBe(false);
+	});
+
+	it("returns false for 'preparation' on session entity type", () => {
+		const fieldDef = makeFieldDef({ key: 'preparation' });
+
+		const result = getHardcodedDefault('preparation', fieldDef, 'session');
+		expect(result).toBe(false);
+	});
+
+	it("returns true for 'preparation' on non-session entity type", () => {
+		const fieldDef = makeFieldDef({ key: 'preparation' });
+
+		const result = getHardcodedDefault('preparation', fieldDef, 'npc');
+		expect(result).toBe(true);
+	});
+
+	it('returns true for regular visible field', () => {
+		const fieldDef = makeFieldDef({ key: 'occupation' });
+
+		const result = getHardcodedDefault('occupation', fieldDef, 'npc');
+		expect(result).toBe(true);
+	});
+
+	it('returns true when fieldDef is undefined', () => {
+		const result = getHardcodedDefault('some_custom_field', undefined, 'npc');
+		expect(result).toBe(true);
+	});
+
+	it("returns false for 'notes' even without fieldDef", () => {
+		const result = getHardcodedDefault('notes', undefined, 'npc');
+		expect(result).toBe(false);
+	});
+
+	it("returns true for field with section other than 'hidden'", () => {
+		const fieldDef = makeFieldDef({ key: 'bio', section: 'public' });
+
+		const result = getHardcodedDefault('bio', fieldDef, 'npc');
+		expect(result).toBe(true);
+	});
+
+	it('returns true for field with no section', () => {
+		const fieldDef = makeFieldDef({ key: 'level' });
+
+		const result = getHardcodedDefault('level', fieldDef, 'character');
+		expect(result).toBe(true);
+	});
+
+	it("returns false for 'notes' regardless of entity type", () => {
+		const fieldDef = makeFieldDef({ key: 'notes' });
+		const types = ['npc', 'character', 'location', 'faction', 'item', 'session', 'deity'];
+
+		for (const entityType of types) {
+			const result = getHardcodedDefault('notes', fieldDef, entityType);
+			expect(result).toBe(false);
+		}
+	});
+});

--- a/src/lib/services/playerExportFieldConfigService.ts
+++ b/src/lib/services/playerExportFieldConfigService.ts
@@ -1,0 +1,153 @@
+/**
+ * Player Export Field Config Service
+ * GitHub Issue #437: Settings UI for per-category player export field defaults
+ *
+ * Pure service functions for managing per-category field visibility defaults
+ * stored in CampaignMetadata.playerExportFieldConfig.
+ *
+ * All functions are pure (no side effects, no store access).
+ * The component layer handles persistence.
+ */
+
+import type { CampaignMetadata } from '$lib/types/campaign';
+import type { PlayerExportFieldConfig } from '$lib/types/playerFieldVisibility';
+import type { FieldDefinition } from '$lib/types/entities';
+
+/**
+ * Get the current field visibility config from campaign metadata.
+ * Returns an empty config if none is configured.
+ */
+export function getPlayerExportFieldConfig(
+	campaignMetadata: CampaignMetadata
+): PlayerExportFieldConfig {
+	return campaignMetadata.playerExportFieldConfig ?? { fieldVisibility: {} };
+}
+
+/**
+ * Get the visibility setting for a specific field in a category.
+ *
+ * @returns true (visible), false (hidden), or undefined (no config, use hardcoded default)
+ */
+export function getFieldVisibilitySetting(
+	config: PlayerExportFieldConfig,
+	entityType: string,
+	fieldKey: string
+): boolean | undefined {
+	const entityConfig = config.fieldVisibility[entityType];
+	if (!entityConfig || !(fieldKey in entityConfig)) {
+		return undefined;
+	}
+	return entityConfig[fieldKey];
+}
+
+/**
+ * Set the visibility for a field in a category.
+ * Returns a new config object (does not mutate the original).
+ */
+export function setFieldVisibilitySetting(
+	config: PlayerExportFieldConfig,
+	entityType: string,
+	fieldKey: string,
+	visible: boolean
+): PlayerExportFieldConfig {
+	const existingEntityConfig = config.fieldVisibility[entityType] ?? {};
+	return {
+		...config,
+		fieldVisibility: {
+			...config.fieldVisibility,
+			[entityType]: {
+				...existingEntityConfig,
+				[fieldKey]: visible
+			}
+		}
+	};
+}
+
+/**
+ * Remove a field visibility setting (returns new config, does not mutate).
+ * Used for "reset to default" functionality on a single field.
+ * Cleans up empty entity type entries.
+ */
+export function removeFieldVisibilitySetting(
+	config: PlayerExportFieldConfig,
+	entityType: string,
+	fieldKey: string
+): PlayerExportFieldConfig {
+	const entityConfig = config.fieldVisibility[entityType];
+	if (!entityConfig) {
+		// Entity type not in config, nothing to remove
+		return {
+			...config,
+			fieldVisibility: { ...config.fieldVisibility }
+		};
+	}
+
+	// Create a shallow copy of the entity config without the target field
+	const { [fieldKey]: _removed, ...remainingFields } = entityConfig;
+
+	// If no fields remain, remove the entity type entry entirely
+	if (Object.keys(remainingFields).length === 0) {
+		const { [entityType]: _removedType, ...remainingTypes } = config.fieldVisibility;
+		return {
+			...config,
+			fieldVisibility: remainingTypes
+		};
+	}
+
+	return {
+		...config,
+		fieldVisibility: {
+			...config.fieldVisibility,
+			[entityType]: remainingFields
+		}
+	};
+}
+
+/**
+ * Reset all field visibility settings for an entity type.
+ * Returns a new config (does not mutate the original).
+ */
+export function resetEntityTypeConfig(
+	config: PlayerExportFieldConfig,
+	entityType: string
+): PlayerExportFieldConfig {
+	const { [entityType]: _removed, ...remainingTypes } = config.fieldVisibility;
+	return {
+		...config,
+		fieldVisibility: remainingTypes
+	};
+}
+
+/**
+ * Get the hardcoded default visibility for a field (backward compatibility reference).
+ *
+ * These are the original rules that apply when no per-category or per-entity
+ * overrides exist:
+ *   - 'notes' field -> false (DM notes always hidden)
+ *   - field.section === 'hidden' -> false (secret fields hidden)
+ *   - 'preparation' on session entity type -> false (DM prep hidden)
+ *   - Everything else -> true
+ */
+export function getHardcodedDefault(
+	fieldKey: string,
+	fieldDef: FieldDefinition | undefined,
+	entityType: string
+): boolean {
+	// 'notes' field is always hidden
+	if (fieldKey === 'notes') {
+		return false;
+	}
+
+	// Fields with section: 'hidden' are hidden
+	if (fieldDef?.section === 'hidden') {
+		return false;
+	}
+
+	// 'preparation' field on session entities is hidden
+	if (fieldKey === 'preparation' && entityType === 'session') {
+		return false;
+	}
+
+	// Everything else is visible by default
+	return true;
+}

--- a/src/lib/services/playerExportService.ts
+++ b/src/lib/services/playerExportService.ts
@@ -23,6 +23,7 @@ import type {
 	PlayerExportPreview,
 	PLAYER_EXPORT_VERSION
 } from '$lib/types/playerExport';
+import type { PlayerExportFieldConfig } from '$lib/types/playerFieldVisibility';
 
 // Re-export the version constant
 export { PLAYER_EXPORT_VERSION } from '$lib/types/playerExport';
@@ -64,11 +65,20 @@ export async function buildPlayerExport(): Promise<PlayerExport> {
 	// Get entity type definitions
 	const typeDefinitions = getEntityTypeDefinitions(campaign);
 
+	// Get player export field config from campaign metadata
+	const metadata = getCampaignMetadata(campaign);
+	const playerExportFieldConfig: PlayerExportFieldConfig | undefined =
+		metadata?.playerExportFieldConfig;
+
 	// Filter out campaign entities from the list to filter
 	const nonCampaignEntities = entities.filter((e) => e.type !== 'campaign');
 
 	// Filter entities for player visibility
-	const filteredEntities = filterEntitiesForPlayer(nonCampaignEntities, typeDefinitions);
+	const filteredEntities = filterEntitiesForPlayer(
+		nonCampaignEntities,
+		typeDefinitions,
+		playerExportFieldConfig
+	);
 
 	return {
 		version: '1.0.0',
@@ -93,11 +103,20 @@ export async function getPlayerExportPreview(): Promise<PlayerExportPreview> {
 	// Get entity type definitions
 	const typeDefinitions = getEntityTypeDefinitions(campaign);
 
+	// Get player export field config from campaign metadata
+	const previewMetadata = getCampaignMetadata(campaign);
+	const previewFieldConfig: PlayerExportFieldConfig | undefined =
+		previewMetadata?.playerExportFieldConfig;
+
 	// Filter out campaign entities
 	const nonCampaignEntities = entities.filter((e) => e.type !== 'campaign');
 
 	// Filter entities for player visibility
-	const filteredEntities = filterEntitiesForPlayer(nonCampaignEntities, typeDefinitions);
+	const filteredEntities = filterEntitiesForPlayer(
+		nonCampaignEntities,
+		typeDefinitions,
+		previewFieldConfig
+	);
 
 	// Calculate counts by type
 	const byType: Record<string, { included: number; excluded: number }> = {};

--- a/src/lib/services/playerFieldVisibility.test.ts
+++ b/src/lib/services/playerFieldVisibility.test.ts
@@ -1,0 +1,747 @@
+/**
+ * Tests for Player Field Visibility Service (TDD RED Phase)
+ * GitHub Issue #436: Data model for player export field visibility configuration
+ *
+ * Tests the cascade resolution function isFieldPlayerVisible() which determines
+ * whether a specific field should be included in a player export.
+ *
+ * Cascade priority (highest to lowest):
+ * 1. Per-entity override (entity.metadata.playerExportFieldOverrides[fieldKey])
+ * 2. Per-category default (config.fieldVisibility[entityType][fieldKey])
+ * 3. Hardcoded rules (current behavior: notes=false, hidden section=false,
+ *    preparation on sessions=false, everything else=true)
+ *
+ * RED Phase: These tests SHOULD FAIL because the implementation does not exist yet.
+ */
+import { describe, it, expect } from 'vitest';
+import { isFieldPlayerVisible } from './playerFieldVisibility';
+import type { BaseEntity, FieldDefinition } from '$lib/types/entities';
+import type { PlayerExportFieldConfig } from '$lib/types/playerFieldVisibility';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeEntity(overrides: Partial<BaseEntity> = {}): BaseEntity {
+	return {
+		id: 'test-entity-1',
+		type: 'npc',
+		name: 'Test Entity',
+		description: 'A test entity',
+		tags: [],
+		fields: {},
+		links: [],
+		notes: '',
+		createdAt: new Date('2025-01-01'),
+		updatedAt: new Date('2025-01-10'),
+		metadata: {},
+		...overrides
+	};
+}
+
+function makeFieldDef(overrides: Partial<FieldDefinition> = {}): FieldDefinition {
+	return {
+		key: 'someField',
+		label: 'Some Field',
+		type: 'text',
+		required: false,
+		order: 1,
+		...overrides
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('isFieldPlayerVisible', () => {
+	// -----------------------------------------------------------------------
+	// 1. Cascade priority tests
+	// -----------------------------------------------------------------------
+	describe('Cascade priority', () => {
+		it('per-entity override wins over category default', () => {
+			// Category default says hidden, but entity override says visible
+			const entity = makeEntity({
+				metadata: { playerExportFieldOverrides: { occupation: true } }
+			});
+			const config: PlayerExportFieldConfig = {
+				fieldVisibility: { npc: { occupation: false } }
+			};
+			const fieldDef = makeFieldDef({ key: 'occupation' });
+
+			const result = isFieldPlayerVisible('occupation', fieldDef, 'npc', entity, config);
+			expect(result).toBe(true);
+		});
+
+		it('per-entity override wins over category default (reverse: override excludes)', () => {
+			// Category default says visible, but entity override says hidden
+			const entity = makeEntity({
+				metadata: { playerExportFieldOverrides: { occupation: false } }
+			});
+			const config: PlayerExportFieldConfig = {
+				fieldVisibility: { npc: { occupation: true } }
+			};
+			const fieldDef = makeFieldDef({ key: 'occupation' });
+
+			const result = isFieldPlayerVisible('occupation', fieldDef, 'npc', entity, config);
+			expect(result).toBe(false);
+		});
+
+		it('per-entity override wins over hardcoded rules (force-include notes)', () => {
+			// Hardcoded rule: 'notes' is always false
+			// But per-entity override says true
+			const entity = makeEntity({
+				metadata: { playerExportFieldOverrides: { notes: true } }
+			});
+			const fieldDef = makeFieldDef({ key: 'notes' });
+
+			const result = isFieldPlayerVisible('notes', fieldDef, 'npc', entity, undefined);
+			expect(result).toBe(true);
+		});
+
+		it('per-entity override wins over hardcoded rules (force-include hidden section field)', () => {
+			// Hardcoded rule: field with section='hidden' is false
+			// But per-entity override says true
+			const entity = makeEntity({
+				metadata: { playerExportFieldOverrides: { secret_motivation: true } }
+			});
+			const fieldDef = makeFieldDef({ key: 'secret_motivation', section: 'hidden' });
+
+			const result = isFieldPlayerVisible(
+				'secret_motivation',
+				fieldDef,
+				'npc',
+				entity,
+				undefined
+			);
+			expect(result).toBe(true);
+		});
+
+		it('per-entity override wins over hardcoded rules (force-include preparation on session)', () => {
+			const entity = makeEntity({
+				type: 'session',
+				metadata: { playerExportFieldOverrides: { preparation: true } }
+			});
+			const fieldDef = makeFieldDef({ key: 'preparation' });
+
+			const result = isFieldPlayerVisible(
+				'preparation',
+				fieldDef,
+				'session',
+				entity,
+				undefined
+			);
+			expect(result).toBe(true);
+		});
+
+		it('category default wins over hardcoded rules (include normally-hidden notes)', () => {
+			// Category default explicitly includes 'notes'
+			// Hardcoded rule would say false
+			const entity = makeEntity(); // no overrides
+			const config: PlayerExportFieldConfig = {
+				fieldVisibility: { npc: { notes: true } }
+			};
+			const fieldDef = makeFieldDef({ key: 'notes' });
+
+			const result = isFieldPlayerVisible('notes', fieldDef, 'npc', entity, config);
+			expect(result).toBe(true);
+		});
+
+		it('category default wins over hardcoded rules (exclude normally-visible field)', () => {
+			// Category default explicitly excludes 'occupation'
+			// Hardcoded rule would say true (normal visible field)
+			const entity = makeEntity();
+			const config: PlayerExportFieldConfig = {
+				fieldVisibility: { npc: { occupation: false } }
+			};
+			const fieldDef = makeFieldDef({ key: 'occupation' });
+
+			const result = isFieldPlayerVisible('occupation', fieldDef, 'npc', entity, config);
+			expect(result).toBe(false);
+		});
+
+		it('hardcoded rules used when no config and no overrides exist', () => {
+			const entity = makeEntity();
+			const fieldDef = makeFieldDef({ key: 'occupation' });
+
+			const result = isFieldPlayerVisible('occupation', fieldDef, 'npc', entity, undefined);
+			expect(result).toBe(true);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// 2. Per-entity override tests
+	// -----------------------------------------------------------------------
+	describe('Per-entity overrides', () => {
+		it('override explicitly includes a normally-hidden field (notes)', () => {
+			const entity = makeEntity({
+				metadata: { playerExportFieldOverrides: { notes: true } }
+			});
+			const fieldDef = makeFieldDef({ key: 'notes' });
+
+			const result = isFieldPlayerVisible('notes', fieldDef, 'npc', entity, undefined);
+			expect(result).toBe(true);
+		});
+
+		it('override explicitly excludes a normally-visible field', () => {
+			const entity = makeEntity({
+				metadata: { playerExportFieldOverrides: { occupation: false } }
+			});
+			const fieldDef = makeFieldDef({ key: 'occupation' });
+
+			const result = isFieldPlayerVisible('occupation', fieldDef, 'npc', entity, undefined);
+			expect(result).toBe(false);
+		});
+
+		it('override set to true for field with hidden section', () => {
+			const entity = makeEntity({
+				metadata: { playerExportFieldOverrides: { secret_plan: true } }
+			});
+			const fieldDef = makeFieldDef({ key: 'secret_plan', section: 'hidden' });
+
+			const result = isFieldPlayerVisible('secret_plan', fieldDef, 'npc', entity, undefined);
+			expect(result).toBe(true);
+		});
+
+		it('override set to false for field with hidden section (redundant but explicit)', () => {
+			const entity = makeEntity({
+				metadata: { playerExportFieldOverrides: { secret_plan: false } }
+			});
+			const fieldDef = makeFieldDef({ key: 'secret_plan', section: 'hidden' });
+
+			const result = isFieldPlayerVisible(
+				'secret_plan',
+				fieldDef,
+				'npc',
+				entity,
+				undefined
+			);
+			expect(result).toBe(false);
+		});
+
+		it('undefined override field falls through to category default', () => {
+			// Entity has overrides object, but not for this specific field
+			const entity = makeEntity({
+				metadata: { playerExportFieldOverrides: { other_field: true } }
+			});
+			const config: PlayerExportFieldConfig = {
+				fieldVisibility: { npc: { occupation: false } }
+			};
+			const fieldDef = makeFieldDef({ key: 'occupation' });
+
+			const result = isFieldPlayerVisible('occupation', fieldDef, 'npc', entity, config);
+			expect(result).toBe(false);
+		});
+
+		it('undefined override field falls through to hardcoded rules when no config', () => {
+			const entity = makeEntity({
+				metadata: { playerExportFieldOverrides: { other_field: true } }
+			});
+			const fieldDef = makeFieldDef({ key: 'notes' });
+
+			const result = isFieldPlayerVisible('notes', fieldDef, 'npc', entity, undefined);
+			expect(result).toBe(false);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// 3. Per-category default tests
+	// -----------------------------------------------------------------------
+	describe('Per-category defaults', () => {
+		it('category config includes a field -> true', () => {
+			const entity = makeEntity();
+			const config: PlayerExportFieldConfig = {
+				fieldVisibility: { npc: { background: true } }
+			};
+			const fieldDef = makeFieldDef({ key: 'background' });
+
+			const result = isFieldPlayerVisible('background', fieldDef, 'npc', entity, config);
+			expect(result).toBe(true);
+		});
+
+		it('category config excludes a field -> false', () => {
+			const entity = makeEntity();
+			const config: PlayerExportFieldConfig = {
+				fieldVisibility: { npc: { background: false } }
+			};
+			const fieldDef = makeFieldDef({ key: 'background' });
+
+			const result = isFieldPlayerVisible('background', fieldDef, 'npc', entity, config);
+			expect(result).toBe(false);
+		});
+
+		it('field not in category config falls through to hardcoded rules (visible field)', () => {
+			const entity = makeEntity();
+			const config: PlayerExportFieldConfig = {
+				fieldVisibility: { npc: { other_field: true } }
+			};
+			const fieldDef = makeFieldDef({ key: 'occupation' });
+
+			// 'occupation' not in config -> hardcoded: true (normal field)
+			const result = isFieldPlayerVisible('occupation', fieldDef, 'npc', entity, config);
+			expect(result).toBe(true);
+		});
+
+		it('field not in category config falls through to hardcoded rules (notes field)', () => {
+			const entity = makeEntity();
+			const config: PlayerExportFieldConfig = {
+				fieldVisibility: { npc: { other_field: true } }
+			};
+			const fieldDef = makeFieldDef({ key: 'notes' });
+
+			// 'notes' not in config -> hardcoded: false
+			const result = isFieldPlayerVisible('notes', fieldDef, 'npc', entity, config);
+			expect(result).toBe(false);
+		});
+
+		it('field not in category config falls through to hardcoded rules (hidden section)', () => {
+			const entity = makeEntity();
+			const config: PlayerExportFieldConfig = {
+				fieldVisibility: { npc: { other_field: true } }
+			};
+			const fieldDef = makeFieldDef({ key: 'secret_plan', section: 'hidden' });
+
+			// 'secret_plan' not in config -> hardcoded: false (hidden section)
+			const result = isFieldPlayerVisible('secret_plan', fieldDef, 'npc', entity, config);
+			expect(result).toBe(false);
+		});
+
+		it('unknown entity type not in config falls through to hardcoded rules', () => {
+			const entity = makeEntity({ type: 'custom_monster' });
+			const config: PlayerExportFieldConfig = {
+				fieldVisibility: { npc: { hitpoints: true } }
+			};
+			const fieldDef = makeFieldDef({ key: 'hitpoints' });
+
+			// 'custom_monster' not in config -> hardcoded: true (normal field)
+			const result = isFieldPlayerVisible(
+				'hitpoints',
+				fieldDef,
+				'custom_monster',
+				entity,
+				config
+			);
+			expect(result).toBe(true);
+		});
+
+		it('category config with multiple fields works correctly', () => {
+			const entity = makeEntity();
+			const config: PlayerExportFieldConfig = {
+				fieldVisibility: {
+					npc: {
+						occupation: true,
+						alignment: true,
+						secret_weakness: false,
+						background: true
+					}
+				}
+			};
+
+			expect(
+				isFieldPlayerVisible(
+					'occupation',
+					makeFieldDef({ key: 'occupation' }),
+					'npc',
+					entity,
+					config
+				)
+			).toBe(true);
+			expect(
+				isFieldPlayerVisible(
+					'secret_weakness',
+					makeFieldDef({ key: 'secret_weakness' }),
+					'npc',
+					entity,
+					config
+				)
+			).toBe(false);
+		});
+
+		it('different entity types have independent configs', () => {
+			const npcEntity = makeEntity({ type: 'npc' });
+			const locationEntity = makeEntity({ type: 'location' });
+			const config: PlayerExportFieldConfig = {
+				fieldVisibility: {
+					npc: { population: false },
+					location: { population: true }
+				}
+			};
+			const fieldDef = makeFieldDef({ key: 'population' });
+
+			expect(
+				isFieldPlayerVisible('population', fieldDef, 'npc', npcEntity, config)
+			).toBe(false);
+			expect(
+				isFieldPlayerVisible('population', fieldDef, 'location', locationEntity, config)
+			).toBe(true);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// 4. Hardcoded rules (backward compatibility)
+	// -----------------------------------------------------------------------
+	describe('Hardcoded rules (backward compatibility)', () => {
+		it("'notes' field -> false (unless overridden)", () => {
+			const entity = makeEntity();
+			const fieldDef = makeFieldDef({ key: 'notes' });
+
+			const result = isFieldPlayerVisible('notes', fieldDef, 'npc', entity, undefined);
+			expect(result).toBe(false);
+		});
+
+		it("field with section: 'hidden' -> false (unless overridden)", () => {
+			const entity = makeEntity();
+			const fieldDef = makeFieldDef({ key: 'secret_motivation', section: 'hidden' });
+
+			const result = isFieldPlayerVisible(
+				'secret_motivation',
+				fieldDef,
+				'npc',
+				entity,
+				undefined
+			);
+			expect(result).toBe(false);
+		});
+
+		it("'preparation' field for session type -> false (unless overridden)", () => {
+			const entity = makeEntity({ type: 'session' });
+			const fieldDef = makeFieldDef({ key: 'preparation' });
+
+			const result = isFieldPlayerVisible(
+				'preparation',
+				fieldDef,
+				'session',
+				entity,
+				undefined
+			);
+			expect(result).toBe(false);
+		});
+
+		it("'preparation' field for non-session type -> true", () => {
+			const entity = makeEntity({ type: 'npc' });
+			const fieldDef = makeFieldDef({ key: 'preparation' });
+
+			const result = isFieldPlayerVisible(
+				'preparation',
+				fieldDef,
+				'npc',
+				entity,
+				undefined
+			);
+			expect(result).toBe(true);
+		});
+
+		it('regular visible field -> true', () => {
+			const entity = makeEntity();
+			const fieldDef = makeFieldDef({ key: 'alignment' });
+
+			const result = isFieldPlayerVisible('alignment', fieldDef, 'npc', entity, undefined);
+			expect(result).toBe(true);
+		});
+
+		it('field with no FieldDefinition (undefined) -> true (safe default)', () => {
+			const entity = makeEntity();
+
+			const result = isFieldPlayerVisible(
+				'some_custom_field',
+				undefined,
+				'npc',
+				entity,
+				undefined
+			);
+			expect(result).toBe(true);
+		});
+
+		it("field with section other than 'hidden' -> true", () => {
+			const entity = makeEntity();
+			const fieldDef = makeFieldDef({ key: 'occupation', section: 'public' });
+
+			const result = isFieldPlayerVisible('occupation', fieldDef, 'npc', entity, undefined);
+			expect(result).toBe(true);
+		});
+
+		it('field with no section -> true', () => {
+			const entity = makeEntity();
+			const fieldDef = makeFieldDef({ key: 'occupation' });
+			// fieldDef has no section property set (undefined by default from makeFieldDef)
+
+			const result = isFieldPlayerVisible('occupation', fieldDef, 'npc', entity, undefined);
+			expect(result).toBe(true);
+		});
+
+		it("'notes' field on any entity type -> false", () => {
+			const types = ['npc', 'character', 'location', 'faction', 'item', 'session', 'deity'];
+			const fieldDef = makeFieldDef({ key: 'notes' });
+
+			for (const entityType of types) {
+				const entity = makeEntity({ type: entityType });
+				const result = isFieldPlayerVisible(
+					'notes',
+					fieldDef,
+					entityType,
+					entity,
+					undefined
+				);
+				expect(result).toBe(false);
+			}
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// 5. Edge cases
+	// -----------------------------------------------------------------------
+	describe('Edge cases', () => {
+		it('config is undefined -> backward compatible (notes hidden)', () => {
+			const entity = makeEntity();
+			const fieldDef = makeFieldDef({ key: 'notes' });
+
+			const result = isFieldPlayerVisible('notes', fieldDef, 'npc', entity, undefined);
+			expect(result).toBe(false);
+		});
+
+		it('config is undefined -> backward compatible (regular field visible)', () => {
+			const entity = makeEntity();
+			const fieldDef = makeFieldDef({ key: 'occupation' });
+
+			const result = isFieldPlayerVisible('occupation', fieldDef, 'npc', entity, undefined);
+			expect(result).toBe(true);
+		});
+
+		it('config.fieldVisibility is empty object -> backward compatible', () => {
+			const entity = makeEntity();
+			const config: PlayerExportFieldConfig = { fieldVisibility: {} };
+			const fieldDef = makeFieldDef({ key: 'notes' });
+
+			const result = isFieldPlayerVisible('notes', fieldDef, 'npc', entity, config);
+			expect(result).toBe(false);
+		});
+
+		it('config.fieldVisibility is empty object -> regular field still visible', () => {
+			const entity = makeEntity();
+			const config: PlayerExportFieldConfig = { fieldVisibility: {} };
+			const fieldDef = makeFieldDef({ key: 'occupation' });
+
+			const result = isFieldPlayerVisible('occupation', fieldDef, 'npc', entity, config);
+			expect(result).toBe(true);
+		});
+
+		it('entity.metadata has no playerExportFieldOverrides -> falls through', () => {
+			const entity = makeEntity({ metadata: { someOtherKey: 'value' } });
+			const fieldDef = makeFieldDef({ key: 'notes' });
+
+			const result = isFieldPlayerVisible('notes', fieldDef, 'npc', entity, undefined);
+			expect(result).toBe(false);
+		});
+
+		it('entity.metadata is empty object -> falls through', () => {
+			const entity = makeEntity({ metadata: {} });
+			const fieldDef = makeFieldDef({ key: 'occupation' });
+
+			const result = isFieldPlayerVisible('occupation', fieldDef, 'npc', entity, undefined);
+			expect(result).toBe(true);
+		});
+
+		it('entity.metadata.playerExportFieldOverrides is empty object -> falls through', () => {
+			const entity = makeEntity({
+				metadata: { playerExportFieldOverrides: {} }
+			});
+			const fieldDef = makeFieldDef({ key: 'notes' });
+
+			// Empty overrides object: 'notes' not listed, so falls through to hardcoded -> false
+			const result = isFieldPlayerVisible('notes', fieldDef, 'npc', entity, undefined);
+			expect(result).toBe(false);
+		});
+
+		it('entity.metadata.playerExportFieldOverrides is empty object -> regular field visible', () => {
+			const entity = makeEntity({
+				metadata: { playerExportFieldOverrides: {} }
+			});
+			const fieldDef = makeFieldDef({ key: 'occupation' });
+
+			const result = isFieldPlayerVisible('occupation', fieldDef, 'npc', entity, undefined);
+			expect(result).toBe(true);
+		});
+
+		it('handles built-in entity types correctly', () => {
+			const builtInTypes = [
+				'character',
+				'npc',
+				'location',
+				'faction',
+				'item',
+				'session',
+				'scene',
+				'deity',
+				'timeline_event',
+				'world_rule'
+			];
+			const entity = makeEntity();
+			const fieldDef = makeFieldDef({ key: 'some_field' });
+
+			for (const type of builtInTypes) {
+				const e = { ...entity, type };
+				const result = isFieldPlayerVisible('some_field', fieldDef, type, e, undefined);
+				expect(result).toBe(true);
+			}
+		});
+
+		it('handles custom entity types', () => {
+			const entity = makeEntity({ type: 'custom_monster' });
+			const fieldDef = makeFieldDef({ key: 'hit_dice' });
+
+			const result = isFieldPlayerVisible(
+				'hit_dice',
+				fieldDef,
+				'custom_monster',
+				entity,
+				undefined
+			);
+			expect(result).toBe(true);
+		});
+
+		it('handles custom entity type with config', () => {
+			const entity = makeEntity({ type: 'custom_vehicle' });
+			const config: PlayerExportFieldConfig = {
+				fieldVisibility: { custom_vehicle: { speed: true, secret_weapon: false } }
+			};
+
+			expect(
+				isFieldPlayerVisible(
+					'speed',
+					makeFieldDef({ key: 'speed' }),
+					'custom_vehicle',
+					entity,
+					config
+				)
+			).toBe(true);
+			expect(
+				isFieldPlayerVisible(
+					'secret_weapon',
+					makeFieldDef({ key: 'secret_weapon' }),
+					'custom_vehicle',
+					entity,
+					config
+				)
+			).toBe(false);
+		});
+
+		it('per-entity override with config undefined still works', () => {
+			const entity = makeEntity({
+				metadata: { playerExportFieldOverrides: { notes: true } }
+			});
+			const fieldDef = makeFieldDef({ key: 'notes' });
+
+			const result = isFieldPlayerVisible('notes', fieldDef, 'npc', entity, undefined);
+			expect(result).toBe(true);
+		});
+
+		it('category config entry for entity type is empty object -> falls through to hardcoded', () => {
+			const entity = makeEntity();
+			const config: PlayerExportFieldConfig = {
+				fieldVisibility: { npc: {} }
+			};
+			const fieldDef = makeFieldDef({ key: 'notes' });
+
+			// npc config exists but is empty -> 'notes' not in config -> hardcoded -> false
+			const result = isFieldPlayerVisible('notes', fieldDef, 'npc', entity, config);
+			expect(result).toBe(false);
+		});
+
+		it('full cascade: override > category > hardcoded for same field', () => {
+			// All three levels set for 'secret_motivation':
+			// Hardcoded: hidden section -> false
+			// Category: true
+			// Entity override: false
+			// Expected: entity override wins -> false
+			const entity = makeEntity({
+				metadata: { playerExportFieldOverrides: { secret_motivation: false } }
+			});
+			const config: PlayerExportFieldConfig = {
+				fieldVisibility: { npc: { secret_motivation: true } }
+			};
+			const fieldDef = makeFieldDef({ key: 'secret_motivation', section: 'hidden' });
+
+			const result = isFieldPlayerVisible(
+				'secret_motivation',
+				fieldDef,
+				'npc',
+				entity,
+				config
+			);
+			expect(result).toBe(false);
+		});
+
+		it('full cascade: no override, category > hardcoded', () => {
+			// Hardcoded: hidden section -> false
+			// Category: true
+			// No entity override
+			// Expected: category wins -> true
+			const entity = makeEntity();
+			const config: PlayerExportFieldConfig = {
+				fieldVisibility: { npc: { secret_motivation: true } }
+			};
+			const fieldDef = makeFieldDef({ key: 'secret_motivation', section: 'hidden' });
+
+			const result = isFieldPlayerVisible(
+				'secret_motivation',
+				fieldDef,
+				'npc',
+				entity,
+				config
+			);
+			expect(result).toBe(true);
+		});
+
+		it('full cascade: no override, no category -> hardcoded', () => {
+			// Hardcoded: hidden section -> false
+			// No category config
+			// No entity override
+			// Expected: hardcoded -> false
+			const entity = makeEntity();
+			const fieldDef = makeFieldDef({ key: 'secret_motivation', section: 'hidden' });
+
+			const result = isFieldPlayerVisible(
+				'secret_motivation',
+				fieldDef,
+				'npc',
+				entity,
+				undefined
+			);
+			expect(result).toBe(false);
+		});
+
+		it('preparation field on session with category override to include it', () => {
+			const entity = makeEntity({ type: 'session' });
+			const config: PlayerExportFieldConfig = {
+				fieldVisibility: { session: { preparation: true } }
+			};
+			const fieldDef = makeFieldDef({ key: 'preparation' });
+
+			const result = isFieldPlayerVisible(
+				'preparation',
+				fieldDef,
+				'session',
+				entity,
+				config
+			);
+			expect(result).toBe(true);
+		});
+
+		it('preparation field on session with category override to exclude it (redundant)', () => {
+			const entity = makeEntity({ type: 'session' });
+			const config: PlayerExportFieldConfig = {
+				fieldVisibility: { session: { preparation: false } }
+			};
+			const fieldDef = makeFieldDef({ key: 'preparation' });
+
+			const result = isFieldPlayerVisible(
+				'preparation',
+				fieldDef,
+				'session',
+				entity,
+				config
+			);
+			expect(result).toBe(false);
+		});
+	});
+});

--- a/src/lib/services/playerFieldVisibility.ts
+++ b/src/lib/services/playerFieldVisibility.ts
@@ -1,0 +1,80 @@
+/**
+ * Player Field Visibility Service
+ * GitHub Issue #436: Data model for player export field visibility configuration
+ *
+ * Resolves whether a specific entity field should be included in a player export
+ * using a three-level cascade:
+ *   1. Per-entity override (entity.metadata.playerExportFieldOverrides[fieldKey])
+ *   2. Per-category default (config.fieldVisibility[entityType][fieldKey])
+ *   3. Hardcoded rules (notes=false, hidden section=false, preparation on sessions=false, else true)
+ */
+
+import type { BaseEntity, FieldDefinition } from '$lib/types/entities';
+import type { PlayerExportFieldConfig, PlayerExportFieldOverrides } from '$lib/types/playerFieldVisibility';
+import { PLAYER_EXPORT_FIELD_OVERRIDES_KEY } from '$lib/types/playerFieldVisibility';
+
+/**
+ * Determine whether a field should be visible in a player export.
+ *
+ * @param fieldKey - The key of the field to check
+ * @param fieldDef - The field definition (undefined for orphaned/unknown fields)
+ * @param entityType - The entity type string
+ * @param entity - The entity instance (for per-entity overrides in metadata)
+ * @param config - The campaign-level field visibility config (undefined = no config)
+ * @returns true if the field should be included in the player export
+ */
+export function isFieldPlayerVisible(
+	fieldKey: string,
+	fieldDef: FieldDefinition | undefined,
+	entityType: string,
+	entity: BaseEntity,
+	config: PlayerExportFieldConfig | undefined
+): boolean {
+	// Level 1: Per-entity override (highest priority)
+	const overrides = entity.metadata?.[PLAYER_EXPORT_FIELD_OVERRIDES_KEY] as
+		| PlayerExportFieldOverrides
+		| undefined;
+
+	if (overrides && fieldKey in overrides) {
+		return overrides[fieldKey];
+	}
+
+	// Level 2: Per-category default
+	if (config?.fieldVisibility) {
+		const categoryConfig = config.fieldVisibility[entityType];
+		if (categoryConfig && fieldKey in categoryConfig) {
+			return categoryConfig[fieldKey];
+		}
+	}
+
+	// Level 3: Hardcoded rules (backward compatibility)
+	return applyHardcodedRules(fieldKey, fieldDef, entityType);
+}
+
+/**
+ * Apply the original hardcoded field visibility rules.
+ * This preserves backward compatibility when no config or overrides exist.
+ */
+function applyHardcodedRules(
+	fieldKey: string,
+	fieldDef: FieldDefinition | undefined,
+	entityType: string
+): boolean {
+	// 'notes' field is always hidden
+	if (fieldKey === 'notes') {
+		return false;
+	}
+
+	// Fields with section: 'hidden' are hidden
+	if (fieldDef?.section === 'hidden') {
+		return false;
+	}
+
+	// 'preparation' field on session entities is hidden
+	if (fieldKey === 'preparation' && entityType === 'session') {
+		return false;
+	}
+
+	// Everything else is visible by default
+	return true;
+}

--- a/src/lib/types/campaign.ts
+++ b/src/lib/types/campaign.ts
@@ -6,6 +6,7 @@ import type {
 	FieldDefinition
 } from './entities';
 import type { ChatMessage } from './ai';
+import type { PlayerExportFieldConfig } from './playerFieldVisibility';
 import type { CombatSession } from './combat';
 import type { MontageSession } from './montage';
 import type { NegotiationSession } from './negotiation';
@@ -92,6 +93,7 @@ export interface CampaignMetadata {
 	fieldTemplates?: FieldTemplate[]; // User-created field templates (Issue #210)
 	settings: CampaignSettings;
 	tableMap?: TableMap; // Visual seating chart for in-person sessions (Issue #318)
+	playerExportFieldConfig?: PlayerExportFieldConfig; // Per-category field visibility for player exports (Issue #436)
 }
 
 // For backup/restore

--- a/src/lib/types/playerFieldVisibility.ts
+++ b/src/lib/types/playerFieldVisibility.ts
@@ -1,0 +1,36 @@
+/**
+ * Player Export Field Visibility Configuration Types
+ * GitHub Issue #436: Data model for player export field visibility configuration
+ *
+ * Provides per-category default visibility and per-entity override support
+ * for controlling which fields appear in player exports.
+ */
+
+/**
+ * Per-category field visibility defaults.
+ *
+ * Stored at the campaign level (in CampaignMetadata).
+ * Controls which fields are visible in player exports for each entity type.
+ *
+ * fieldVisibility is a nested record:
+ *   entityType -> fieldKey -> visible (true/false)
+ *
+ * Fields not listed fall through to hardcoded rules.
+ */
+export interface PlayerExportFieldConfig {
+	fieldVisibility: Record<string, Record<string, boolean>>;
+}
+
+/**
+ * Metadata key for per-entity field visibility overrides.
+ *
+ * Stored in entity.metadata.playerExportFieldOverrides as Record<string, boolean>.
+ * key = field key, value = true (force include) / false (force exclude).
+ * Fields not listed fall back to category default, then hardcoded rules.
+ */
+export const PLAYER_EXPORT_FIELD_OVERRIDES_KEY = 'playerExportFieldOverrides' as const;
+
+/**
+ * Type for the per-entity overrides stored in entity.metadata.
+ */
+export type PlayerExportFieldOverrides = Record<string, boolean>;


### PR DESCRIPTION
## Summary
- Implements configurable three-level cascade for player export field visibility: per-entity overrides → per-category defaults → hardcoded rules
- Adds Settings UI (PlayerExportFieldSettings) for DMs to configure per-category field visibility defaults
- Adds per-entity FieldVisibilityToggle component with 3-state cycling (inherit/include/exclude)
- Updates player export service to pass field visibility config from campaign metadata
- Full integration with custom entity types and additional fields on built-in types

Closes #434, #436, #437, #438, #439, #440

### Files Added (10)
- `src/lib/types/playerFieldVisibility.ts` - Type definitions
- `src/lib/services/playerFieldVisibility.ts` - Core cascade resolution
- `src/lib/services/playerExportFieldConfigService.ts` - Config CRUD service
- `src/lib/services/entityFieldVisibilityService.ts` - Per-entity override helpers
- `src/lib/components/entity/FieldVisibilityToggle.svelte` - Toggle UI component
- `src/lib/components/settings/PlayerExportFieldSettings.svelte` - Settings UI
- 4 test files (239 tests total)

### Files Modified (5)
- `src/lib/types/campaign.ts` - Added playerExportFieldConfig to CampaignMetadata
- `src/lib/services/playerExportFilterService.ts` - Config-aware field filtering
- `src/lib/services/playerExportService.ts` - Pass config from campaign metadata
- `src/lib/components/settings/index.ts` - Barrel export

## Test plan
- [x] 49 tests for playerFieldVisibility cascade logic
- [x] 36 tests for playerExportFieldConfigService CRUD operations
- [x] 30 tests for entityFieldVisibilityService override helpers
- [x] 102 tests for updated playerExportFilterService (97 existing + 27 new)
- [x] 22 integration tests for custom field compatibility
- [x] Full test suite: 12,389 passed, 257 files
- [x] TypeScript check passes (2 pre-existing errors only)
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)