### PR TITLE
chore: bump version to v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.1] - 2026-02-12
+
 ### Breaking Changes
 
 **Respite Activities Refactored as Independent Entities (Issue #493)**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "director-assist",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- Version bump to v1.8.1 for release
- Updates CHANGELOG.md with v1.8.1 release date

🤖 Generated with [Claude Code](https://claude.com/claude-code)