### PR TITLE
fix: resolve ESLint no-explicit-any errors and flaky combat e2e test

### DIFF
--- a/e2e/combat-lifecycle.spec.ts
+++ b/e2e/combat-lifecycle.spec.ts
@@ -75,9 +75,22 @@ test.describe('Combat Lifecycle', () => {
     await expect(page.getByText('Round 1').first()).toBeVisible({ timeout: 10000 });
 
     // ------------------------------------------------------------------ Advance turns
-    // With 2 combatants, clicking Next Turn twice advances to Round 2.
+    // The app defaults to director-selected turn mode.
+    // Click each combatant card to select their turn, then click "Next Turn" to end it.
+    // After both combatants act, the round advances to Round 2.
+
+    // Select first combatant's turn by clicking their card
+    const combatantCards = page.locator('[data-testid="combatant-card"]');
+    await combatantCards.first().click();
+    // Wait for active indicator (aria-current="true" on the card)
+    await expect(combatantCards.first()).toHaveAttribute('aria-current', 'true', { timeout: 5000 });
     await page.click('button:has-text("Next Turn")');
+
+    // Select second combatant's turn by clicking their card
+    await combatantCards.nth(1).click();
+    await expect(combatantCards.nth(1)).toHaveAttribute('aria-current', 'true', { timeout: 5000 });
     await page.click('button:has-text("Next Turn")');
+
     await expect(page.getByText('Round 2').first()).toBeVisible({ timeout: 10000 });
 
     // ------------------------------------------------------------------ End combat

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -82,6 +82,11 @@ export default [
 		}
 	},
 
+	// Ignore ErrorBoundary.svelte (svelte:boundary causes a parser error)
+	{
+		ignores: ['src/lib/components/ui/ErrorBoundary.svelte']
+	},
+
 	// Test files configuration
 	{
 		files: ['**/*.test.ts', '**/*.test.js', 'src/tests/**/*'],

--- a/src/lib/components/entity/CreateRelateCommand.svelte
+++ b/src/lib/components/entity/CreateRelateCommand.svelte
@@ -106,7 +106,7 @@
 			: [];
 
 		// Build metadata object
-		const metadata: Record<string, any> = {};
+		const metadata: { tags?: string[]; tension?: number } = {};
 		if (parsedTags.length > 0) {
 			metadata.tags = parsedTags;
 		}

--- a/src/lib/components/entity/FieldInput.svelte
+++ b/src/lib/components/entity/FieldInput.svelte
@@ -34,7 +34,7 @@
 		onchange: (value: FieldValue) => void;
 		disabled?: boolean;
 		error?: string;
-		allFields?: Record<string, any>; // For computed field evaluation
+		allFields?: Record<string, FieldValue>; // For computed field evaluation
 	}
 
 	let {

--- a/src/lib/components/entity/FieldRenderer.svelte
+++ b/src/lib/components/entity/FieldRenderer.svelte
@@ -31,7 +31,7 @@
 	interface Props {
 		field: FieldDefinition;
 		value: FieldValue;
-		allFields?: Record<string, any>; // For computed field evaluation
+		allFields?: Record<string, FieldValue>; // For computed field evaluation
 		compact?: boolean; // Compact display mode for lists/cards
 	}
 

--- a/src/lib/components/entity/GenerateSuggestionsButton.svelte
+++ b/src/lib/components/entity/GenerateSuggestionsButton.svelte
@@ -27,7 +27,7 @@
 
 	interface Props {
 		entityType: string;
-		currentData: Record<string, any>;
+		currentData: Record<string, unknown>;
 		entityId?: number;
 		onSuggestionsGenerated?: () => void;
 		disabled?: boolean;

--- a/src/lib/components/entity/GenerateSuggestionsButton.test.ts
+++ b/src/lib/components/entity/GenerateSuggestionsButton.test.ts
@@ -893,7 +893,7 @@ describe('GenerateSuggestionsButton Component - Edge Cases', () => {
 				entityType: 'character',
 				currentData: {
 					name: 'Aragorn',
-					stats: { str: 16, dex: 14 }
+					stats: { str: 16, dex: 14 } as any
 				},
 				onSuggestionsGenerated: vi.fn()
 			}

--- a/src/lib/components/entity/RelateCommand.svelte
+++ b/src/lib/components/entity/RelateCommand.svelte
@@ -132,7 +132,7 @@
 				: [];
 
 			// Build metadata object
-			const metadata: Record<string, any> = {};
+			const metadata: { tags?: string[]; tension?: number } = {};
 			if (parsedTags.length > 0) {
 				metadata.tags = parsedTags;
 			}

--- a/src/lib/components/negotiation/MotivationPitfallPanel.svelte
+++ b/src/lib/components/negotiation/MotivationPitfallPanel.svelte
@@ -35,7 +35,7 @@
 		onRevealPitfall
 	}: Props = $props();
 
-	const motivationIcons: Record<MotivationType, any> = {
+	const motivationIcons: Record<MotivationType, typeof Heart> = {
 		charity: Heart,
 		discovery: Search,
 		faith: Users,
@@ -51,7 +51,7 @@
 		wealth: DollarSign
 	};
 
-	function getIconForType(type: string): any {
+	function getIconForType(type: string): typeof Heart {
 		// Check if it's a canonical type
 		if (type in motivationIcons) {
 			return motivationIcons[type as MotivationType];

--- a/src/lib/components/player/PlayerFieldDisplay.svelte
+++ b/src/lib/components/player/PlayerFieldDisplay.svelte
@@ -16,7 +16,7 @@
 	interface Props {
 		field: FieldDefinition;
 		value: FieldValue;
-		allFields?: Record<string, any>; // For computed field evaluation
+		allFields?: Record<string, FieldValue>; // For computed field evaluation
 		compact?: boolean;
 	}
 

--- a/src/lib/services/analyzers/relationshipAnalyzer.ts
+++ b/src/lib/services/analyzers/relationshipAnalyzer.ts
@@ -207,7 +207,7 @@ export const relationshipAnalyzer: SuggestionAnalyzer = {
 		// 3. AI-powered semantic analysis (optional, rate-limited)
 		if (config.enableAIAnalysis) {
 			// Select a small sample of unlinked entity pairs for AI analysis
-			const unlinkedPairs: Array<[any, any]> = [];
+			const unlinkedPairs: Array<[BaseEntity, BaseEntity]> = [];
 			const maxAIPairs = 5; // Limit AI calls
 
 			for (let i = 0; i < context.entities.length && unlinkedPairs.length < maxAIPairs; i++) {

--- a/src/lib/services/forgeSteelImportService.ts
+++ b/src/lib/services/forgeSteelImportService.ts
@@ -5,7 +5,7 @@
  * to Director Assist entities.
  */
 
-import type { NewEntity } from '$lib/types';
+import type { FieldValue, NewEntity } from '$lib/types';
 import type { ForgeSteelHero } from '$lib/types/forgeSteel';
 import { validateForgeSteelHeroStructure } from '$lib/types/forgeSteel';
 
@@ -103,7 +103,7 @@ export function mapForgeSteelHeroToEntity(hero: ForgeSteelHero): NewEntity {
 	const status = hero.state.defeated ? 'deceased' : 'active';
 
 	// Build fields object
-	const fields: Record<string, any> = {
+	const fields: Record<string, FieldValue> = {
 		concept,
 		background: hero.state.notes,
 		status

--- a/src/lib/services/playerCharacterContextService.ts
+++ b/src/lib/services/playerCharacterContextService.ts
@@ -13,7 +13,7 @@
  * @see GitHub Issue #319
  */
 
-import type { BaseEntity, EntityId } from '$lib/types';
+import type { BaseEntity, EntityId, FieldValue } from '$lib/types';
 import { entityRepository } from '$lib/db/repositories';
 import { getEntityTypeDefinition } from '$lib/config/entityTypes';
 
@@ -42,7 +42,7 @@ export interface PlayerCharacterContext {
 	/** Character summary */
 	summary?: string;
 	/** All character fields (excluding hidden/secrets) */
-	fields: Record<string, any>;
+	fields: Record<string, FieldValue>;
 	/** Field labels for proper formatting */
 	fieldLabels: Record<string, string>;
 }
@@ -139,7 +139,7 @@ export async function buildFullCharacterContext(
 	// Get the character type definition to access field definitions
 	const typeDef = getEntityTypeDefinition('character');
 
-	const fields: Record<string, any> = {};
+	const fields: Record<string, FieldValue> = {};
 	const fieldLabels: Record<string, string> = {};
 
 	// Process all fields from the character

--- a/src/lib/services/playerDataLoader.ts
+++ b/src/lib/services/playerDataLoader.ts
@@ -7,6 +7,7 @@
  * Pure TypeScript service with no Svelte dependencies.
  */
 
+import type { FieldValue } from '$lib/types';
 import type { PlayerExport, PlayerEntity, PlayerEntityLink } from '$lib/types/playerExport';
 
 /**
@@ -163,9 +164,9 @@ export function validateEntity(rawEntity: unknown, index: number): PlayerEntity 
 
 	// Fields (object, default to empty object)
 	// Note: We accept unknown field values and let TypeScript cast them to FieldValue
-	let fields: Record<string, any> = {};
+	let fields: Record<string, FieldValue> = {};
 	if (entity.fields && typeof entity.fields === 'object' && !Array.isArray(entity.fields)) {
-		fields = entity.fields as Record<string, any>;
+		fields = entity.fields as Record<string, FieldValue>;
 	}
 
 	// Links (array of PlayerEntityLink, default to empty array)

--- a/src/lib/services/respiteActivityService.ts
+++ b/src/lib/services/respiteActivityService.ts
@@ -9,7 +9,7 @@
 
 import { entityRepository } from '$lib/db/repositories';
 import { respiteRepository } from '$lib/db/repositories/respiteRepository';
-import type { BaseEntity, NewEntity } from '$lib/types';
+import type { BaseEntity, FieldValue, NewEntity } from '$lib/types';
 import type {
 	CreateRespiteActivityInput,
 	RespiteActivityStatus
@@ -120,7 +120,7 @@ export async function updateActivityStatus(
 		throw new Error(`Activity entity ${activityEntityId} not found`);
 	}
 
-	const updates: Record<string, any> = {
+	const updates: Record<string, FieldValue> = {
 		activityStatus: status
 	};
 

--- a/src/lib/services/suggestionActionService.ts
+++ b/src/lib/services/suggestionActionService.ts
@@ -5,7 +5,7 @@
  * of executed actions for undo functionality.
  */
 
-import type { AISuggestion } from '$lib/types';
+import type { AISuggestion, EntityLink, FieldValue } from '$lib/types';
 import { entityRepository, suggestionRepository } from '$lib/db/repositories';
 import { nanoid } from 'nanoid';
 
@@ -233,7 +233,8 @@ async function executeEditEntity(
 	actionData: Record<string, unknown>,
 	historyEntry: ActionHistoryEntry
 ): Promise<ActionResult> {
-	const { entityId, updates } = actionData as any;
+	const entityId = actionData.entityId as string | undefined;
+	const updates = actionData.updates as Record<string, unknown> | undefined;
 
 	if (!entityId || !updates) {
 		return {
@@ -274,7 +275,10 @@ async function executeCreateEntity(
 	actionData: Record<string, unknown>,
 	historyEntry: ActionHistoryEntry
 ): Promise<ActionResult> {
-	const { type, name, fields, links } = actionData as any;
+	const type = actionData.type as string | undefined;
+	const name = actionData.name as string | undefined;
+	const fields = actionData.fields as Record<string, unknown> | undefined;
+	const links = actionData.links as Record<string, unknown>[] | undefined;
 
 	if (!type || !name) {
 		return {
@@ -288,10 +292,10 @@ async function executeCreateEntity(
 		const newEntity = await entityRepository.create({
 			type,
 			name,
-			description: fields?.description || '',
-			tags: fields?.tags || [],
-			fields: fields || {},
-			links: links || [],
+			description: (fields?.description as string) || '',
+			tags: (fields?.tags as string[]) || [],
+			fields: (fields || {}) as Record<string, FieldValue>,
+			links: (links || []) as unknown as EntityLink[],
 			notes: '',
 			metadata: {}
 		});
@@ -318,7 +322,9 @@ async function executeFlagForReview(
 	actionData: Record<string, unknown>,
 	historyEntry: ActionHistoryEntry
 ): Promise<ActionResult> {
-	const { entityIds, reason, priority } = actionData as any;
+	const entityIds = actionData.entityIds as string[] | undefined;
+	const reason = actionData.reason as string | undefined;
+	const priority = actionData.priority as string | undefined;
 
 	if (!entityIds || !Array.isArray(entityIds) || entityIds.length === 0) {
 		return {

--- a/src/lib/stores/combat.svelte.ts
+++ b/src/lib/stores/combat.svelte.ts
@@ -408,6 +408,21 @@ function createCombatStore() {
 	// Turn Management
 	// ========================================================================
 
+	async function selectCombatantTurn(
+		combatId: string,
+		combatantId: string
+	): Promise<CombatSession> {
+		try {
+			error = null;
+			const updated = await combatRepository.selectCombatantTurn(combatId, combatantId);
+			updateActiveCombatIfMatch(updated);
+			return updated;
+		} catch (err: unknown) {
+			error = getErrorMessage(err);
+			throw err;
+		}
+	}
+
 	async function nextTurn(combatId: string): Promise<CombatSession> {
 		try {
 			error = null;
@@ -716,6 +731,7 @@ function createCombatStore() {
 		rollInitiativeForAll,
 
 		// Turns
+		selectCombatantTurn,
 		nextTurn,
 		previousTurn,
 

--- a/src/lib/stores/suggestions.svelte.test.ts
+++ b/src/lib/stores/suggestions.svelte.test.ts
@@ -381,7 +381,7 @@ describe('Suggestions Store - B4 New Methods', () => {
 			const result = await suggestionsStore.executeAction(noActionSuggestion);
 
 			expect(result.success).toBe(false);
-			expect(result.error).toMatch(/no.*action/i);
+			expect(result.message).toMatch(/no.*action/i);
 		});
 
 		it('should set loading state during execution', async () => {
@@ -420,7 +420,7 @@ describe('Suggestions Store - B4 New Methods', () => {
 			const result = await suggestionsStore.executeAction(mockSuggestion);
 
 			expect(result.success).toBe(false);
-			expect(result.error).toContain('error');
+			expect(result.message).toContain('error');
 		});
 	});
 

--- a/src/lib/stores/suggestions.svelte.ts
+++ b/src/lib/stores/suggestions.svelte.ts
@@ -7,13 +7,14 @@
 
 import { suggestionRepository } from '$lib/db/repositories';
 import { executeAction as executeActionService, getActionHistory } from '$lib/services/suggestionActionService';
+import type { ActionHistoryEntry, ActionResult } from '$lib/services/suggestionActionService';
 import type { AISuggestion, SuggestionQueryFilters } from '$lib/types';
 
 function createSuggestionsStore() {
 	let suggestions = $state<AISuggestion[]>([]);
 	let loading = $state(false);
 	let filters = $state<SuggestionQueryFilters>({});
-	let actionHistory = $state<any[]>([]);
+	let actionHistory = $state<ActionHistoryEntry[]>([]);
 
 	// Derived state for filtered suggestions
 	const filteredSuggestions = $derived.by(() => {
@@ -116,12 +117,12 @@ function createSuggestionsStore() {
 			}
 		},
 
-		async executeAction(suggestion: AISuggestion): Promise<any> {
+		async executeAction(suggestion: AISuggestion): Promise<ActionResult> {
 			loading = true;
 			try {
 				// Check if suggestion has a suggested action
 				if (!suggestion.suggestedAction) {
-					return { success: false, error: 'No action to execute' };
+					return { success: false, message: 'No action to execute', affectedEntityIds: [] };
 				}
 
 				// Execute the action
@@ -138,7 +139,7 @@ function createSuggestionsStore() {
 				return result;
 			} catch (e) {
 				console.error('Failed to execute action:', e);
-				return { success: false, error: e instanceof Error ? e.message : 'Unknown error' };
+				return { success: false, message: e instanceof Error ? e.message : 'Unknown error', affectedEntityIds: [] };
 			} finally {
 				loading = false;
 			}

--- a/src/lib/utils/entityFormUtils.ts
+++ b/src/lib/utils/entityFormUtils.ts
@@ -2,7 +2,7 @@ import {
 	getEntityTypeDefinition,
 	getEntityTypeDefinitionWithSystem
 } from '$lib/config/entityTypes';
-import type { EntityTypeDefinition, EntityTypeOverride } from '$lib/types';
+import type { EntityType, EntityTypeDefinition, EntityTypeOverride } from '$lib/types';
 import type { SystemProfile } from '$lib/types/systems';
 
 /**
@@ -62,7 +62,7 @@ export function getSystemAwareEntityType(
 	// Apply system modifications AND overrides
 	// Overrides are applied last so fieldOrder isn't undone by system's sort
 	return getEntityTypeDefinitionWithSystem(
-		entityType as any, // Cast to EntityType - getEntityTypeDefinitionWithSystem expects this
+		entityType as EntityType, // Cast to EntityType - getEntityTypeDefinitionWithSystem expects this
 		baseDefinition,
 		systemProfile,
 		customTypes ?? [],

--- a/src/lib/utils/networkGraph.test.ts
+++ b/src/lib/utils/networkGraph.test.ts
@@ -334,7 +334,7 @@ describe('networkGraph - toVisNetworkData', () => {
 			expect(result.nodes.length).toBe(2);
 
 			// Check first node
-			const node1 = result.nodes.get('entity-1');
+			const node1 = result.nodes.get('entity-1')!;
 			expect(node1).toBeDefined();
 			expect(node1.id).toBe('entity-1');
 			expect(node1.label).toBe('Gandalf');
@@ -345,7 +345,7 @@ describe('networkGraph - toVisNetworkData', () => {
 			expect(node1.title).toContain('Connections: 5');
 
 			// Check second node
-			const node2 = result.nodes.get('entity-2');
+			const node2 = result.nodes.get('entity-2')!;
 			expect(node2).toBeDefined();
 			expect(node2.id).toBe('entity-2');
 			expect(node2.label).toBe('Rivendell');
@@ -379,7 +379,7 @@ describe('networkGraph - toVisNetworkData', () => {
 
 			expect(result.edges.length).toBe(1);
 
-			const edge = result.edges.get(1);
+			const edge = result.edges.get(1)!;
 			expect(edge).toBeDefined();
 			expect(edge.id).toBe(1);
 			expect(edge.from).toBe('entity-1');
@@ -413,7 +413,7 @@ describe('networkGraph - toVisNetworkData', () => {
 
 			const result = toVisNetworkData(map, options);
 
-			const edge = result.edges.get(1);
+			const edge = result.edges.get(1)!;
 			expect(edge).toBeDefined();
 			expect(edge.arrows).toBe('to');
 		});
@@ -432,7 +432,7 @@ describe('networkGraph - toVisNetworkData', () => {
 
 			const result = toVisNetworkData(map, options);
 
-			const node = result.nodes.get('entity-1');
+			const node = result.nodes.get('entity-1')!;
 			expect(node.color).toBe('#1d4ed8'); // Dark mode character color
 		});
 	});
@@ -458,7 +458,7 @@ describe('networkGraph - toVisNetworkData', () => {
 
 			const result = toVisNetworkData(map, { isDark: false });
 
-			const edge = result.edges.get(1);
+			const edge = result.edges.get(1)!;
 			expect(edge.width).toBe(3);
 			expect(edge.dashes).toBe(false);
 		});
@@ -483,7 +483,7 @@ describe('networkGraph - toVisNetworkData', () => {
 
 			const result = toVisNetworkData(map, { isDark: false });
 
-			const edge = result.edges.get(1);
+			const edge = result.edges.get(1)!;
 			expect(edge.width).toBe(2);
 			expect(edge.dashes).toEqual([5, 5]);
 		});
@@ -508,7 +508,7 @@ describe('networkGraph - toVisNetworkData', () => {
 
 			const result = toVisNetworkData(map, { isDark: false });
 
-			const edge = result.edges.get(1);
+			const edge = result.edges.get(1)!;
 			expect(edge.width).toBe(1);
 			expect(edge.dashes).toEqual([2, 4]);
 		});
@@ -537,10 +537,10 @@ describe('networkGraph - toVisNetworkData', () => {
 			expect(result.edges.length).toBe(4);
 
 			// Verify all nodes have correct shapes
-			expect(result.nodes.get('c1').shape).toBe('circle');
-			expect(result.nodes.get('c2').shape).toBe('circle');
-			expect(result.nodes.get('l1').shape).toBe('square');
-			expect(result.nodes.get('f1').shape).toBe('hexagon');
+			expect(result.nodes.get('c1')!.shape).toBe('circle');
+			expect(result.nodes.get('c2')!.shape).toBe('circle');
+			expect(result.nodes.get('l1')!.shape).toBe('square');
+			expect(result.nodes.get('f1')!.shape).toBe('hexagon');
 		});
 	});
 
@@ -555,7 +555,7 @@ describe('networkGraph - toVisNetworkData', () => {
 
 			const result = toVisNetworkData(map, { isDark: false });
 
-			const node = result.nodes.get('e1');
+			const node = result.nodes.get('e1')!;
 			expect(node.title).toBe('Hero\nType: character\nConnections: 10');
 		});
 
@@ -569,7 +569,7 @@ describe('networkGraph - toVisNetworkData', () => {
 
 			const result = toVisNetworkData(map, { isDark: false });
 
-			const node = result.nodes.get('e1');
+			const node = result.nodes.get('e1')!;
 			expect(node.title).toBe('Sword\nType: item\nConnections: 1');
 		});
 
@@ -583,7 +583,7 @@ describe('networkGraph - toVisNetworkData', () => {
 
 			const result = toVisNetworkData(map, { isDark: false });
 
-			const node = result.nodes.get('e1');
+			const node = result.nodes.get('e1')!;
 			expect(node.title).toBe('Remote Cave\nType: location\nConnections: 0');
 		});
 	});
@@ -618,7 +618,7 @@ describe('networkGraph - toVisNetworkData', () => {
 			const result = toVisNetworkData(map, { isDark: false });
 
 			// Should be able to get by ID
-			const node = result.nodes.get('e1');
+			const node = result.nodes.get('e1')!;
 			expect(node).toBeDefined();
 
 			// Should be able to get all
@@ -644,7 +644,7 @@ describe('networkGraph - toVisNetworkData', () => {
 
 			const result = toVisNetworkData(map, { isDark: false });
 
-			const node = result.nodes.get('e1');
+			const node = result.nodes.get('e1')!;
 			expect(node.label).toBe('A'.repeat(100));
 		});
 
@@ -667,7 +667,7 @@ describe('networkGraph - toVisNetworkData', () => {
 
 			const result = toVisNetworkData(map, { isDark: false });
 
-			const edge = result.edges.get(1);
+			const edge = result.edges.get(1)!;
 			expect(edge.label).toBe('friend-of/ally');
 		});
 
@@ -690,7 +690,7 @@ describe('networkGraph - toVisNetworkData', () => {
 
 			const result = toVisNetworkData(map, { isDark: false });
 
-			const edge = result.edges.get(1);
+			const edge = result.edges.get(1)!;
 			expect(edge.width).toBe(2); // Default width
 			expect(edge.dashes).toBe(false); // Default dashes
 		});

--- a/src/lib/utils/networkGraph.ts
+++ b/src/lib/utils/networkGraph.ts
@@ -14,6 +14,24 @@ import type { RelationshipMap } from '$lib/db/repositories/entityRepository';
 import type { NetworkDisplayOptions } from '$lib/types/network';
 import type { EntityType } from '$lib/types';
 
+interface VisNode {
+	id: string;
+	label: string;
+	shape: string;
+	color: string;
+	title: string;
+}
+
+interface VisEdge {
+	id: number;
+	from: string;
+	to: string;
+	label: string;
+	arrows: string;
+	width: number;
+	dashes: boolean | number[];
+}
+
 /**
  * Get the vis.js node shape for an entity type
  */
@@ -84,7 +102,7 @@ export function getEntityColor(entityType: EntityType, isDark: boolean): string 
 export function toVisNetworkData(
 	map: RelationshipMap,
 	options: NetworkDisplayOptions
-): { nodes: DataSet<any>; edges: DataSet<any> } {
+): { nodes: DataSet<VisNode>; edges: DataSet<VisEdge> } {
 	const { isDark } = options;
 
 	// Convert nodes

--- a/src/routes/combat/[id]/+page.svelte
+++ b/src/routes/combat/[id]/+page.svelte
@@ -81,8 +81,17 @@
 		}
 	});
 
-	function handleCombatantClick(combatant: Combatant) {
+	async function handleCombatantClick(combatant: Combatant) {
 		selectedCombatant = combatant;
+
+		// In director-selected mode, also select this combatant's turn
+		if (combat && combat.status === 'active' && combat.turnMode === 'director-selected' && !combat.activeCombatantId) {
+			try {
+				await combatStore.selectCombatantTurn(combat.id, combatant.id);
+			} catch {
+				// Combatant may not be eligible; ignore silently
+			}
+		}
 	}
 
 	async function handleNextTurn() {


### PR DESCRIPTION
## Summary
- Fix all 25 `@typescript-eslint/no-explicit-any` ESLint errors in production code by replacing `any` with proper TypeScript types (`FieldValue`, `EntityType`, `BaseEntity`, `ActionHistoryEntry`, `ActionResult`, `typeof Heart`, `VisNode`/`VisEdge` interfaces)
- Add `ErrorBoundary.svelte` to ESLint ignores (svelte:boundary parser limitation)
- Fix flaky e2e combat-lifecycle test by adding `selectCombatantTurn` to combat store, wiring it into `handleCombatantClick`, and updating the test to click combatant cards before advancing turns (matching director-selected mode behavior)

Closes #593, Closes #562

## Test plan
- [x] `npm run lint` → 0 errors
- [x] `npm run check` → 0 errors
- [x] `npm run build` → success
- [x] `npx vitest run` → 13,713 tests pass (296 files)
- [ ] `npx playwright test e2e/combat-lifecycle.spec.ts` → verify in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)