### PR TITLE
fix: modal dismissal bug in settings modals

### DIFF
--- a/src/lib/components/settings/ForgeSteelImportModal.svelte
+++ b/src/lib/components/settings/ForgeSteelImportModal.svelte
@@ -85,6 +85,7 @@
 
 	function handleCancel() {
 		if (!isImporting) {
+			open = false;
 			oncancel?.();
 		}
 	}

--- a/src/lib/components/settings/PlayerExportModal.svelte
+++ b/src/lib/components/settings/PlayerExportModal.svelte
@@ -76,6 +76,7 @@
 
 	function handleClose() {
 		if (!isExporting) {
+			open = false;
 			onclose?.();
 		}
 	}

--- a/src/lib/components/settings/PublishPlayerDataModal.svelte
+++ b/src/lib/components/settings/PublishPlayerDataModal.svelte
@@ -64,6 +64,7 @@
 
 	function handleClose() {
 		if (!isPublishing) {
+			open = false;
 			onclose?.();
 		}
 	}

--- a/src/lib/components/settings/modalDismissal.test.ts
+++ b/src/lib/components/settings/modalDismissal.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Regression test: Modal dismissal bug prevention
+ *
+ * Modals with `$bindable(false)` open prop must set `open = false` in their
+ * close handler before calling the callback. Without this, the $effect that
+ * syncs `open` with dialogElement.showModal()/close() never fires, and the
+ * modal stays open.
+ *
+ * This test statically analyzes modal source files to ensure the pattern is
+ * followed, preventing regression of the bug fixed in all three settings modals.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Find the close/cancel handler function in a modal source and verify
+ * it sets `open = false` before calling the callback.
+ */
+function extractCloseHandlers(source: string): { name: string; body: string }[] {
+	const handlers: { name: string; body: string }[] = [];
+	// Match function declarations like: function handleClose() { ... }
+	// or function handleCancel() { ... }
+	const funcRegex = /function\s+(handle(?:Close|Cancel))\s*\([^)]*\)\s*\{/g;
+	let match;
+
+	while ((match = funcRegex.exec(source)) !== null) {
+		const funcName = match[1];
+		const startIndex = match.index + match[0].length;
+
+		// Extract the function body by counting braces
+		let braceCount = 1;
+		let i = startIndex;
+		while (i < source.length && braceCount > 0) {
+			if (source[i] === '{') braceCount++;
+			if (source[i] === '}') braceCount--;
+			i++;
+		}
+
+		const body = source.slice(startIndex, i - 1);
+		handlers.push({ name: funcName, body });
+	}
+
+	return handlers;
+}
+
+describe('Modal dismissal pattern', () => {
+	const settingsDir = resolve(__dirname);
+
+	// Find all .svelte files in the settings directory that use $bindable open
+	const modalFiles = readdirSync(settingsDir)
+		.filter((file) => file.endsWith('.svelte'))
+		.filter((file) => {
+			const content = readFileSync(resolve(settingsDir, file), 'utf-8');
+			return content.includes('$bindable(false)') && content.includes('open');
+		});
+
+	it('should find at least 3 modals with $bindable open prop', () => {
+		expect(modalFiles.length).toBeGreaterThanOrEqual(3);
+	});
+
+	for (const file of modalFiles) {
+		describe(file, () => {
+			const filePath = resolve(settingsDir, file);
+			const source = readFileSync(filePath, 'utf-8');
+			const handlers = extractCloseHandlers(source);
+
+			it('should have a handleClose or handleCancel function', () => {
+				expect(handlers.length).toBeGreaterThan(0);
+			});
+
+			for (const handler of handlers) {
+				it(`${handler.name}() should set open = false`, () => {
+					expect(handler.body).toContain('open = false');
+				});
+			}
+		});
+	}
+});


### PR DESCRIPTION
## Summary
- **Fixed** PublishPlayerDataModal, PlayerExportModal, and ForgeSteelImportModal not dismissing when clicking X, Cancel, or after completing their action
- **Root cause**: close handlers called the callback but never set `open = false`, so the `$effect` syncing open state with `dialogElement.close()` never fired
- **Added** regression test (`modalDismissal.test.ts`) that statically validates all `$bindable` modals in the settings directory set `open = false` in their close handlers

## Test plan
- [x] `npm run check` — 0 errors
- [x] `npx vitest run` — 7/7 new tests pass
- [ ] Manual: Open PublishPlayerDataModal → click X → modal dismisses
- [ ] Manual: Open PlayerExportModal → click Cancel → modal dismisses
- [ ] Manual: Open ForgeSteelImportModal → click Cancel → modal dismisses

🤖 Generated with [Claude Code](https://claude.com/claude-code)