### PR TITLE
fix: make token indicator prominent on combatant card (#526)

### DIFF
--- a/src/lib/components/combat/CombatantCard.svelte
+++ b/src/lib/components/combat/CombatantCard.svelte
@@ -88,21 +88,21 @@
 	<div class="flex items-start justify-between gap-2 mb-3">
 		<div class="flex-1 min-w-0">
 			<div class="flex items-center gap-2">
-				<h3
-					class="font-semibold text-slate-900 dark:text-white truncate ellipsis"
-					data-testid="combatant-name"
-				>
-					{combatant.name}
-				</h3>
 				{#if combatant.tokenIndicator}
 					<span
-						class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-purple-100 dark:bg-purple-900 text-purple-800 dark:text-purple-200"
+						class="flex-shrink-0 inline-flex items-center justify-center w-8 h-8 rounded-full text-sm font-bold bg-purple-600 dark:bg-purple-500 text-white"
 						data-testid="token-indicator-badge"
 						aria-label={`Token ${combatant.tokenIndicator}`}
 					>
 						{combatant.tokenIndicator}
 					</span>
 				{/if}
+				<h3
+					class="font-semibold text-slate-900 dark:text-white truncate ellipsis"
+					data-testid="combatant-name"
+				>
+					{combatant.name}
+				</h3>
 				{#if isCurrent}
 					<span
 						class="text-blue-600 dark:text-blue-400"


### PR DESCRIPTION
## Summary

- Moved token indicator **before** the combatant name so it's the first thing visible
- Changed from tiny `text-xs` purple badge to a bold, high-contrast 32px circle with white text on purple background
- Token indicator is now immediately recognizable at a glance for matching physical miniatures

Fixes #526

## Test plan

- [x] All 350 combat component tests pass
- [x] 0 TypeScript errors
- [x] Visual: token indicator displays as a prominent circle badge before the name

🤖 Generated with [Claude Code](https://claude.com/claude-code)