### PR TITLE
fix: add dark mode compliance fixes for text colors

### DIFF
--- a/src/lib/components/narrative/NarrativeTimeline.svelte
+++ b/src/lib/components/narrative/NarrativeTimeline.svelte
@@ -59,7 +59,7 @@
 		<!-- Empty state -->
 		<div class="flex flex-col items-center justify-center py-12 text-center">
 			<Calendar class="mb-4 h-12 w-12 text-gray-400" aria-hidden="true" />
-			<p class="text-lg font-medium text-gray-900">No events yet</p>
+			<p class="text-lg font-medium text-gray-900 dark:text-gray-100">No events yet</p>
 			<p class="mt-1 text-sm text-gray-500">Timeline events will appear here as they are created</p>
 		</div>
 	{:else if sortedEvents.length > 0}

--- a/src/lib/components/narrative/TimelineEvent.svelte
+++ b/src/lib/components/narrative/TimelineEvent.svelte
@@ -108,7 +108,7 @@
 	<div class="flex-1 pb-8">
 		<!-- Event header -->
 		<div class="mb-2">
-			<h3 class="text-lg font-semibold text-gray-900">{event.name}</h3>
+			<h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">{event.name}</h3>
 			{#if event.createdAt}
 				<p class="text-sm text-gray-500">{formatDate(event.createdAt)}</p>
 			{/if}
@@ -116,7 +116,7 @@
 
 		<!-- Event description -->
 		{#if event.description && event.description.trim() !== ''}
-			<p class="mb-2 text-sm text-gray-700 line-clamp-3">{event.description}</p>
+			<p class="mb-2 text-sm text-gray-700 dark:text-gray-300 line-clamp-3">{event.description}</p>
 		{/if}
 
 		<!-- Outcome -->
@@ -130,7 +130,7 @@
 				<button
 					type="button"
 					onclick={handleViewSource}
-					class="rounded border border-gray-300 bg-white px-3 py-1 text-sm font-medium text-gray-700 hover:bg-gray-50"
+					class="rounded border border-gray-300 bg-white px-3 py-1 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:hover:bg-gray-700"
 				>
 					View Source
 				</button>
@@ -140,7 +140,7 @@
 				<button
 					type="button"
 					onclick={handleLink}
-					class="rounded border border-gray-300 bg-white px-3 py-1 text-sm font-medium text-gray-700 hover:bg-gray-50"
+					class="rounded border border-gray-300 bg-white px-3 py-1 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:hover:bg-gray-700"
 				>
 					Link
 				</button>

--- a/src/lib/components/negotiation/NegotiationSetup.svelte
+++ b/src/lib/components/negotiation/NegotiationSetup.svelte
@@ -179,7 +179,7 @@
 	<div class="space-y-4">
 		<!-- Name -->
 		<div>
-			<label for="name" class="block text-sm font-medium text-gray-700">
+			<label for="name" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
 				Negotiation Name <span class="text-red-600">*</span>
 			</label>
 			<input
@@ -198,7 +198,7 @@
 
 		<!-- NPC Name -->
 		<div>
-			<label for="npc-name" class="block text-sm font-medium text-gray-700">
+			<label for="npc-name" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
 				NPC Name <span class="text-red-600">*</span>
 			</label>
 			<input
@@ -217,7 +217,7 @@
 
 		<!-- Description -->
 		<div>
-			<label for="description" class="block text-sm font-medium text-gray-700">
+			<label for="description" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
 				Description
 			</label>
 			<textarea
@@ -230,7 +230,7 @@
 
 		<!-- Starting Interest -->
 		<div>
-			<label for="interest" class="block text-sm font-medium text-gray-700">
+			<label for="interest" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
 				Starting Interest
 			</label>
 			<select
@@ -248,7 +248,7 @@
 
 		<!-- Starting Patience -->
 		<div>
-			<label for="patience" class="block text-sm font-medium text-gray-700">
+			<label for="patience" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
 				Starting Patience
 			</label>
 			<select
@@ -268,7 +268,7 @@
 
 	<!-- Motivations Section -->
 	<fieldset class="space-y-3">
-		<legend class="text-lg font-semibold text-gray-900">Motivations</legend>
+		<legend class="text-lg font-semibold text-gray-900 dark:text-gray-100">Motivations</legend>
 
 		{#if motivations.length === 0}
 			<p class="text-sm text-gray-500">No motivations added yet.</p>
@@ -280,7 +280,7 @@
 						class="flex items-center gap-3 rounded-lg border border-gray-200 bg-white p-3"
 					>
 						<div class="flex-1 space-y-2">
-							<label for="motivation-type-{index}" class="block text-sm font-medium text-gray-700">
+							<label for="motivation-type-{index}" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
 								Motivation Type
 							</label>
 							<select
@@ -302,7 +302,7 @@
 								bind:checked={motivation.isKnown}
 								class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
 							/>
-							<label for="motivation-known-{index}" class="text-sm text-gray-700">
+							<label for="motivation-known-{index}" class="text-sm text-gray-700 dark:text-gray-300">
 								Known to heroes
 							</label>
 						</div>
@@ -336,7 +336,7 @@
 
 	<!-- Pitfalls Section -->
 	<fieldset class="space-y-3">
-		<legend class="text-lg font-semibold text-gray-900">Pitfalls</legend>
+		<legend class="text-lg font-semibold text-gray-900 dark:text-gray-100">Pitfalls</legend>
 
 		{#if pitfalls.length === 0}
 			<p class="text-sm text-gray-500">No pitfalls added yet.</p>
@@ -348,7 +348,7 @@
 						class="flex items-center gap-3 rounded-lg border border-red-200 bg-red-50 p-3"
 					>
 						<div class="flex-1 space-y-2">
-							<label for="pitfall-type-{index}" class="block text-sm font-medium text-gray-700">
+							<label for="pitfall-type-{index}" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
 								Pitfall Type
 							</label>
 							<select
@@ -370,7 +370,7 @@
 								bind:checked={pitfall.isKnown}
 								class="h-4 w-4 rounded border-gray-300 text-red-600 focus:ring-red-500"
 							/>
-							<label for="pitfall-known-{index}" class="text-sm text-gray-700">
+							<label for="pitfall-known-{index}" class="text-sm text-gray-700 dark:text-gray-300">
 								Known to heroes
 							</label>
 						</div>
@@ -407,7 +407,7 @@
 			<button
 				type="button"
 				onclick={handleCancel}
-				class="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+				class="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:hover:bg-gray-700"
 			>
 				Cancel
 			</button>

--- a/src/routes/entities/[type]/[id]/edit/+page.svelte
+++ b/src/routes/entities/[type]/[id]/edit/+page.svelte
@@ -1180,7 +1180,7 @@
 								<input
 									id={field.key}
 									type="checkbox"
-									class="w-4 h-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500 dark:border-slate-600 dark:bg-slate-700 dark:checked:bg-slate-600"
+									class="w-4 h-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500 dark:border-slate-600 dark:bg-slate-700 dark:checked:bg-slate-600 dark:text-slate-100"
 									checked={(fields[field.key] as boolean) ?? false}
 									onchange={(e) => updateField(field.key, e.currentTarget.checked)}
 								/>
@@ -1194,7 +1194,7 @@
 									<label class="flex items-center gap-2 cursor-pointer">
 										<input
 											type="checkbox"
-											class="w-4 h-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500 dark:border-slate-600 dark:bg-slate-700 dark:checked:bg-slate-600"
+											class="w-4 h-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500 dark:border-slate-600 dark:bg-slate-700 dark:checked:bg-slate-600 dark:text-slate-100"
 											checked={Array.isArray(fields[field.key]) &&
 												(fields[field.key] as string[]).includes(option)}
 											onchange={(e) => {
@@ -1544,7 +1544,7 @@
 					<label class="flex items-center gap-2 cursor-pointer">
 						<input
 							type="checkbox"
-							class="w-4 h-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500 dark:border-slate-600 dark:bg-slate-700 dark:checked:bg-slate-600"
+							class="w-4 h-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500 dark:border-slate-600 dark:bg-slate-700 dark:checked:bg-slate-600 dark:text-slate-100"
 							checked={playerVisible === false}
 							onchange={(e) => {
 								playerVisible = e.currentTarget.checked ? false : undefined;

--- a/src/routes/entities/[type]/new/+page.svelte
+++ b/src/routes/entities/[type]/new/+page.svelte
@@ -841,7 +841,7 @@
 							<input
 								id={field.key}
 								type="checkbox"
-								class="w-4 h-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500 dark:border-slate-600 dark:bg-slate-700 dark:checked:bg-slate-600"
+								class="w-4 h-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500 dark:border-slate-600 dark:bg-slate-700 dark:checked:bg-slate-600 dark:text-slate-100"
 								checked={(fields[field.key] as boolean) ?? false}
 								onchange={(e) => updateField(field.key, e.currentTarget.checked)}
 							/>
@@ -855,7 +855,7 @@
 								<label class="flex items-center gap-2 cursor-pointer">
 									<input
 										type="checkbox"
-										class="w-4 h-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500 dark:border-slate-600 dark:bg-slate-700 dark:checked:bg-slate-600"
+										class="w-4 h-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500 dark:border-slate-600 dark:bg-slate-700 dark:checked:bg-slate-600 dark:text-slate-100"
 										checked={Array.isArray(fields[field.key]) &&
 											(fields[field.key] as string[]).includes(option)}
 										onchange={(e) => {
@@ -1195,7 +1195,7 @@
 					<input
 						id="player-visibility-checkbox"
 						type="checkbox"
-						class="w-4 h-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500 dark:border-slate-600 dark:bg-slate-700 dark:checked:bg-slate-600"
+						class="w-4 h-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500 dark:border-slate-600 dark:bg-slate-700 dark:checked:bg-slate-600 dark:text-slate-100"
 						checked={playerVisible === false}
 						onchange={(e) => {
 							playerVisible = e.currentTarget.checked ? false : undefined;

--- a/src/tests/darkModeCompliance.test.ts
+++ b/src/tests/darkModeCompliance.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Dark Mode Compliance Test (Regression Prevention)
+ *
+ * Static analysis test that scans all .svelte files for dark text color violations.
+ * Any use of text-gray-700, text-gray-800, text-gray-900, text-black,
+ * text-slate-700, text-slate-800, or text-slate-900 WITHOUT a corresponding
+ * dark:text-* on the same line is flagged as a violation.
+ *
+ * This prevents future regressions where developers add dark text classes
+ * but forget the dark mode counterpart, causing unreadable text on dark backgrounds.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Standalone dark text classes that require a dark: counterpart.
+// Uses negative lookbehind to exclude pseudo-class prefixed variants like
+// hover:text-slate-700 (which need dark:hover:text-*, not dark:text-*).
+const DARK_TEXT_PATTERN =
+	/(?<![\w-]:)text-(?:gray-(?:700|800|900)|black|slate-(?:700|800|900))\b/;
+
+// The corresponding dark mode fix
+const DARK_MODE_TEXT_PATTERN = /\bdark:text-/;
+
+interface Violation {
+	file: string;
+	line: number;
+	content: string;
+}
+
+/**
+ * Recursively find all .svelte files under a directory
+ */
+function findSvelteFiles(dir: string): string[] {
+	const results: string[] = [];
+	const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+	for (const entry of entries) {
+		const fullPath = path.join(dir, entry.name);
+		if (entry.isDirectory() && entry.name !== 'node_modules' && entry.name !== '.svelte-kit') {
+			results.push(...findSvelteFiles(fullPath));
+		} else if (entry.isFile() && entry.name.endsWith('.svelte')) {
+			results.push(fullPath);
+		}
+	}
+
+	return results;
+}
+
+/**
+ * Strip <style> blocks and HTML comments from content,
+ * preserving line numbers by replacing removed content with empty lines.
+ */
+function stripStyleAndComments(content: string): string {
+	// Replace <style>...</style> blocks with empty lines
+	let result = content.replace(/<style[\s\S]*?<\/style>/g, (match) => {
+		return match.replace(/[^\n]/g, '');
+	});
+
+	// Replace HTML comments with empty lines
+	result = result.replace(/<!--[\s\S]*?-->/g, (match) => {
+		return match.replace(/[^\n]/g, '');
+	});
+
+	return result;
+}
+
+/**
+ * Scan a single file for dark mode text violations
+ */
+function scanFile(filePath: string): Violation[] {
+	const content = fs.readFileSync(filePath, 'utf-8');
+	const stripped = stripStyleAndComments(content);
+	const lines = stripped.split('\n');
+	const violations: Violation[] = [];
+
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i];
+		if (DARK_TEXT_PATTERN.test(line) && !DARK_MODE_TEXT_PATTERN.test(line)) {
+			violations.push({
+				file: filePath,
+				line: i + 1,
+				content: content.split('\n')[i].trim()
+			});
+		}
+	}
+
+	return violations;
+}
+
+// Scan all svelte files
+const srcDir = path.resolve(__dirname, '..');
+const svelteFiles = findSvelteFiles(srcDir);
+const allViolations: Map<string, Violation[]> = new Map();
+
+for (const file of svelteFiles) {
+	const violations = scanFile(file);
+	if (violations.length > 0) {
+		allViolations.set(file, violations);
+	}
+}
+
+describe('Dark Mode Text Compliance', () => {
+	it('should find .svelte files to scan', () => {
+		expect(svelteFiles.length).toBeGreaterThan(0);
+	});
+
+	// Generate one test per file that has violations
+	for (const file of svelteFiles) {
+		const relativePath = path.relative(srcDir, file);
+		const violations = allViolations.get(file) || [];
+
+		it(`${relativePath} should have no dark text classes without dark: variants`, () => {
+			if (violations.length > 0) {
+				const message = violations
+					.map((v) => `  Line ${v.line}: ${v.content}`)
+					.join('\n');
+				expect.fail(
+					`Found ${violations.length} dark mode violation(s) in ${relativePath}:\n${message}\n\n` +
+						'Each dark text class (text-gray-700, text-gray-800, text-gray-900, text-black, ' +
+						'text-slate-700, text-slate-800, text-slate-900) needs a corresponding dark:text-* variant on the same line.'
+				);
+			}
+		});
+	}
+
+	it('should have zero total violations across all files', () => {
+		const totalViolations = Array.from(allViolations.values()).reduce(
+			(sum, v) => sum + v.length,
+			0
+		);
+		if (totalViolations > 0) {
+			const summary = Array.from(allViolations.entries())
+				.map(([file, violations]) => {
+					const relativePath = path.relative(srcDir, file);
+					return `${relativePath}: ${violations.length} violation(s)`;
+				})
+				.join('\n  ');
+			expect.fail(
+				`Found ${totalViolations} total dark mode violation(s):\n  ${summary}`
+			);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

This PR fixes dark text visibility issues in dark mode across multiple components and adds a regression prevention test.

### Changes

**Components Fixed:**
- NegotiationSetup.svelte: 12 text color fixes (labels, legends, buttons)
- NarrativeTimeline.svelte: 1 empty state text fix
- TimelineEvent.svelte: 4 heading and description text fixes
- Entity edit/new pages: 6 checkbox accent color fixes

**New Test:**
- darkModeCompliance.test.ts: Static analysis test that scans .svelte files for dark text classes without dark: variants to prevent future regressions

### Type
- Type: Bug Fix
- Breaking Changes: No

## Testing
- Static analysis test added and passing
- Manual testing confirms text is now visible in dark mode across all fixed components