### PR TITLE
fix: correct 'New Scene' button URL (404 error)

### DIFF
--- a/src/routes/scene/+page.svelte
+++ b/src/routes/scene/+page.svelte
@@ -56,7 +56,7 @@ function handleRunScene(sceneId: string) {
 }
 
 function handleNewScene() {
-	goto('/entity/new?type=scene');
+	goto('/entities/scene/new');
 }
 
 onMount(() => {

--- a/src/tests/routes/scene/scene-list-page.test.ts
+++ b/src/tests/routes/scene/scene-list-page.test.ts
@@ -372,7 +372,7 @@ describe('Scene List Page - New Scene Creation', () => {
 		const newButton = screen.getByRole('button', { name: /new scene/i });
 		await fireEvent.click(newButton);
 
-		expect(goto).toHaveBeenCalledWith('/entity/new?type=scene');
+		expect(goto).toHaveBeenCalledWith('/entities/scene/new');
 	});
 
 	it('should have prominent styling for new scene button', () => {


### PR DESCRIPTION
## Summary

- Fixed the "New Scene" button on the Scene list page (`/scene`) navigating to `/entity/new?type=scene` (a non-existent route, causing a 404 error)
- Corrected the URL to `/entities/scene/new`, which is the proper SvelteKit route for creating new scene entities

## Changes

- `src/routes/scene/+page.svelte`: Updated `handleNewScene()` to use `/entities/scene/new`
- `src/tests/routes/scene/scene-list-page.test.ts`: Updated test assertion to match the corrected URL

## Test plan

- [x] Updated unit test passes (RED → GREEN verified)
- [x] All 26 scene list page tests pass
- [x] No TypeScript errors in changed files
- [ ] Manual: Navigate to Scene list, click "New Scene", verify it opens the new scene form at `/entities/scene/new`

Closes #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)