### PR TITLE
chore: release v1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.1] - 2026-02-12
+
+### Fixed
+
+- **Dark mode text visibility** — Added `dark:text-*` variants to 23 elements across NegotiationSetup, NarrativeTimeline, TimelineEvent, and entity form pages that were unreadable in dark mode (#517)
+- **Modal dismissal bug** — Fixed settings modals not dismissing correctly (#515)
+
+### Added
+
+- **Player export field visibility UI** — Wired up field visibility controls for player export configuration (#516)
+- **Dark mode compliance test** — Static analysis regression test scans all `.svelte` files for dark text classes missing `dark:` counterparts
+
 ## [1.9.0] - 2026-02-12
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "director-assist",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- Version bump to v1.9.1
- Changelog update for patch release

## Changes since v1.9.0
- **#517** fix: dark mode text visibility + regression prevention test
- **#516** feat: player export field visibility UI
- **#515** fix: modal dismissal bug in settings modals

## Test plan
- [x] `npm run check` — 0 errors
- [x] `npx vitest run` — 12,999 tests pass
- [x] `npm run build` — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)