### PR TITLE
fix: rehydrate date fields after backup import (#591)

### DIFF
--- a/src/lib/services/backupRehydration.test.ts
+++ b/src/lib/services/backupRehydration.test.ts
@@ -1,0 +1,1044 @@
+/**
+ * Tests for Backup Date Rehydration Service (TDD RED Phase)
+ *
+ * This test suite validates the `rehydrateBackupDates` utility function which
+ * corrects a critical bug in the import flow: `JSON.parse` converts all Date
+ * objects to ISO strings, so the raw result of parsing a backup file has
+ * strings everywhere the application expects Date objects. Calling
+ * `.toISOString()` on those strings throws a TypeError at runtime.
+ *
+ * The Valibot schemas in `src/lib/db/schemas/` already contain the correct
+ * date transforms, but the settings page import path calls `JSON.parse(text)
+ * as CampaignBackup` with a bare type assertion and never runs the schemas.
+ * This service fills that gap.
+ *
+ * Testing Strategy:
+ * - Each top-level date field in CampaignBackup is rehydrated to a Date
+ * - Nested date fields in every session/entity collection are rehydrated
+ * - Fields that are already Date objects are passed through unchanged (idempotency)
+ * - Optional date fields that are absent remain absent (not set to undefined)
+ * - The function does not mutate the input — it returns a new object
+ *
+ * Coverage:
+ * - NegotiationSession: createdAt, updatedAt, completedAt
+ * - NegotiationArgument (nested): arguments[].createdAt  <-- the crash site
+ * - CombatSession: createdAt, updatedAt
+ * - CombatLogEntry (nested): log[].timestamp
+ * - MontageSession: createdAt, updatedAt, completedAt
+ * - RespiteSession: createdAt, updatedAt, completedAt
+ * - KitSwap (nested): kitSwaps[].createdAt
+ * - BaseEntity: createdAt, updatedAt
+ * - EntityLink (nested): links[].createdAt, links[].updatedAt
+ * - ChatMessage: timestamp
+ * - CampaignBackup top-level: exportedAt
+ * - Already-Date passthrough (idempotency)
+ *
+ * RED Phase: These tests MUST FAIL because the module does not exist yet.
+ * The implementation will be added in the GREEN phase.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { rehydrateBackupDates } from '$lib/services/backupRehydration';
+
+// ---------------------------------------------------------------------------
+// Shared ISO timestamps used across tests
+// ---------------------------------------------------------------------------
+
+const ISO_CREATED = '2025-01-15T10:00:00.000Z';
+const ISO_UPDATED = '2025-01-15T11:00:00.000Z';
+const ISO_COMPLETED = '2025-01-15T12:00:00.000Z';
+const ISO_TIMESTAMP = '2025-01-15T10:30:00.000Z';
+const ISO_EXPORTED = '2025-01-15T09:00:00.000Z';
+
+// ---------------------------------------------------------------------------
+// Helper builders that produce the shapes JSON.parse gives us — dates as
+// ISO strings, not Date objects.
+// ---------------------------------------------------------------------------
+
+function makeRawNegotiationArgument(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 'arg-1',
+		type: 'motivation' as const,
+		tier: 1 as const,
+		description: 'A compelling argument',
+		interestChange: 1,
+		patienceChange: 0,
+		createdAt: ISO_TIMESTAMP, // string, not Date — this is the crash site
+		...overrides
+	};
+}
+
+function makeRawNegotiationSession(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 'neg-1',
+		name: 'Test Negotiation',
+		npcName: 'Merchant Aldric',
+		status: 'active' as const,
+		interest: 3,
+		patience: 4,
+		impression: 0,
+		motivations: [],
+		pitfalls: [],
+		arguments: [makeRawNegotiationArgument()],
+		createdAt: ISO_CREATED, // string
+		updatedAt: ISO_UPDATED, // string
+		...overrides
+	};
+}
+
+function makeRawCombatLogEntry(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 'log-1',
+		round: 1,
+		turn: 1,
+		timestamp: ISO_TIMESTAMP, // string
+		message: 'Aragorn attacks the orc.',
+		type: 'action' as const,
+		...overrides
+	};
+}
+
+function makeRawCombatSession(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 'combat-1',
+		name: 'Battle at the Bridge',
+		status: 'active' as const,
+		currentRound: 1,
+		currentTurn: 0,
+		combatants: [],
+		groups: [],
+		victoryPoints: 0,
+		heroPoints: 3,
+		log: [makeRawCombatLogEntry()],
+		createdAt: ISO_CREATED, // string
+		updatedAt: ISO_UPDATED, // string
+		turnMode: 'director-selected' as const,
+		actedCombatantIds: [],
+		...overrides
+	};
+}
+
+function makeRawMontageSession(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 'montage-1',
+		name: 'The Great Escape',
+		status: 'active' as const,
+		difficulty: 'moderate' as const,
+		playerCount: 4,
+		successLimit: 6,
+		failureLimit: 3,
+		challenges: [],
+		successCount: 2,
+		failureCount: 0,
+		currentRound: 1 as const,
+		victoryPoints: 0,
+		createdAt: ISO_CREATED, // string
+		updatedAt: ISO_UPDATED, // string
+		...overrides
+	};
+}
+
+function makeRawKitSwap(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 'swap-1',
+		heroId: 'hero-1',
+		from: 'Rogue Kit',
+		to: 'Martial Artist Kit',
+		createdAt: ISO_CREATED, // string
+		...overrides
+	};
+}
+
+function makeRawRespiteSession(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 'respite-1',
+		name: 'Rest at the Inn',
+		status: 'active' as const,
+		heroes: [],
+		victoryPointsAvailable: 5,
+		victoryPointsConverted: 0,
+		activityIds: [],
+		kitSwaps: [makeRawKitSwap()],
+		createdAt: ISO_CREATED, // string
+		updatedAt: ISO_UPDATED, // string
+		...overrides
+	};
+}
+
+function makeRawEntityLink(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 'link-1',
+		targetId: 'entity-2',
+		targetType: 'npc',
+		relationship: 'knows',
+		bidirectional: false,
+		createdAt: ISO_CREATED, // string
+		updatedAt: ISO_UPDATED, // string
+		...overrides
+	};
+}
+
+function makeRawEntity(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 'entity-1',
+		type: 'character',
+		name: 'Baldric the Bold',
+		description: 'A seasoned adventurer.',
+		tags: ['hero'],
+		fields: {},
+		links: [makeRawEntityLink()],
+		notes: '',
+		createdAt: ISO_CREATED, // string
+		updatedAt: ISO_UPDATED, // string
+		metadata: {}
+	};
+}
+
+function makeRawChatMessage(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 'msg-1',
+		role: 'user' as const,
+		content: 'What happens next?',
+		timestamp: ISO_TIMESTAMP, // string
+		...overrides
+	};
+}
+
+function makeRawBackup(overrides: Record<string, unknown> = {}) {
+	return {
+		version: '2.0',
+		exportedAt: ISO_EXPORTED, // string
+		entities: [makeRawEntity()],
+		chatHistory: [makeRawChatMessage()],
+		negotiationSessions: [makeRawNegotiationSession()],
+		combatSessions: [makeRawCombatSession()],
+		montageSessions: [makeRawMontageSession()],
+		...overrides
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('rehydrateBackupDates', () => {
+	// -------------------------------------------------------------------------
+	// Top-level backup field
+	// -------------------------------------------------------------------------
+
+	describe('CampaignBackup top-level fields', () => {
+		it('should rehydrate exportedAt from ISO string to Date', () => {
+			const raw = makeRawBackup();
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.exportedAt).toBeInstanceOf(Date);
+			expect(result.exportedAt.toISOString()).toBe(ISO_EXPORTED);
+		});
+
+		it('should pass through exportedAt when it is already a Date', () => {
+			const existingDate = new Date(ISO_EXPORTED);
+			const raw = makeRawBackup({ exportedAt: existingDate });
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.exportedAt).toBeInstanceOf(Date);
+			expect(result.exportedAt.toISOString()).toBe(ISO_EXPORTED);
+		});
+
+		it('should not mutate the input object', () => {
+			const raw = makeRawBackup();
+			const originalExportedAt = raw.exportedAt;
+
+			rehydrateBackupDates(raw);
+
+			// The original should still be a string
+			expect(raw.exportedAt).toBe(originalExportedAt);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// NegotiationSession — top-level dates
+	// -------------------------------------------------------------------------
+
+	describe('NegotiationSession dates', () => {
+		it('should rehydrate createdAt from ISO string to Date', () => {
+			const raw = makeRawBackup();
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.negotiationSessions![0].createdAt).toBeInstanceOf(Date);
+			expect(result.negotiationSessions![0].createdAt.toISOString()).toBe(ISO_CREATED);
+		});
+
+		it('should rehydrate updatedAt from ISO string to Date', () => {
+			const raw = makeRawBackup();
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.negotiationSessions![0].updatedAt).toBeInstanceOf(Date);
+			expect(result.negotiationSessions![0].updatedAt.toISOString()).toBe(ISO_UPDATED);
+		});
+
+		it('should rehydrate completedAt from ISO string to Date when present', () => {
+			const raw = makeRawBackup({
+				negotiationSessions: [
+					makeRawNegotiationSession({ completedAt: ISO_COMPLETED, status: 'completed' })
+				]
+			});
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.negotiationSessions![0].completedAt).toBeInstanceOf(Date);
+			expect(result.negotiationSessions![0].completedAt!.toISOString()).toBe(ISO_COMPLETED);
+		});
+
+		it('should leave completedAt undefined when not present', () => {
+			// makeRawNegotiationSession does not include completedAt by default
+			const raw = makeRawBackup();
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.negotiationSessions![0].completedAt).toBeUndefined();
+		});
+
+		it('should pass through createdAt when it is already a Date', () => {
+			const existingDate = new Date(ISO_CREATED);
+			const raw = makeRawBackup({
+				negotiationSessions: [makeRawNegotiationSession({ createdAt: existingDate })]
+			});
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.negotiationSessions![0].createdAt).toBeInstanceOf(Date);
+			expect(result.negotiationSessions![0].createdAt.toISOString()).toBe(ISO_CREATED);
+		});
+
+		it('should handle an empty negotiationSessions array', () => {
+			const raw = makeRawBackup({ negotiationSessions: [] });
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.negotiationSessions).toEqual([]);
+		});
+
+		it('should handle absent negotiationSessions', () => {
+			const raw = makeRawBackup({ negotiationSessions: undefined });
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.negotiationSessions).toBeUndefined();
+		});
+
+		it('should rehydrate all sessions when multiple exist', () => {
+			const raw = makeRawBackup({
+				negotiationSessions: [
+					makeRawNegotiationSession({ id: 'neg-1' }),
+					makeRawNegotiationSession({ id: 'neg-2' })
+				]
+			});
+
+			const result = rehydrateBackupDates(raw);
+
+			result.negotiationSessions!.forEach((session) => {
+				expect(session.createdAt).toBeInstanceOf(Date);
+				expect(session.updatedAt).toBeInstanceOf(Date);
+			});
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// NegotiationArgument — nested dates (the actual crash site)
+	// -------------------------------------------------------------------------
+
+	describe('NegotiationArgument nested dates', () => {
+		it('should rehydrate arguments[].createdAt from ISO string to Date', () => {
+			// This is the specific field that causes the crash when .toISOString()
+			// is called on it after a JSON.parse import.
+			const raw = makeRawBackup();
+
+			const result = rehydrateBackupDates(raw);
+
+			const firstArg = result.negotiationSessions![0].arguments[0];
+			expect(firstArg.createdAt).toBeInstanceOf(Date);
+			expect(firstArg.createdAt.toISOString()).toBe(ISO_TIMESTAMP);
+		});
+
+		it('should rehydrate all arguments when multiple exist', () => {
+			const raw = makeRawBackup({
+				negotiationSessions: [
+					makeRawNegotiationSession({
+						arguments: [
+							makeRawNegotiationArgument({ id: 'arg-1' }),
+							makeRawNegotiationArgument({ id: 'arg-2', createdAt: ISO_UPDATED })
+						]
+					})
+				]
+			});
+
+			const result = rehydrateBackupDates(raw);
+
+			const args = result.negotiationSessions![0].arguments;
+			expect(args[0].createdAt).toBeInstanceOf(Date);
+			expect(args[1].createdAt).toBeInstanceOf(Date);
+			expect(args[1].createdAt.toISOString()).toBe(ISO_UPDATED);
+		});
+
+		it('should pass through arguments[].createdAt when already a Date', () => {
+			const existingDate = new Date(ISO_TIMESTAMP);
+			const raw = makeRawBackup({
+				negotiationSessions: [
+					makeRawNegotiationSession({
+						arguments: [makeRawNegotiationArgument({ createdAt: existingDate })]
+					})
+				]
+			});
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.negotiationSessions![0].arguments[0].createdAt).toBeInstanceOf(Date);
+		});
+
+		it('should handle an empty arguments array', () => {
+			const raw = makeRawBackup({
+				negotiationSessions: [makeRawNegotiationSession({ arguments: [] })]
+			});
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.negotiationSessions![0].arguments).toEqual([]);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// CombatSession — top-level dates
+	// -------------------------------------------------------------------------
+
+	describe('CombatSession dates', () => {
+		it('should rehydrate createdAt from ISO string to Date', () => {
+			const raw = makeRawBackup();
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.combatSessions![0].createdAt).toBeInstanceOf(Date);
+			expect(result.combatSessions![0].createdAt.toISOString()).toBe(ISO_CREATED);
+		});
+
+		it('should rehydrate updatedAt from ISO string to Date', () => {
+			const raw = makeRawBackup();
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.combatSessions![0].updatedAt).toBeInstanceOf(Date);
+			expect(result.combatSessions![0].updatedAt.toISOString()).toBe(ISO_UPDATED);
+		});
+
+		it('should pass through createdAt when it is already a Date', () => {
+			const existingDate = new Date(ISO_CREATED);
+			const raw = makeRawBackup({
+				combatSessions: [makeRawCombatSession({ createdAt: existingDate })]
+			});
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.combatSessions![0].createdAt).toBeInstanceOf(Date);
+		});
+
+		it('should handle an empty combatSessions array', () => {
+			const raw = makeRawBackup({ combatSessions: [] });
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.combatSessions).toEqual([]);
+		});
+
+		it('should handle absent combatSessions', () => {
+			const raw = makeRawBackup({ combatSessions: undefined });
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.combatSessions).toBeUndefined();
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// CombatLogEntry — nested dates
+	// -------------------------------------------------------------------------
+
+	describe('CombatLogEntry nested dates', () => {
+		it('should rehydrate log[].timestamp from ISO string to Date', () => {
+			const raw = makeRawBackup();
+
+			const result = rehydrateBackupDates(raw);
+
+			const firstEntry = result.combatSessions![0].log[0];
+			expect(firstEntry.timestamp).toBeInstanceOf(Date);
+			expect(firstEntry.timestamp.toISOString()).toBe(ISO_TIMESTAMP);
+		});
+
+		it('should rehydrate all log entries when multiple exist', () => {
+			const raw = makeRawBackup({
+				combatSessions: [
+					makeRawCombatSession({
+						log: [
+							makeRawCombatLogEntry({ id: 'log-1' }),
+							makeRawCombatLogEntry({ id: 'log-2', timestamp: ISO_UPDATED })
+						]
+					})
+				]
+			});
+
+			const result = rehydrateBackupDates(raw);
+
+			const log = result.combatSessions![0].log;
+			expect(log[0].timestamp).toBeInstanceOf(Date);
+			expect(log[1].timestamp).toBeInstanceOf(Date);
+			expect(log[1].timestamp.toISOString()).toBe(ISO_UPDATED);
+		});
+
+		it('should pass through log[].timestamp when already a Date', () => {
+			const existingDate = new Date(ISO_TIMESTAMP);
+			const raw = makeRawBackup({
+				combatSessions: [
+					makeRawCombatSession({
+						log: [makeRawCombatLogEntry({ timestamp: existingDate })]
+					})
+				]
+			});
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.combatSessions![0].log[0].timestamp).toBeInstanceOf(Date);
+		});
+
+		it('should handle an empty log array', () => {
+			const raw = makeRawBackup({
+				combatSessions: [makeRawCombatSession({ log: [] })]
+			});
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.combatSessions![0].log).toEqual([]);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// MontageSession — top-level dates
+	// -------------------------------------------------------------------------
+
+	describe('MontageSession dates', () => {
+		it('should rehydrate createdAt from ISO string to Date', () => {
+			const raw = makeRawBackup();
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.montageSessions![0].createdAt).toBeInstanceOf(Date);
+			expect(result.montageSessions![0].createdAt.toISOString()).toBe(ISO_CREATED);
+		});
+
+		it('should rehydrate updatedAt from ISO string to Date', () => {
+			const raw = makeRawBackup();
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.montageSessions![0].updatedAt).toBeInstanceOf(Date);
+			expect(result.montageSessions![0].updatedAt.toISOString()).toBe(ISO_UPDATED);
+		});
+
+		it('should rehydrate completedAt from ISO string to Date when present', () => {
+			const raw = makeRawBackup({
+				montageSessions: [makeRawMontageSession({ completedAt: ISO_COMPLETED, status: 'completed' })]
+			});
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.montageSessions![0].completedAt).toBeInstanceOf(Date);
+			expect(result.montageSessions![0].completedAt!.toISOString()).toBe(ISO_COMPLETED);
+		});
+
+		it('should leave completedAt undefined when not present', () => {
+			const raw = makeRawBackup();
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.montageSessions![0].completedAt).toBeUndefined();
+		});
+
+		it('should pass through createdAt when it is already a Date', () => {
+			const existingDate = new Date(ISO_CREATED);
+			const raw = makeRawBackup({
+				montageSessions: [makeRawMontageSession({ createdAt: existingDate })]
+			});
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.montageSessions![0].createdAt).toBeInstanceOf(Date);
+		});
+
+		it('should handle absent montageSessions', () => {
+			const raw = makeRawBackup({ montageSessions: undefined });
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.montageSessions).toBeUndefined();
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// RespiteSession — top-level dates
+	// -------------------------------------------------------------------------
+
+	describe('RespiteSession dates', () => {
+		it('should rehydrate createdAt from ISO string to Date', () => {
+			const raw = makeRawBackup({ respiteSessions: [makeRawRespiteSession()] });
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.respiteSessions![0].createdAt).toBeInstanceOf(Date);
+			expect(result.respiteSessions![0].createdAt.toISOString()).toBe(ISO_CREATED);
+		});
+
+		it('should rehydrate updatedAt from ISO string to Date', () => {
+			const raw = makeRawBackup({ respiteSessions: [makeRawRespiteSession()] });
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.respiteSessions![0].updatedAt).toBeInstanceOf(Date);
+			expect(result.respiteSessions![0].updatedAt.toISOString()).toBe(ISO_UPDATED);
+		});
+
+		it('should rehydrate completedAt from ISO string to Date when present', () => {
+			const raw = makeRawBackup({
+				respiteSessions: [
+					makeRawRespiteSession({ completedAt: ISO_COMPLETED, status: 'completed' })
+				]
+			});
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.respiteSessions![0].completedAt).toBeInstanceOf(Date);
+			expect(result.respiteSessions![0].completedAt!.toISOString()).toBe(ISO_COMPLETED);
+		});
+
+		it('should leave completedAt undefined when not present', () => {
+			const raw = makeRawBackup({ respiteSessions: [makeRawRespiteSession()] });
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.respiteSessions![0].completedAt).toBeUndefined();
+		});
+
+		it('should pass through createdAt when it is already a Date', () => {
+			const existingDate = new Date(ISO_CREATED);
+			const raw = makeRawBackup({
+				respiteSessions: [makeRawRespiteSession({ createdAt: existingDate })]
+			});
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.respiteSessions![0].createdAt).toBeInstanceOf(Date);
+		});
+
+		it('should handle an empty respiteSessions array', () => {
+			const raw = makeRawBackup({ respiteSessions: [] });
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.respiteSessions).toEqual([]);
+		});
+
+		it('should handle absent respiteSessions', () => {
+			const raw = makeRawBackup({ respiteSessions: undefined });
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.respiteSessions).toBeUndefined();
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// KitSwap — nested inside RespiteSession
+	// -------------------------------------------------------------------------
+
+	describe('KitSwap nested dates', () => {
+		it('should rehydrate kitSwaps[].createdAt from ISO string to Date', () => {
+			const raw = makeRawBackup({ respiteSessions: [makeRawRespiteSession()] });
+
+			const result = rehydrateBackupDates(raw);
+
+			const firstSwap = result.respiteSessions![0].kitSwaps[0];
+			expect(firstSwap.createdAt).toBeInstanceOf(Date);
+			expect(firstSwap.createdAt.toISOString()).toBe(ISO_CREATED);
+		});
+
+		it('should rehydrate all kitSwaps when multiple exist', () => {
+			const raw = makeRawBackup({
+				respiteSessions: [
+					makeRawRespiteSession({
+						kitSwaps: [
+							makeRawKitSwap({ id: 'swap-1' }),
+							makeRawKitSwap({ id: 'swap-2', createdAt: ISO_UPDATED })
+						]
+					})
+				]
+			});
+
+			const result = rehydrateBackupDates(raw);
+
+			const swaps = result.respiteSessions![0].kitSwaps;
+			expect(swaps[0].createdAt).toBeInstanceOf(Date);
+			expect(swaps[1].createdAt).toBeInstanceOf(Date);
+			expect(swaps[1].createdAt.toISOString()).toBe(ISO_UPDATED);
+		});
+
+		it('should pass through kitSwaps[].createdAt when already a Date', () => {
+			const existingDate = new Date(ISO_CREATED);
+			const raw = makeRawBackup({
+				respiteSessions: [
+					makeRawRespiteSession({
+						kitSwaps: [makeRawKitSwap({ createdAt: existingDate })]
+					})
+				]
+			});
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.respiteSessions![0].kitSwaps[0].createdAt).toBeInstanceOf(Date);
+		});
+
+		it('should handle an empty kitSwaps array', () => {
+			const raw = makeRawBackup({
+				respiteSessions: [makeRawRespiteSession({ kitSwaps: [] })]
+			});
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.respiteSessions![0].kitSwaps).toEqual([]);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// BaseEntity — top-level dates
+	// -------------------------------------------------------------------------
+
+	describe('BaseEntity dates', () => {
+		it('should rehydrate entities[].createdAt from ISO string to Date', () => {
+			const raw = makeRawBackup();
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.entities[0].createdAt).toBeInstanceOf(Date);
+			expect(result.entities[0].createdAt.toISOString()).toBe(ISO_CREATED);
+		});
+
+		it('should rehydrate entities[].updatedAt from ISO string to Date', () => {
+			const raw = makeRawBackup();
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.entities[0].updatedAt).toBeInstanceOf(Date);
+			expect(result.entities[0].updatedAt.toISOString()).toBe(ISO_UPDATED);
+		});
+
+		it('should pass through entities[].createdAt when already a Date', () => {
+			const existingDate = new Date(ISO_CREATED);
+			const raw = makeRawBackup({
+				entities: [makeRawEntity(), { ...makeRawEntity(), id: 'entity-2', createdAt: existingDate }]
+			});
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.entities[1].createdAt).toBeInstanceOf(Date);
+		});
+
+		it('should rehydrate all entities when multiple exist', () => {
+			const raw = makeRawBackup({
+				entities: [makeRawEntity(), { ...makeRawEntity(), id: 'entity-2', name: 'Elara' }]
+			});
+
+			const result = rehydrateBackupDates(raw);
+
+			result.entities.forEach((entity) => {
+				expect(entity.createdAt).toBeInstanceOf(Date);
+				expect(entity.updatedAt).toBeInstanceOf(Date);
+			});
+		});
+
+		it('should handle an empty entities array', () => {
+			const raw = makeRawBackup({ entities: [] });
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.entities).toEqual([]);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// EntityLink — nested inside BaseEntity
+	// -------------------------------------------------------------------------
+
+	describe('EntityLink nested dates', () => {
+		it('should rehydrate entities[].links[].createdAt from ISO string to Date', () => {
+			const raw = makeRawBackup();
+
+			const result = rehydrateBackupDates(raw);
+
+			const firstLink = result.entities[0].links[0];
+			expect(firstLink.createdAt).toBeInstanceOf(Date);
+			expect(firstLink.createdAt!.toISOString()).toBe(ISO_CREATED);
+		});
+
+		it('should rehydrate entities[].links[].updatedAt from ISO string to Date', () => {
+			const raw = makeRawBackup();
+
+			const result = rehydrateBackupDates(raw);
+
+			const firstLink = result.entities[0].links[0];
+			expect(firstLink.updatedAt).toBeInstanceOf(Date);
+			expect(firstLink.updatedAt!.toISOString()).toBe(ISO_UPDATED);
+		});
+
+		it('should leave link createdAt undefined when not present on the link', () => {
+			const linkWithoutDates = {
+				id: 'link-nodates',
+				targetId: 'entity-3',
+				targetType: 'npc',
+				relationship: 'allied_with',
+				bidirectional: true
+				// no createdAt, no updatedAt
+			};
+			const raw = makeRawBackup({
+				entities: [{ ...makeRawEntity(), links: [linkWithoutDates] }]
+			});
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.entities[0].links[0].createdAt).toBeUndefined();
+			expect(result.entities[0].links[0].updatedAt).toBeUndefined();
+		});
+
+		it('should pass through link createdAt when already a Date', () => {
+			const existingDate = new Date(ISO_CREATED);
+			const raw = makeRawBackup({
+				entities: [
+					{
+						...makeRawEntity(),
+						links: [makeRawEntityLink({ createdAt: existingDate })]
+					}
+				]
+			});
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.entities[0].links[0].createdAt).toBeInstanceOf(Date);
+		});
+
+		it('should rehydrate all links across all entities', () => {
+			const raw = makeRawBackup({
+				entities: [
+					{
+						...makeRawEntity(),
+						id: 'entity-1',
+						links: [makeRawEntityLink({ id: 'link-1' }), makeRawEntityLink({ id: 'link-2' })]
+					},
+					{
+						...makeRawEntity(),
+						id: 'entity-2',
+						links: [makeRawEntityLink({ id: 'link-3' })]
+					}
+				]
+			});
+
+			const result = rehydrateBackupDates(raw);
+
+			result.entities.forEach((entity) => {
+				entity.links.forEach((link) => {
+					expect(link.createdAt).toBeInstanceOf(Date);
+					expect(link.updatedAt).toBeInstanceOf(Date);
+				});
+			});
+		});
+
+		it('should handle an entity with no links', () => {
+			const raw = makeRawBackup({
+				entities: [{ ...makeRawEntity(), links: [] }]
+			});
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.entities[0].links).toEqual([]);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// ChatMessage — top-level dates
+	// -------------------------------------------------------------------------
+
+	describe('ChatMessage dates', () => {
+		it('should rehydrate chatHistory[].timestamp from ISO string to Date', () => {
+			const raw = makeRawBackup();
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.chatHistory[0].timestamp).toBeInstanceOf(Date);
+			expect(result.chatHistory[0].timestamp.toISOString()).toBe(ISO_TIMESTAMP);
+		});
+
+		it('should rehydrate all messages when multiple exist', () => {
+			const raw = makeRawBackup({
+				chatHistory: [
+					makeRawChatMessage({ id: 'msg-1' }),
+					makeRawChatMessage({ id: 'msg-2', timestamp: ISO_UPDATED })
+				]
+			});
+
+			const result = rehydrateBackupDates(raw);
+
+			result.chatHistory.forEach((msg) => {
+				expect(msg.timestamp).toBeInstanceOf(Date);
+			});
+			expect(result.chatHistory[1].timestamp.toISOString()).toBe(ISO_UPDATED);
+		});
+
+		it('should pass through chatHistory[].timestamp when already a Date', () => {
+			const existingDate = new Date(ISO_TIMESTAMP);
+			const raw = makeRawBackup({
+				chatHistory: [makeRawChatMessage({ timestamp: existingDate })]
+			});
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.chatHistory[0].timestamp).toBeInstanceOf(Date);
+		});
+
+		it('should handle an empty chatHistory array', () => {
+			const raw = makeRawBackup({ chatHistory: [] });
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(result.chatHistory).toEqual([]);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Idempotency — already-Date fields are passed through unchanged
+	// -------------------------------------------------------------------------
+
+	describe('Idempotency — already-Date fields', () => {
+		it('should be safe to call twice on the same data without double-converting', () => {
+			const raw = makeRawBackup();
+
+			const firstPass = rehydrateBackupDates(raw);
+			// Calling again on the already-rehydrated result must not throw and
+			// must return valid Dates.
+			const secondPass = rehydrateBackupDates(firstPass);
+
+			expect(secondPass.exportedAt).toBeInstanceOf(Date);
+			expect(secondPass.negotiationSessions![0].createdAt).toBeInstanceOf(Date);
+			expect(secondPass.negotiationSessions![0].arguments[0].createdAt).toBeInstanceOf(Date);
+			expect(secondPass.combatSessions![0].createdAt).toBeInstanceOf(Date);
+			expect(secondPass.combatSessions![0].log[0].timestamp).toBeInstanceOf(Date);
+			expect(secondPass.montageSessions![0].createdAt).toBeInstanceOf(Date);
+			expect(secondPass.entities[0].createdAt).toBeInstanceOf(Date);
+			expect(secondPass.entities[0].links[0].createdAt).toBeInstanceOf(Date);
+			expect(secondPass.chatHistory[0].timestamp).toBeInstanceOf(Date);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Integration — full backup round-trip
+	// -------------------------------------------------------------------------
+
+	describe('Full backup round-trip', () => {
+		it('should rehydrate every date field in a complete backup with all session types', () => {
+			const raw = {
+				version: '2.0',
+				exportedAt: ISO_EXPORTED,
+				entities: [makeRawEntity()],
+				chatHistory: [makeRawChatMessage()],
+				negotiationSessions: [
+					makeRawNegotiationSession({ completedAt: ISO_COMPLETED, status: 'completed' })
+				],
+				combatSessions: [makeRawCombatSession()],
+				montageSessions: [
+					makeRawMontageSession({ completedAt: ISO_COMPLETED, status: 'completed' })
+				],
+				respiteSessions: [
+					makeRawRespiteSession({ completedAt: ISO_COMPLETED, status: 'completed' })
+				]
+			};
+
+			const result = rehydrateBackupDates(raw);
+
+			// Top-level
+			expect(result.exportedAt).toBeInstanceOf(Date);
+
+			// Negotiation
+			const neg = result.negotiationSessions![0];
+			expect(neg.createdAt).toBeInstanceOf(Date);
+			expect(neg.updatedAt).toBeInstanceOf(Date);
+			expect(neg.completedAt).toBeInstanceOf(Date);
+			expect(neg.arguments[0].createdAt).toBeInstanceOf(Date);
+
+			// Combat
+			const combat = result.combatSessions![0];
+			expect(combat.createdAt).toBeInstanceOf(Date);
+			expect(combat.updatedAt).toBeInstanceOf(Date);
+			expect(combat.log[0].timestamp).toBeInstanceOf(Date);
+
+			// Montage
+			const montage = result.montageSessions![0];
+			expect(montage.createdAt).toBeInstanceOf(Date);
+			expect(montage.updatedAt).toBeInstanceOf(Date);
+			expect(montage.completedAt).toBeInstanceOf(Date);
+
+			// Respite
+			const respite = result.respiteSessions![0];
+			expect(respite.createdAt).toBeInstanceOf(Date);
+			expect(respite.updatedAt).toBeInstanceOf(Date);
+			expect(respite.completedAt).toBeInstanceOf(Date);
+			expect(respite.kitSwaps[0].createdAt).toBeInstanceOf(Date);
+
+			// Entity
+			const entity = result.entities[0];
+			expect(entity.createdAt).toBeInstanceOf(Date);
+			expect(entity.updatedAt).toBeInstanceOf(Date);
+			expect(entity.links[0].createdAt).toBeInstanceOf(Date);
+			expect(entity.links[0].updatedAt).toBeInstanceOf(Date);
+
+			// Chat
+			expect(result.chatHistory[0].timestamp).toBeInstanceOf(Date);
+		});
+
+		it('should not throw when calling .toISOString() on any rehydrated date field', () => {
+			// This is the specific crash scenario described in the bug report.
+			const raw = makeRawBackup({
+				negotiationSessions: [
+					makeRawNegotiationSession({ completedAt: ISO_COMPLETED, status: 'completed' })
+				],
+				respiteSessions: [makeRawRespiteSession()]
+			});
+
+			const result = rehydrateBackupDates(raw);
+
+			expect(() => result.exportedAt.toISOString()).not.toThrow();
+			expect(() => result.negotiationSessions![0].createdAt.toISOString()).not.toThrow();
+			expect(() => result.negotiationSessions![0].updatedAt.toISOString()).not.toThrow();
+			expect(() => result.negotiationSessions![0].completedAt!.toISOString()).not.toThrow();
+			expect(() => result.negotiationSessions![0].arguments[0].createdAt.toISOString()).not.toThrow();
+			expect(() => result.combatSessions![0].createdAt.toISOString()).not.toThrow();
+			expect(() => result.combatSessions![0].updatedAt.toISOString()).not.toThrow();
+			expect(() => result.combatSessions![0].log[0].timestamp.toISOString()).not.toThrow();
+			expect(() => result.montageSessions![0].createdAt.toISOString()).not.toThrow();
+			expect(() => result.montageSessions![0].updatedAt.toISOString()).not.toThrow();
+			expect(() => result.respiteSessions![0].createdAt.toISOString()).not.toThrow();
+			expect(() => result.respiteSessions![0].updatedAt.toISOString()).not.toThrow();
+			expect(() => result.respiteSessions![0].kitSwaps[0].createdAt.toISOString()).not.toThrow();
+			expect(() => result.entities[0].createdAt.toISOString()).not.toThrow();
+			expect(() => result.entities[0].updatedAt.toISOString()).not.toThrow();
+			expect(() => result.entities[0].links[0].createdAt!.toISOString()).not.toThrow();
+			expect(() => result.entities[0].links[0].updatedAt!.toISOString()).not.toThrow();
+			expect(() => result.chatHistory[0].timestamp.toISOString()).not.toThrow();
+		});
+	});
+});

--- a/src/lib/services/backupRehydration.ts
+++ b/src/lib/services/backupRehydration.ts
@@ -1,0 +1,202 @@
+/**
+ * Backup Date Rehydration Service
+ *
+ * After JSON.parse, all Date objects in a backup file become ISO strings.
+ * Any code that later calls .toISOString() on those strings throws a TypeError.
+ * This utility walks the raw parsed backup object and converts every date field
+ * back to a real Date object before the data is stored or used.
+ *
+ * Design principles:
+ * - Does NOT mutate the input — returns a new object at every level it modifies
+ * - Idempotent — if a field is already a Date, it passes through unchanged
+ * - Optional fields that are absent remain absent (not coerced to undefined)
+ * - No Valibot schemas — just straightforward structural mapping
+ */
+
+import type { CampaignBackup } from '$lib/types';
+
+// ---------------------------------------------------------------------------
+// Core helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Converts a value to a Date.
+ * - If already a Date, returns it as-is (idempotency).
+ * - If a string, parses it via the Date constructor.
+ */
+function toDate(value: Date | string): Date {
+	if (value instanceof Date) {
+		return value;
+	}
+	return new Date(value);
+}
+
+// ---------------------------------------------------------------------------
+// Per-collection rehydrators
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function rehydrateEntityLink(link: any): any {
+	const result = { ...link };
+	if ('createdAt' in link && link.createdAt !== undefined) {
+		result.createdAt = toDate(link.createdAt);
+	}
+	if ('updatedAt' in link && link.updatedAt !== undefined) {
+		result.updatedAt = toDate(link.updatedAt);
+	}
+	return result;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function rehydrateEntity(entity: any): any {
+	return {
+		...entity,
+		createdAt: toDate(entity.createdAt),
+		updatedAt: toDate(entity.updatedAt),
+		links: Array.isArray(entity.links) ? entity.links.map(rehydrateEntityLink) : entity.links
+	};
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function rehydrateChatMessage(msg: any): any {
+	return {
+		...msg,
+		timestamp: toDate(msg.timestamp)
+	};
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function rehydrateNegotiationArgument(arg: any): any {
+	return {
+		...arg,
+		createdAt: toDate(arg.createdAt)
+	};
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function rehydrateNegotiationSession(session: any): any {
+	const result = {
+		...session,
+		createdAt: toDate(session.createdAt),
+		updatedAt: toDate(session.updatedAt),
+		arguments: Array.isArray(session.arguments)
+			? session.arguments.map(rehydrateNegotiationArgument)
+			: session.arguments
+	};
+	if ('completedAt' in session && session.completedAt !== undefined) {
+		result.completedAt = toDate(session.completedAt);
+	}
+	return result;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function rehydrateCombatLogEntry(entry: any): any {
+	return {
+		...entry,
+		timestamp: toDate(entry.timestamp)
+	};
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function rehydrateCombatSession(session: any): any {
+	return {
+		...session,
+		createdAt: toDate(session.createdAt),
+		updatedAt: toDate(session.updatedAt),
+		log: Array.isArray(session.log) ? session.log.map(rehydrateCombatLogEntry) : session.log
+	};
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function rehydrateMontageSession(session: any): any {
+	const result = {
+		...session,
+		createdAt: toDate(session.createdAt),
+		updatedAt: toDate(session.updatedAt)
+	};
+	if ('completedAt' in session && session.completedAt !== undefined) {
+		result.completedAt = toDate(session.completedAt);
+	}
+	return result;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function rehydrateKitSwap(swap: any): any {
+	return {
+		...swap,
+		createdAt: toDate(swap.createdAt)
+	};
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function rehydrateRespiteSession(session: any): any {
+	const result = {
+		...session,
+		createdAt: toDate(session.createdAt),
+		updatedAt: toDate(session.updatedAt),
+		kitSwaps: Array.isArray(session.kitSwaps)
+			? session.kitSwaps.map(rehydrateKitSwap)
+			: session.kitSwaps
+	};
+	if ('completedAt' in session && session.completedAt !== undefined) {
+		result.completedAt = toDate(session.completedAt);
+	}
+	return result;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Takes a raw object produced by JSON.parse of a backup file and returns a
+ * new object with every date field converted from ISO string to Date.
+ *
+ * The input is typed as `unknown` to make clear this comes from untrusted
+ * JSON. The return type matches CampaignBackup so callers get full type safety
+ * after rehydration.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function rehydrateBackupDates(raw: any): CampaignBackup {
+	const backup = { ...raw };
+
+	// Top-level date
+	backup.exportedAt = toDate(raw.exportedAt);
+
+	// entities[] — always present per CampaignBackup shape
+	if (Array.isArray(raw.entities)) {
+		backup.entities = raw.entities.map(rehydrateEntity);
+	}
+
+	// chatHistory[] — always present per CampaignBackup shape
+	if (Array.isArray(raw.chatHistory)) {
+		backup.chatHistory = raw.chatHistory.map(rehydrateChatMessage);
+	}
+
+	// Optional session collections — preserve absent as absent (not undefined)
+	if ('negotiationSessions' in raw) {
+		backup.negotiationSessions = Array.isArray(raw.negotiationSessions)
+			? raw.negotiationSessions.map(rehydrateNegotiationSession)
+			: raw.negotiationSessions;
+	}
+
+	if ('combatSessions' in raw) {
+		backup.combatSessions = Array.isArray(raw.combatSessions)
+			? raw.combatSessions.map(rehydrateCombatSession)
+			: raw.combatSessions;
+	}
+
+	if ('montageSessions' in raw) {
+		backup.montageSessions = Array.isArray(raw.montageSessions)
+			? raw.montageSessions.map(rehydrateMontageSession)
+			: raw.montageSessions;
+	}
+
+	if ('respiteSessions' in raw) {
+		backup.respiteSessions = Array.isArray(raw.respiteSessions)
+			? raw.respiteSessions.map(rehydrateRespiteSession)
+			: raw.respiteSessions;
+	}
+
+	return backup as CampaignBackup;
+}

--- a/src/lib/types/campaign.ts
+++ b/src/lib/types/campaign.ts
@@ -10,6 +10,7 @@ import type { PlayerExportFieldConfig } from './playerFieldVisibility';
 import type { CombatSession } from './combat';
 import type { MontageSession } from './montage';
 import type { NegotiationSession } from './negotiation';
+import type { RespiteSession } from './respite';
 
 // Campaign model
 export interface Campaign {
@@ -108,6 +109,7 @@ export interface CampaignBackup {
 	combatSessions?: CombatSession[]; // Issue #310: Combat sessions for backup/restore
 	montageSessions?: MontageSession[]; // Issue #310: Montage sessions for backup/restore
 	negotiationSessions?: NegotiationSession[]; // Issue #392: Negotiation sessions for backup/restore
+	respiteSessions?: RespiteSession[]; // Issue #591: Respite sessions for backup/restore
 }
 
 // Issue #152: Backup reminder system types

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -5,6 +5,7 @@
 	import { entityRepository, chatRepository, appConfigRepository } from '$lib/db/repositories';
 	import { convertOldCampaignToEntity } from '$lib/db/migrations/migrateCampaignToEntity';
 	import type { CampaignBackup, ModelInfo } from '$lib/types';
+	import { rehydrateBackupDates } from '$lib/services/backupRehydration';
 	import {
 		fetchModels,
 		getSelectedModel,
@@ -204,6 +205,8 @@
 			const montageSessions = await db.montageSessions.toArray();
 			// Issue #392: Get negotiation sessions
 			const negotiationSessions = await db.negotiationSessions.toArray();
+			// Issue #591: Get respite sessions
+			const respiteSessions = await db.respiteSessions.toArray();
 
 			const exportDate = new Date();
 			const backup: CampaignBackup = {
@@ -215,7 +218,8 @@
 				selectedModel: modelToExport,
 				combatSessions,
 				montageSessions,
-				negotiationSessions
+				negotiationSessions,
+				respiteSessions
 			};
 
 			const json = JSON.stringify(backup, null, 2);
@@ -278,7 +282,7 @@
 			isImporting = true;
 			try {
 				const text = await file.text();
-				const backup = JSON.parse(text) as CampaignBackup;
+				const backup = rehydrateBackupDates(JSON.parse(text));
 
 				// Validate backup structure - must have entities (new format) or campaign (old format)
 				if (!backup.version || !backup.entities) {
@@ -305,7 +309,7 @@
 				// Import data
 				await db.transaction(
 					'rw',
-					[db.campaign, db.entities, db.chatMessages, db.appConfig, db.combatSessions, db.montageSessions, db.negotiationSessions],
+					[db.campaign, db.entities, db.chatMessages, db.appConfig, db.combatSessions, db.montageSessions, db.negotiationSessions, db.respiteSessions],
 					async () => {
 						await db.campaign.clear();
 						await db.entities.clear();
@@ -314,6 +318,7 @@
 						await db.combatSessions.clear();
 						await db.montageSessions.clear();
 						await db.negotiationSessions.clear();
+						await db.respiteSessions.clear();
 
 						// Handle old format: convert campaign to entity
 						let entitiesToImport = [...backup.entities];
@@ -343,6 +348,11 @@
 						// Issue #392: Restore negotiation sessions
 						if (backup.negotiationSessions && backup.negotiationSessions.length > 0) {
 							await db.negotiationSessions.bulkAdd(backup.negotiationSessions);
+						}
+
+						// Issue #591: Restore respite sessions
+						if (backup.respiteSessions && backup.respiteSessions.length > 0) {
+							await db.respiteSessions.bulkAdd(backup.respiteSessions);
 						}
 
 						// Set active campaign


### PR DESCRIPTION
## Summary

- Fixes a critical crash where importing a backup file caused `TypeError: createdAt.toISOString is not a function` when loading negotiation sessions (and potentially combat, montage, and respite sessions)
- Root cause: `JSON.parse()` converts `Date` objects to ISO strings, and the import flow never converted them back
- Also fixes a gap where respite sessions were never exported or imported at all

## Changes

- **New:** `backupRehydration.ts` service that converts all ISO date strings back to `Date` objects after `JSON.parse`, covering entities, chat messages, and all session types (combat, montage, negotiation, respite) including nested objects (arguments, log entries, kit swaps, entity links)
- **New:** 59 test cases validating rehydration of every date field
- **Fix:** Added missing `respiteSessions` field to `CampaignBackup` type interface
- **Fix:** Added respite session export/import support to settings page

## Test plan

- [x] 59/59 new unit tests pass
- [x] Full test suite passes (13,772 tests)
- [x] `npm run check` — 0 errors
- [x] `npm run build` — succeeds
- [ ] Manual: export a backup, import it, then load a negotiation session — should not crash
- [ ] Manual: verify respite sessions survive an export/import round-trip

Closes #591

🤖 Generated with [Claude Code](https://claude.com/claude-code)